### PR TITLE
[PDI-8352] Removed transitive dependency on org.eclipse.jdt.core (brough...

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -245,6 +245,7 @@
     <exclude org="commons-logging" module="commons-logging" conf="pmr"/>
     <exclude org="commons-net" module="commons-net" conf="pmr"/>
     <exclude org="log4j" module="log4j" conf="pmr"/>
+    <exclude org="org.eclipse.jdt" module="core" />
 
     <!--                                       END SECTION                                            -->
     <!--                                                                                              -->

--- a/shims/hadoop-20/ivy.xml
+++ b/shims/hadoop-20/ivy.xml
@@ -29,6 +29,7 @@
     <dependency org="org.apache.hadoop" name="hadoop-core" rev="${dependency.hadoop.revision}" transitive="true">
       <exclude org="junit"/>
       <exclude org="ant"/>
+      <exclude org="org.eclipse.jdt" module="core" />
     </dependency>
     <!-- Our modified Hive driver (need to include it until changes are accepted into main Hive project) -->
     <dependency org="org.apache.hive" name="hive-jdbc" rev="${dependency.hive-jdbc.revision}" changing="true" />


### PR DESCRIPTION
...t in by hadoop-core -> jetty). We don't need this on the client.
