### PR TITLE
[PDI-8007] [PDI-8008]

### DIFF
--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInput.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInput.java
@@ -44,6 +44,7 @@ import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowDataUtil;
 import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStep;
@@ -91,7 +92,7 @@ public class CassandraInput extends BaseStep implements StepInterface {
     
     if (first) {
       first = false;
-      // m_meta = (CassandraInputMeta)smi;
+
       m_data = (CassandraInputData)sdi;
       m_meta = (CassandraInputMeta)smi;
       
@@ -111,8 +112,8 @@ public class CassandraInput extends BaseStep implements StepInterface {
         throw new KettleException("Some connection details are missing!!");
       }
 
-      logBasic("Connecting to Cassandra node at '" + hostS + ":" + portS + "' using " +
-      		"keyspace '" + keyspaceS +"'...");      
+      logBasic(BaseMessages.getString(CassandraInputMeta.PKG, 
+          "CassandraInput.Info.Connecting", hostS, portS, keyspaceS));
       try {
         if (Const.isEmpty(timeoutS)) {
           m_connection = CassandraInputData.getCassandraConnection(hostS, 
@@ -166,9 +167,9 @@ public class CassandraInput extends BaseStep implements StepInterface {
       }
       
       // column family name (key) is the first field output
-      // String colFamName = m_data.getOutputRowMeta().getValueMeta(0).getName();
       try {
-        logBasic("Getting meta data for column family '" + colFamName + "'");
+        logBasic(BaseMessages.getString(CassandraInputMeta.PKG, 
+            "CassandraInput.Info.GettintMetaData", colFamName));
         m_cassandraMeta = new CassandraColumnMetaData(m_connection, colFamName);
       } catch (Exception e) {
         closeConnection();
@@ -180,15 +181,18 @@ public class CassandraInput extends BaseStep implements StepInterface {
         m_meta.getUseCompression() ? Compression.GZIP : Compression.NONE;
       try {
         if (!m_meta.getUseThriftIO()) {
-          logBasic("Executing query '" + queryS + "'" 
-              + (m_meta.getUseCompression() ? " (using GZIP query compression)" : "") 
-              + "...");
+          logBasic(BaseMessages.getString(CassandraInputMeta.PKG, 
+              "CassandraInput.Info.ExecutingQuery", queryS, 
+              (m_meta.getUseCompression() 
+                  ? BaseMessages.getString(CassandraInputMeta.PKG, "CassandraInput.Info.UsingGZIPCompression") 
+                      : ""))); 
+
           byte[] queryBytes = (m_meta.getUseCompression() ? 
               CassandraInputData.compressQuery(queryS, compression) : queryS.getBytes());
 
           // In Cassandra 1.1 the version of CQL to use can be set programatically. The default
           // is to use CQL v 2.0.0
-          //m_connection.getClient().set_cql_version("3.0.0");
+          // m_connection.getClient().set_cql_version("3.0.0");
           CqlResult result = m_connection.getClient().
           execute_cql_query(ByteBuffer.wrap(queryBytes), compression);
           m_resultIterator = result.getRowsIterator();
@@ -230,7 +234,6 @@ public class CassandraInput extends BaseStep implements StepInterface {
       Object[] outputRowData = null;
       
       if (m_meta.getOutputKeyValueTimestampTuples()) {
-        //System.err.println("Number of columns in row: " + nextRow.getColumnsSize());
         Iterator<Column> columnIterator = nextRow.getColumnsIterator();
         
         // The key always appears to be the first column in the list (even though it is separately
@@ -267,7 +270,6 @@ public class CassandraInput extends BaseStep implements StepInterface {
         }
       }            
     } else {
-      //m_connection.close();
       closeConnection();
       setOutputDone();
       return false;
@@ -293,7 +295,8 @@ public class CassandraInput extends BaseStep implements StepInterface {
  
   protected void closeConnection() {
     if (m_connection != null) {
-      logBasic("Closing connection...");
+      logBasic(BaseMessages.getString(CassandraInputMeta.PKG, 
+          "CassandraInput.Info.ClosingConnection"));
       m_connection.close();
     }
   }

--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputDialog.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputDialog.java
@@ -422,7 +422,6 @@ public class CassandraInputDialog extends BaseStepDialog implements
         getString(PKG, "CassandraInputDialog.Schema.Button"));
     props.setLook(m_showSchemaBut);
     fd = new FormData();
-//    fd.left = new FormAttachment(middle, 0);
     fd.right = new FormAttachment(100, 0);
     fd.bottom = new FormAttachment(wOK, -margin);
     m_showSchemaBut.setLayoutData(fd);
@@ -432,7 +431,6 @@ public class CassandraInputDialog extends BaseStepDialog implements
         RowMeta outputF = new RowMeta();
         CassandraConnection conn = null;
         try {
-//          CassandraInputMeta tempMeta = (CassandraInputMeta)m_currentMeta.clone();
           String hostS = transMeta.environmentSubstitute(m_hostText.getText());
           String portS = transMeta.environmentSubstitute(m_portText.getText());
           String userS = m_userText.getText();
@@ -442,10 +440,7 @@ public class CassandraInputDialog extends BaseStepDialog implements
             passS = transMeta.environmentSubstitute(passS);
           }
           String keyspaceS = transMeta.environmentSubstitute(m_keyspaceText.getText());
-  //        tempMeta.setCassandraHost(hostS); tempMeta.setCassandraPort(portS);
-//          tempMeta.setCassandraKeyspace(keyspaceS);
           String cqlText = transMeta.environmentSubstitute(m_cqlText.getText());
-//          tempMeta.setCQLSelectQuery(cqlText);                    
           
           conn = CassandraInputData.
             getCassandraConnection(hostS, Integer.parseInt(portS), userS, passS);
@@ -463,17 +458,14 @@ public class CassandraInputDialog extends BaseStepDialog implements
           
           String colFam = CassandraInputData.getColumnFamilyNameFromCQLSelectQuery(cqlText);
           if (Const.isEmpty(colFam)) {
-            throw new Exception("SELECT query does not seem to contain the name " +
-            		"of a column family!");
+            throw new Exception(BaseMessages.getString(PKG, 
+                "CassandraInput.Error.NoFromClauseInQuery"));
           }
           
           if (!CassandraColumnMetaData.columnFamilyExists(conn, colFam)) {
-            throw new Exception("The column family '" + colFam + "' does not " +
-                "seem to exist in the keyspace '" + keyspaceS);
-          }
-          
-/*          tempMeta.getFields(outputF, stepname, null, null, transMeta);
-          String colFam = outputF.getValueMeta(0).getName(); */
+            throw new Exception(BaseMessages.getString(PKG, 
+                "CassandraInput.Error.NonExistentColumnFamily", colFam, keyspaceS));
+          }          
           
           CassandraColumnMetaData cassMeta = new CassandraColumnMetaData(conn, colFam);
           String schemaDescription = cassMeta.getSchemaDescription();
@@ -542,9 +534,7 @@ public class CassandraInputDialog extends BaseStepDialog implements
       public void mouseUp(MouseEvent e) { setPosition(); }
     });
     
-    
-
-    
+        
     // Add listeners
     lsCancel = new Listener() {
         public void handleEvent(Event e) {

--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputMeta.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInputMeta.java
@@ -43,6 +43,7 @@ import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.Trans;
@@ -64,6 +65,8 @@ import org.w3c.dom.Node;
  */
 @Step(id = "CassandraInput", image = "Cassandra.png", name = "Cassandra Input", description="Reads data from a Cassandra table", categoryDescription="Big Data")
 public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterface {
+  
+  protected static final Class<?> PKG = CassandraInputMeta.class;
   
   /** The host to contact */
   protected String m_cassandraHost = "localhost";
@@ -496,13 +499,13 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
       
       if (!subQ.toLowerCase().startsWith("select")) {
         // not a select statement!
-        logError("No 'SELECT' in query!");
+        logError(BaseMessages.getString(PKG, "CassandraInput.Error.NoSelectInQuery"));
         return;
       }
       
       if (subQ.indexOf(';') < 0) {
         // query must end with a ';' or it will wait for more!
-        logError("Query must be terminated by a ';'");
+        logError(BaseMessages.getString(PKG, "CassandraInput.Error.QueryTermination"));
         return;
       }
       
@@ -514,13 +517,10 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
         try {
           m_rowLimit = Integer.parseInt(limitS);
         } catch (NumberFormatException ex) {
-          logError("Unable to parse LIMIT clause in query: " + m_cqlSelectQuery 
-              + " using default limit of 10,000");
+          logError(BaseMessages.getString(PKG, "CassandraInput.Error.UnableToParseLimitClause", m_cqlSelectQuery)); 
           m_rowLimit = 10000;
         }
-      }
-      
-      //subQ = subQ.toLowerCase();
+      }      
       
       // strip off where clause (if any)      
       if (subQ.toLowerCase().lastIndexOf("where") > 0) {
@@ -540,9 +540,8 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
       }
       
       fromIndex = offset;
-//      int fromIndex = subQ.toLowerCase().lastIndexOf("from");
       if (fromIndex < 0) {
-        logError("Must specify a column family using a 'FROM' clause");
+        logError(BaseMessages.getString(PKG, "CassandraInput.Error.MustSpecifyAColumnFamily"));
         return; // no from clause
       }      
       
@@ -565,7 +564,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
         try {
           m_colLimit = Integer.parseInt(firstS);
         } catch (NumberFormatException ex) {
-          logError("Unable to parse FIRST clause in query: " + m_cqlSelectQuery);
+          logError(BaseMessages.getString(PKG, "CassandraInput.Error.UnableToParseFirstClause", m_cqlSelectQuery));
           return;
         }
       }
@@ -656,9 +655,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
             if (!colMeta.columnExistsInSchema(col)) {
               // this one isn't known about in about in the schema - we can output it
               // as long as its values satisfy the default validator...
-              logBasic("Query specifies column '" + col + "', however this column is " +
-                        "not in the column family schema. The default column family " +
-                        "validator will be used");
+              logBasic(BaseMessages.getString(PKG, "CassandraInput.Info.DefaultColumnValidator", col));
             }
             ValueMetaInterface vm = colMeta.getValueMetaForColumn(col);
             rowMeta.addValueMeta(vm);            
@@ -666,8 +663,7 @@ public class CassandraInputMeta extends BaseStepMeta implements StepMetaInterfac
         }
       } catch (Exception ex) {
         ex.printStackTrace();
-        logBasic("Unable to connect to retrieve column meta data for '" + colFamName 
-            + "' at this stage.", ex);
+        logBasic(BaseMessages.getString(PKG, "CassandraInput.Info.UnableToRetrieveColumnMetaData", colFamName)); 
         return;
       } finally {
         if (conn != null) {

--- a/src/org/pentaho/di/trans/steps/cassandrainput/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/messages/messages_en_US.properties
@@ -16,3 +16,19 @@ CassandraInputDialog.Thrift.Label=Use Thrift I/O
 
 CassandraInputDialog.Error.ProblemGettingSchemaInfo.Title=Problem getting schema info
 CassandraInputDialog.Error.ProblemGettingSchemaInfo.Message=An error occurred while getting the schema information:
+
+CassandraInput.Error.NoSelectInQuery=No SELECT in query!
+CassandraInput.Error.QueryTermination=Query must be terminated by a ';'
+CassandraInput.Error.UnableToParseLimitClause=Unable to parse LIMIT clause in query: {0} - using default limit of 10,000
+CassandraInput.Error.MustSpecifyAColumnFamily=Must specify a column family using a 'FROM' clause
+CassandraInput.Error.UnableToParseFirstClause=Unable to parse FIRST clause in query: {0}
+CassandraInput.Error.NoFromClauseInQuery=SELECT query does not seem to contain the name of a column family
+CassandraInput.Error.NonExistentColumnFamily=The column family {0} does not seem to exist in the keyspace {1}
+
+CassandraInput.Info.DefaultColumnValidator=Query specifies column {0}, however this column is not in the column family schema. The default column family validator will be used
+CassandraInput.Info.UnableToRetrieveColumnMetaData=Unable to connect to retrieve column meta data for {0} at this stage
+CassandraInput.Info.Connecting=Connecting to Cassandra node at {0} : {1} using keyspace {2} ...
+CassandraInput.Info.GettintMetaData=Getting meta data for column family {0}
+CassandraInput.Info.ExecutingQuery=Executing query {0} {1} ...
+CassandraInput.Info.UsingGZIPCompression=(using GZIP query compression)
+CassandraInput.Info.ClosingConnection=Closing connection ...


### PR DESCRIPTION
[PDI-8007] CQL queries using FIRST N or LIMIT clauses fail in Cassandra input due to parsing errors
[PDI-8008] Select \* LIMIT N type queries in Cassandra input return 1 more row than expected when using Thrift I/O mode
