### PR TITLE
[1.3] unit test fixes

### DIFF
--- a/test-src/org/pentaho/di/job/entries/sqoop/SqoopUtilsTest.java
+++ b/test-src/org/pentaho/di/job/entries/sqoop/SqoopUtilsTest.java
@@ -55,7 +55,7 @@ public class SqoopUtilsTest {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 10000)
   public void configureConnectionInformation() {
     SqoopConfig config = new SqoopConfig() {
     };


### PR DESCRIPTION
The connection info test timed out on occasionally.

**This needs to be merged in to 1.3-cdh4 as well.**
