### PR TITLE
Removed SqoopUtils.asBoolean()

### DIFF
--- a/src/org/pentaho/di/job/entries/sqoop/AbstractSqoopJobEntry.java
+++ b/src/org/pentaho/di/job/entries/sqoop/AbstractSqoopJobEntry.java
@@ -317,7 +317,7 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends JobEn
 
     t.start();
 
-    if (SqoopUtils.asBoolean(sqoopConfig.getBlockingExecution(), variables)) {
+    if (variables.getBooleanValueOfVariable(sqoopConfig.getBlockingExecution(), true)) {
       while (!parentJob.isStopped() && t.isAlive()) {
         try {
           t.join(SqoopUtils.asLong(sqoopConfig.getBlockingPollingInterval(), variables));

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
@@ -221,21 +221,6 @@ public class SqoopUtils {
   }
 
   /**
-   * @return {@code true} if {@link Boolean#parseBoolean(String)} returns {@code true} for {@link #isBlockingExecution()}
-   */
-  /**
-   * Determine if the string equates to {@link Boolean#TRUE} after performing a variable substitution.
-   *
-   * @param s             String-encoded boolean value or variable expression
-   * @param variableSpace Context for variables so we can substitute {@code s}
-   * @return the value returned by {@link Boolean#parseBoolean(String) Boolean.parseBoolean(s)} after substitution
-   */
-  public static boolean asBoolean(String s, VariableSpace variableSpace) {
-    String value = variableSpace.environmentSubstitute(s);
-    return Boolean.parseBoolean(value);
-  }
-
-  /**
    * Parse the string as a {@link Long} after variable substitution.
    *
    * @param s             String-encoded {@link Long} value or variable expression that should resolve to a {@link Long} value

--- a/test-src/org/pentaho/di/job/entries/sqoop/SqoopUtilsTest.java
+++ b/test-src/org/pentaho/di/job/entries/sqoop/SqoopUtilsTest.java
@@ -248,24 +248,6 @@ public class SqoopUtilsTest {
   }
 
   @Test
-  public void asBoolean() {
-    VariableSpace variableSpace = new Variables();
-
-    assertFalse(SqoopUtils.asBoolean("not-true", variableSpace));
-    assertFalse(SqoopUtils.asBoolean(Boolean.FALSE.toString(), variableSpace));
-    assertTrue(SqoopUtils.asBoolean(Boolean.TRUE.toString(), variableSpace));
-
-    // No variable set, should attempt convert ${booleanValue} as is
-    assertFalse(SqoopUtils.asBoolean("${booleanValue}", variableSpace));
-
-    variableSpace.setVariable("booleanValue", Boolean.TRUE.toString());
-    assertTrue(SqoopUtils.asBoolean("${booleanValue}", variableSpace));
-
-    variableSpace.setVariable("booleanValue", Boolean.FALSE.toString());
-    assertFalse(SqoopUtils.asBoolean("${booleanValue}", variableSpace));
-  }
-
-  @Test
   public void asLong() {
     VariableSpace variableSpace = new Variables();
 


### PR DESCRIPTION
Replaced SqoopUtils.asBoolean() with VariableSpace.getBooleanValueOfVariable() to reduce code duplication.
