### PR TITLE
[1.3 cdh4] hive jdbc upgrade

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ dependency.jackson-mapper-asl.revision=1.5.2
 dependency.jfreechart.revision=1.0.9
 dependency.libbase.revision=1.2.4
 dependency.libformula.revision=1.2.5
-dependency.hive-jdbc.revision=0.7.0-pentaho-1.0.1
+dependency.hive-jdbc.revision=0.7.0-pentaho-SNAPSHOT
 dependency.mondrian.revision=3.4.1
 
 dependency.apache-oozie.revision=3.1.3-cdh4.0.0


### PR DESCRIPTION
Updated to a Hive JDBC driver that works with 0.8.1.
