### PR TITLE
[PDI-8233] Avro Input join mode sometimes fails with array index out of .bounds exception if many fields are being decoded.

### DIFF
--- a/src/org/pentaho/di/trans/steps/avroinput/AvroInput.java
+++ b/src/org/pentaho/di/trans/steps/avroinput/AvroInput.java
@@ -110,7 +110,8 @@ public class AvroInput extends BaseStep implements StepInterface {
 
       // initialize substitution fields
       if (m_meta.getLookupFields() != null
-          && m_meta.getLookupFields().size() > 0) {
+          && m_meta.getLookupFields().size() > 0 && getInputRowMeta() != null
+          && currentInputRow != null) {
         for (AvroInputMeta.LookupField f : m_meta.getLookupFields()) {
           f.init(getInputRowMeta(), this);
         }


### PR DESCRIPTION
Small additional fix for an initialization exception that would occur in join/lookup mode when no data is flowing into the step (and hence no input row meta is available).
