### PR TITLE
[BISERVER-7270] JSON fix for Sugar.  Ivy version change

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -83,7 +83,7 @@
     <dependency org="commons-cli" name="commons-cli" rev="1.2" transitive="false" conf="default->default" />
     <dependency org="commons-io" name="commons-io" rev="1.4" transitive="false" conf="default->default" />
     
-    <dependency org="com.thoughtworks.xstream" name="xstream"         rev="1.3.1" />
+    <dependency org="com.thoughtworks.xstream" name="xstream"         rev="1.4.2" />
 
     <dependency org="junit" name="junit" rev="4.5" conf="test->default" />
     <dependency org="commons-io" name="commons-io" rev="1.4" transitive="false" conf="test->default" />
@@ -127,7 +127,7 @@
     <dependency org="net.sf.saxon" name="saxon" rev="9.1.0.8" conf="pmr->default"/>
     <dependency org="net.sf.saxon" name="saxon-dom" rev="9.1.0.8" conf="pmr->default"/>
     <dependency org="rhino" name="js" rev="1.7R1" conf="pmr->default"/>
-    <dependency org="com.thoughtworks.xstream" name="xstream" rev="1.3" conf="pmr->default"/>
+    <dependency org="com.thoughtworks.xstream" name="xstream" rev="1.4.2" conf="pmr->default"/>
     <dependency org="org.apache.hbase" name="hbase" rev="${dependency.apache-hbase.revision}" transitive="false"
                 conf="pmr->default"
                 changing="false"/>


### PR DESCRIPTION
Update versions of XStream to 1.4.2 and Jettison to 1.2
