### PR TITLE
Fixed a NPE when attempting to load a null class.

### DIFF
--- a/shims/api/src/org/pentaho/hadoop/shim/HadoopConfigurationClassLoader.java
+++ b/shims/api/src/org/pentaho/hadoop/shim/HadoopConfigurationClassLoader.java
@@ -67,7 +67,7 @@ public class HadoopConfigurationClassLoader extends URLClassLoader {
    * @return {@code true} if the class should be ignored by this class loader
    */
   protected boolean ignoreClass(String name) {
-    if (loadClassesFromParent.contains(name)) {
+    if (name == null || loadClassesFromParent.contains(name)) {
       return true;
     }
     for (String prefix : loadClassesFromParent) {

--- a/shims/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationClassLoaderTest.java
+++ b/shims/api/test-src/org/pentaho/hadoop/shim/HadoopConfigurationClassLoaderTest.java
@@ -47,6 +47,6 @@ public class HadoopConfigurationClassLoaderTest {
     assertTrue(hccl.ignoreClass("org.apache.log4j"));
     assertTrue(hccl.ignoreClass("org.apache.log4j.Logger"));
     assertFalse(hccl.ignoreClass("bogus"));
+    assertTrue(hccl.ignoreClass(null));
   }
-
 }


### PR DESCRIPTION
Turns out the Hadoop Job Executor will cause this to happen if a class name is omitted from the configuration. While that shouldn't be possible we need to not throw a NPE when someone attempts to load a null classname.
