### PR TITLE
[PDI-7826] Model/Visualize from Sqoop Export job entry

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -6,7 +6,7 @@ project.revision=TRUNK-SNAPSHOT
 
 junit.maxmemory=500M
 
-dependency.kettle.revision=4.3.1-SNAPSHOT
+dependency.kettle.revision=4.4.0-SNAPSHOT
 kettle-distrib-artifact-name=pdi-ce-${dependency.kettle.revision}
 kettle-distrib-with-plugin-name=${kettle-distrib-artifact-name}-big-data
 

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopExportJobEntry.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopExportJobEntry.java
@@ -22,7 +22,19 @@
 
 package org.pentaho.di.job.entries.sqoop;
 
+import org.pentaho.di.cluster.SlaveServer;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.ProvidesDatabaseConnectionInformation;
 import org.pentaho.di.core.annotations.JobEntry;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.w3c.dom.Node;
+
+import java.util.List;
 
 /**
  * Provides a way to orchestrate <a href="http://sqoop.apache.org/">Sqoop</a> exports.
@@ -35,7 +47,10 @@ import org.pentaho.di.core.annotations.JobEntry;
   i18nPackageName = "org.pentaho.di.job.entries.sqoop",
   version = "1"
 )
-public class SqoopExportJobEntry extends AbstractSqoopJobEntry<SqoopExportConfig> {
+public class SqoopExportJobEntry extends AbstractSqoopJobEntry<SqoopExportConfig> implements ProvidesDatabaseConnectionInformation {
+
+  // Database meta object for UI interactions. Populated during transformation load or configuration changes via UI.
+  private transient DatabaseMeta databaseMeta;
 
   @Override
   protected SqoopExportConfig buildSqoopConfig() {
@@ -50,4 +65,64 @@ public class SqoopExportJobEntry extends AbstractSqoopJobEntry<SqoopExportConfig
     return "export";
   }
 
+  /**
+   * @return the current database meta. Agile BI uses this to generate a model.
+   */
+  @Override
+  public DatabaseMeta getDatabaseMeta() {
+    return databaseMeta;
+  }
+
+  /**
+   * @return the current table name from the configuration. Agile BI uses this to generate a model.
+   */
+  @Override
+  public String getTableName() {
+    return environmentSubstitute(getJobConfig().getTable());
+  }
+
+  /**
+   * @return the current schema name from the configuration. Agile BI uses this to generate a model.
+   */
+  @Override
+  public String getSchemaName() {
+    return environmentSubstitute(getJobConfig().getSchema());
+  }
+
+  @Override
+  public String getMissingDatabaseConnectionInformationMessage() {
+    if (Const.isEmpty(getJobConfig().getDatabase()) && !Const.isEmpty(getJobConfig().getConnect())) {
+      // We're using advanced configuration, alert the user we cannot visualize unless we're not using a database managed by Kettle
+      return BaseMessages.getString(AbstractSqoopJobEntry.class, "ErrorMustConfigureDatabaseConnectionFromList");
+    }
+    // Use the default error message
+    return null;
+  }
+
+  /**
+   * Additionally sets the database meta if a database is set.
+   */
+  @Override
+  public void loadXML(Node node, List<DatabaseMeta> databaseMetas, List<SlaveServer> slaveServers, Repository repository) throws KettleXMLException {
+    super.loadXML(node, databaseMetas, slaveServers, repository);
+    setDatabaseMeta(DatabaseMeta.findDatabase(databaseMetas, getJobConfig().getDatabase()));
+  }
+
+  /**
+   * Additionally sets the database meta if a database is set.
+   */
+  @Override
+  public void loadRep(Repository rep, ObjectId id_jobentry, List<DatabaseMeta> databases, List<SlaveServer> slaveServers) throws KettleException {
+    super.loadRep(rep, id_jobentry, databases, slaveServers);
+    setDatabaseMeta(DatabaseMeta.findDatabase(databases, getJobConfig().getDatabase()));
+  }
+
+  /**
+   * Set the current database meta.
+   *
+   * @param databaseMeta Database meta representing the database this job is currently configured to export to
+   */
+  public void setDatabaseMeta(DatabaseMeta databaseMeta) {
+    this.databaseMeta = databaseMeta;
+  }
 }

--- a/src/org/pentaho/di/job/entries/sqoop/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/job/entries/sqoop/messages/messages_en_US.properties
@@ -57,6 +57,7 @@ ErrorRetrievingSchemas=Error getting schemas list
 ErrorBrowsingDirectory=Error browsing for directory
 ErrorConfiguringFromCommandLine=Error configuring from command line. Please fix any errors to switch to another view.
 ErrorUnknownArguments=Unknown argument(s): {0}
+ErrorMustConfigureDatabaseConnectionFromList=Cannot perform this operation when the database connection information is provided via Advanced Options.
 
 AvailableSchemas.Title=Available schemas
 AvailableSchemas.Message=Please select a schema name

--- a/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryController.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryController.java
@@ -57,7 +57,7 @@ import static org.pentaho.di.job.entries.sqoop.SqoopConfig.*;
  * @param <S> Type of Sqoop configuration object this controller depends upon. Must match the configuration object the
  *            job entry expects.
  */
-public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig> extends AbstractJobEntryController<S, AbstractSqoopJobEntry<S>> {
+public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E extends AbstractSqoopJobEntry<S>> extends AbstractJobEntryController<S, E> {
 
   public static final String SELECTED_DATABASE_CONNECTION = "selectedDatabaseConnection";
   public static final String MODE_TOGGLE_LABEL = "modeToggleLabel";
@@ -111,7 +111,7 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig> ext
    * @param jobEntry        Job entry the dialog is being created for
    * @param bindingFactory  Binding factory to generate bindings
    */
-  public AbstractSqoopJobEntryController(JobMeta jobMeta, XulDomContainer container, AbstractSqoopJobEntry<S> jobEntry, BindingFactory bindingFactory) {
+  public AbstractSqoopJobEntryController(JobMeta jobMeta, XulDomContainer container, E jobEntry, BindingFactory bindingFactory) {
     super(jobMeta, container, jobEntry, bindingFactory);
     this.config = (S) jobEntry.getJobConfig().clone();
     this.advancedArguments = new AbstractModelList<ArgumentWrapper>();

--- a/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryDialog.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryDialog.java
@@ -51,7 +51,7 @@ import java.util.ResourceBundle;
  * @param <S> Type of Sqoop configuration object this dialog depends upon. Must match the configuration object the
  *            job entry expects.
  */
-public abstract class AbstractSqoopJobEntryDialog<S extends SqoopConfig> extends JobEntryDialog implements JobEntryDialogInterface {
+public abstract class AbstractSqoopJobEntryDialog<S extends SqoopConfig, E extends AbstractSqoopJobEntry<S>> extends JobEntryDialog implements JobEntryDialogInterface {
 
   protected ResourceBundle bundle = new ResourceBundle() {
     @Override
@@ -66,12 +66,12 @@ public abstract class AbstractSqoopJobEntryDialog<S extends SqoopConfig> extends
   };
 
   private XulDomContainer container;
-  private AbstractSqoopJobEntryController<S> controller;
+  private AbstractSqoopJobEntryController<S, E> controller;
 
   @SuppressWarnings("unchecked")
   protected AbstractSqoopJobEntryDialog(Shell parent, JobEntryInterface jobEntry, Repository rep, JobMeta jobMeta) throws XulException {
     super(parent, jobEntry, rep, jobMeta);
-    init(AbstractSqoopJobEntry.class.cast(jobEntry));
+    init((E) jobEntry);
   }
 
   /**
@@ -92,14 +92,14 @@ public abstract class AbstractSqoopJobEntryDialog<S extends SqoopConfig> extends
    * @param bindingFactory Binding factory to create bindings with
    * @return Controller capable of handling requests for this dialog
    */
-  protected abstract AbstractSqoopJobEntryController<S> createController(XulDomContainer container, AbstractSqoopJobEntry<S> jobEntry, BindingFactory bindingFactory);
+  protected abstract AbstractSqoopJobEntryController<S, E> createController(XulDomContainer container, E jobEntry, BindingFactory bindingFactory);
 
   /**
    * Initialize this dialog for the job entry instance provided.
    *
    * @param jobEntry The job entry this dialog supports.
    */
-  protected void init(AbstractSqoopJobEntry<S> jobEntry) throws XulException {
+  protected void init(E jobEntry) throws XulException {
     SwtXulLoader swtXulLoader = new SwtXulLoader();
     // Register the settings manager so dialog position and size is restored
     swtXulLoader.setSettingsManager(XulSpoonSettingsManager.getInstance());

--- a/src/org/pentaho/di/ui/job/entries/sqoop/SqoopExportJobEntryController.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/SqoopExportJobEntryController.java
@@ -29,6 +29,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.sqoop.AbstractSqoopJobEntry;
 import org.pentaho.di.job.entries.sqoop.SqoopExportConfig;
+import org.pentaho.di.job.entries.sqoop.SqoopExportJobEntry;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.binding.Binding;
 import org.pentaho.ui.xul.binding.BindingFactory;
@@ -42,9 +43,9 @@ import static org.pentaho.di.job.entries.sqoop.SqoopExportConfig.EXPORT_DIR;
 /**
  * Controller for the Sqoop Export Dialog.
  */
-public class SqoopExportJobEntryController extends AbstractSqoopJobEntryController<SqoopExportConfig> {
+public class SqoopExportJobEntryController extends AbstractSqoopJobEntryController<SqoopExportConfig, SqoopExportJobEntry> {
 
-  public SqoopExportJobEntryController(JobMeta jobMeta, XulDomContainer container, AbstractSqoopJobEntry<SqoopExportConfig> sqoopJobEntry, BindingFactory bindingFactory) {
+  public SqoopExportJobEntryController(JobMeta jobMeta, XulDomContainer container, SqoopExportJobEntry sqoopJobEntry, BindingFactory bindingFactory) {
     super(jobMeta, container, sqoopJobEntry, bindingFactory);
   }
 
@@ -76,5 +77,12 @@ public class SqoopExportJobEntryController extends AbstractSqoopJobEntryControll
     } catch (KettleFileException e) {
       getJobEntry().logError(BaseMessages.getString(AbstractSqoopJobEntry.class, "ErrorBrowsingDirectory"), e);
     }
+  }
+
+  @Override
+  public void accept() {
+    // Set the database meta based on the current database
+    jobEntry.setDatabaseMeta(jobMeta.findDatabase(config.getDatabase()));
+    super.accept();
   }
 }

--- a/src/org/pentaho/di/ui/job/entries/sqoop/SqoopExportJobEntryDialog.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/SqoopExportJobEntryDialog.java
@@ -40,7 +40,7 @@ import org.pentaho.ui.xul.binding.BindingFactory;
  *
  * @see org.pentaho.di.job.entries.sqoop.SqoopExportJobEntry
  */
-public class SqoopExportJobEntryDialog extends AbstractSqoopJobEntryDialog<SqoopExportConfig> {
+public class SqoopExportJobEntryDialog extends AbstractSqoopJobEntryDialog<SqoopExportConfig, SqoopExportJobEntry> {
 
   public SqoopExportJobEntryDialog(Shell parent, JobEntryInterface jobEntry, Repository rep, JobMeta jobMeta) throws XulException, InvocationTargetException {
     super(parent, jobEntry, rep, jobMeta);
@@ -57,7 +57,7 @@ public class SqoopExportJobEntryDialog extends AbstractSqoopJobEntryDialog<Sqoop
   }
 
   @Override
-  protected AbstractSqoopJobEntryController<SqoopExportConfig> createController(XulDomContainer container, AbstractSqoopJobEntry<SqoopExportConfig> jobEntry, BindingFactory bindingFactory) {
+  protected SqoopExportJobEntryController createController(XulDomContainer container, SqoopExportJobEntry jobEntry, BindingFactory bindingFactory) {
     return new SqoopExportJobEntryController(jobMeta, container, jobEntry, bindingFactory);
   }
 }

--- a/src/org/pentaho/di/ui/job/entries/sqoop/SqoopImportJobEntryController.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/SqoopImportJobEntryController.java
@@ -29,6 +29,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.job.entries.sqoop.AbstractSqoopJobEntry;
 import org.pentaho.di.job.entries.sqoop.SqoopImportConfig;
+import org.pentaho.di.job.entries.sqoop.SqoopImportJobEntry;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.binding.Binding;
 import org.pentaho.ui.xul.binding.BindingFactory;
@@ -41,9 +42,9 @@ import static org.pentaho.di.job.entries.sqoop.SqoopImportConfig.TARGET_DIR;
 /**
  * Controller for the Sqoop Import Dialog.
  */
-public class SqoopImportJobEntryController extends AbstractSqoopJobEntryController<SqoopImportConfig> {
+public class SqoopImportJobEntryController extends AbstractSqoopJobEntryController<SqoopImportConfig, SqoopImportJobEntry> {
 
-  public SqoopImportJobEntryController(JobMeta jobMeta, XulDomContainer container, AbstractSqoopJobEntry<SqoopImportConfig> sqoopJobEntry, BindingFactory bindingFactory) {
+  public SqoopImportJobEntryController(JobMeta jobMeta, XulDomContainer container, SqoopImportJobEntry sqoopJobEntry, BindingFactory bindingFactory) {
     super(jobMeta, container, sqoopJobEntry, bindingFactory);
   }
 

--- a/src/org/pentaho/di/ui/job/entries/sqoop/SqoopImportJobEntryDialog.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/SqoopImportJobEntryDialog.java
@@ -38,7 +38,7 @@ import org.pentaho.ui.xul.binding.BindingFactory;
  *
  * @see org.pentaho.di.job.entries.sqoop.SqoopImportJobEntry
  */
-public class SqoopImportJobEntryDialog extends AbstractSqoopJobEntryDialog<SqoopImportConfig> {
+public class SqoopImportJobEntryDialog extends AbstractSqoopJobEntryDialog<SqoopImportConfig, SqoopImportJobEntry> {
 
   public SqoopImportJobEntryDialog(Shell parent, JobEntryInterface jobEntry, Repository rep, JobMeta jobMeta) throws XulException {
     super(parent, jobEntry, rep, jobMeta);
@@ -50,7 +50,7 @@ public class SqoopImportJobEntryDialog extends AbstractSqoopJobEntryDialog<Sqoop
   }
 
   @Override
-  protected AbstractSqoopJobEntryController<SqoopImportConfig> createController(XulDomContainer container, AbstractSqoopJobEntry<SqoopImportConfig> jobEntry, BindingFactory bindingFactory) {
+  protected SqoopImportJobEntryController createController(XulDomContainer container, SqoopImportJobEntry jobEntry, BindingFactory bindingFactory) {
     return new SqoopImportJobEntryController(jobMeta, container, jobEntry, bindingFactory);
   }
 

--- a/test-src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryControllerTest.java
+++ b/test-src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryControllerTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.*;
 
 public class AbstractSqoopJobEntryControllerTest {
 
-  private class TestSqoopJobEntryController extends AbstractSqoopJobEntryController<SqoopConfig> {
+  private class TestSqoopJobEntryController extends AbstractSqoopJobEntryController<SqoopConfig, AbstractSqoopJobEntry<SqoopConfig>> {
     private XulDeck modeDeck;
     private XulDeck advancedModeDeck;
     private XulButton advancedListButton;


### PR DESCRIPTION
Did some refactoring to the Sqoop controller and dialog code to support saving the database meta object into the job meta. Updated saving and loading from file and repository as well with unit tests.

When this is pulled in http://jira.pentaho.com/browse/PDI-7826 can be closed.
