### PR TITLE
[PDI-8779] Opening HBase Input step dialog hangs indefinitely when Zookeeper Host value points to host that is not accessible.

### DIFF
--- a/src/org/pentaho/di/trans/steps/hbaseinput/HBaseInputDialog.java
+++ b/src/org/pentaho/di/trans/steps/hbaseinput/HBaseInputDialog.java
@@ -33,8 +33,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -450,26 +448,6 @@ public class HBaseInputDialog extends BaseStepDialog implements
         m_currentMeta.setChanged();
         m_mappedTableNamesCombo.setToolTipText(transMeta
             .environmentSubstitute(m_mappedTableNamesCombo.getText()));
-      }
-    });
-    m_mappedTableNamesCombo.addSelectionListener(new SelectionAdapter() {
-      @Override
-      public void widgetSelected(SelectionEvent e) {
-        setupMappingNamesForTable(true);
-      }
-
-      @Override
-      public void widgetDefaultSelected(SelectionEvent e) {
-        setupMappingNamesForTable(true);
-      }
-    });
-    m_mappedTableNamesCombo.addFocusListener(new FocusListener() {
-      public void focusGained(FocusEvent e) {
-
-      }
-
-      public void focusLost(FocusEvent e) {
-        setupMappingNamesForTable(true);
       }
     });
 
@@ -1250,6 +1228,12 @@ public class HBaseInputDialog extends BaseStepDialog implements
           .getText());
     }
 
+    if (Const.isEmpty(zookeeperHosts) && Const.isEmpty(coreConf)
+        && Const.isEmpty(defaultConf)) {
+      throw new Exception(BaseMessages.getString(HBaseInputMeta.PKG,
+          "MappingDialog.Error.Message.CantConnectNoConnectionDetailsProvided"));
+    }
+
     conf = HBaseInputData.getHBaseConnection(zookeeperHosts, zookeeperPort,
         coreConf, defaultConf, null);
 
@@ -1279,7 +1263,7 @@ public class HBaseInputDialog extends BaseStepDialog implements
         String keyType = null;
         boolean filterAliasesDone = false;
         try {
-          if (displayFieldsMappingFromHBase) {
+          if (displayFieldsMappingFromHBase && readFieldsFromMapping) {
             HBaseConnection connection = getHBaseConnection();
             admin.setConnection(connection);
             current = admin.getMapping(transMeta

--- a/src/org/pentaho/di/trans/steps/hbaseinput/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/trans/steps/hbaseinput/messages/messages_en_US.properties
@@ -60,6 +60,7 @@ HBaseInputDialog.Filters.FIELD_FORMAT=Format
 HBaseInputDialog.Filters.FIELD_SIGNED=Signed comparison
 
 MappingDialog.TableName.Label=HBase table name
+MappingDialog.TableName.GetTableNames=Get table names
 MappingDialog.MappingName.Label=Mapping name
 MappingDialog.SaveMapping=Save mapping
 MappingDialog.SaveMapping.TipText=Persist the mapping in HBase
@@ -119,6 +120,7 @@ MappingDialog.Error.Title.ErrorSaving=Error during save
 MappingDialog.Error.Message.ErrorSaving=An error occurred while trying to save the mapping
 MappingDialog.Error.Title.ErrorLoadingMapping=Error during load
 MappingDialog.Error.Message.ErrorLoadingMapping=An error occurred while trying to load the mapping definition
+MappingDialog.Error.Message.CantConnectNoConnectionDetailsProvided=Can't connect to HBase as no connection details have been provided
 
 MappingDialog.GetFieldsChoice.Title=Question
 MappingDialog.GetFieldsChoice.Message=Data has already been entered - {0} fields were found.\nHow do you want to add the {1} incoming fields?

--- a/src/org/pentaho/di/trans/steps/hbaseoutput/HBaseOutputDialog.java
+++ b/src/org/pentaho/di/trans/steps/hbaseoutput/HBaseOutputDialog.java
@@ -31,8 +31,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -425,26 +423,6 @@ public class HBaseOutputDialog extends BaseStepDialog implements
             .environmentSubstitute(m_mappedTableNamesCombo.getText()));
       }
     });
-    m_mappedTableNamesCombo.addSelectionListener(new SelectionAdapter() {
-      @Override
-      public void widgetSelected(SelectionEvent e) {
-        setupMappingNamesForTable(true);
-      }
-
-      @Override
-      public void widgetDefaultSelected(SelectionEvent e) {
-        setupMappingNamesForTable(true);
-      }
-    });
-    m_mappedTableNamesCombo.addFocusListener(new FocusListener() {
-      public void focusGained(FocusEvent e) {
-
-      }
-
-      public void focusLost(FocusEvent e) {
-        setupMappingNamesForTable(true);
-      }
-    });
 
     fd = new FormData();
     fd.left = new FormAttachment(middle, 0);
@@ -795,6 +773,12 @@ public class HBaseOutputDialog extends BaseStepDialog implements
     if (!Const.isEmpty(m_zookeeperPortText.getText())) {
       zookeeperPort = transMeta.environmentSubstitute(m_zookeeperPortText
           .getText());
+    }
+
+    if (Const.isEmpty(zookeeperHosts) && Const.isEmpty(coreConf)
+        && Const.isEmpty(defaultConf)) {
+      throw new Exception(BaseMessages.getString(HBaseOutputMeta.PKG,
+          "MappingDialog.Error.Message.CantConnectNoConnectionDetailsProvided"));
     }
 
     conf = HBaseOutputData.getHBaseConnection(zookeeperHosts, zookeeperPort,

--- a/src/org/pentaho/di/trans/steps/hbaseoutput/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/trans/steps/hbaseoutput/messages/messages_en_US.properties
@@ -35,6 +35,7 @@ HBaseOutputDialog.Error.IssuesWithMapping.ButtonOK=OK and close
 HBaseOutputDialog.Error.IssuesWithMapping.ButtonCancel=Cancel and rectify
 
 MappingDialog.TableName.Label=HBase table name
+MappingDialog.TableName.GetTableNames=Get table names
 MappingDialog.MappingName.Label=Mapping name
 MappingDialog.SaveMapping=Save mapping
 MappingDialog.SaveMapping.TipText=Persist the mapping in HBase
@@ -54,6 +55,7 @@ MappingDialog.Error.Message1.DuplicateColumn=Column "
 MappingDialog.Error.Message2.DuplicateColumn=" has already been defined for this mapping
 MappingDialog.Error.Title.NoKeyDefined=No key defined
 MappingDialog.Error.Message.NoKeyDefined=No key has been defined for this mapping
+MappingDialog.Error.Message.CantConnectNoConnectionDetailsProvided=Can't connect to HBase as no connection details have been provided
 
 MappingDialog.Error.Title.IssuesPreventingSaving=Error(s) in field definitions
 MappingDialog.Error.Message.IssuesPreventingSaving=The following issues prevent this mapping from being created

--- a/src/org/pentaho/hbase/mapping/MappingEditor.java
+++ b/src/org/pentaho/hbase/mapping/MappingEditor.java
@@ -92,6 +92,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
   // table name line
   protected CCombo m_existingTableNamesCombo;
+  protected Button m_getTableNames;
   protected boolean m_familiesInvalidated;
 
   // mapping name line
@@ -209,16 +210,36 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     fd.right = new FormAttachment(middle, -margin);
     tableNameLab.setLayoutData(fd);
 
+    m_getTableNames = new Button(this, SWT.PUSH | SWT.CENTER);
+    props.setLook(m_getTableNames);
+    m_getTableNames.setText(Messages
+        .getString("MappingDialog.TableName.GetTableNames"));
+    fd = new FormData();
+    fd.right = new FormAttachment(100, 0);
+    if (showConnectWidgets) {
+      fd.top = new FormAttachment(m_zookeeperPortText, 0);
+    } else {
+      fd.top = new FormAttachment(0, 0);
+    }
+    m_getTableNames.setLayoutData(fd);
+
+    m_getTableNames.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent e) {
+        populateTableCombo(false);
+      }
+    });
+
     m_existingTableNamesCombo = new CCombo(this, SWT.BORDER);
     props.setLook(m_existingTableNamesCombo);
     fd = new FormData();
     fd.left = new FormAttachment(middle, 0);
+    fd.right = new FormAttachment(m_getTableNames, -margin);
     if (showConnectWidgets) {
       fd.top = new FormAttachment(m_zookeeperPortText, margin);
     } else {
       fd.top = new FormAttachment(0, margin);
     }
-    fd.right = new FormAttachment(100, 0);
     m_existingTableNamesCombo.setLayoutData(fd);
 
     // allow or disallow table creation by enabling/disabling the ability
@@ -232,7 +253,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     props.setLook(tableNameLab);
     fd = new FormData();
     fd.left = new FormAttachment(0, 0);
-    fd.top = new FormAttachment(m_existingTableNamesCombo, margin);
+    fd.top = new FormAttachment(m_getTableNames, 0);
     fd.right = new FormAttachment(middle, -margin);
     mappingNameLab.setLayoutData(fd);
 
@@ -240,7 +261,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     props.setLook(m_existingMappingNamesCombo);
     fd = new FormData();
     fd.left = new FormAttachment(middle, 0);
-    fd.top = new FormAttachment(m_existingTableNamesCombo, margin);
+    fd.top = new FormAttachment(m_getTableNames, 0);
     fd.right = new FormAttachment(100, 0);
     m_existingMappingNamesCombo.setLayoutData(fd);
 
@@ -267,7 +288,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
     m_existingTableNamesCombo.addFocusListener(new FocusListener() {
       public void focusGained(FocusEvent e) {
-        populateTableCombo(false);
+        // populateTableCombo(false);
       }
 
       public void focusLost(FocusEvent e) {


### PR DESCRIPTION
HBaseInput and HBaseOutput step dialogs now avoid attempting to connect to HBase when opened. Selecting an entry from the HBase table drop down box no longer attempts to populate the mapping drop down box (user must always press the get mapping names button). Similarly, the MappingEditor no longer attempts to fetch table names from HBase when first opened. It now sports a "Get table names" button.
