### PR TITLE
PDI-5246: Space in class name of HTJE step causes class not found 

### DIFF
--- a/src/org/pentaho/di/job/entries/hadooptransjobexecutor/JobEntryHadoopTransJobExecutor.java
+++ b/src/org/pentaho/di/job/entries/hadooptransjobexecutor/JobEntryHadoopTransJobExecutor.java
@@ -664,12 +664,12 @@ public class JobEntryHadoopTransJobExecutor extends JobEntryBase implements Clon
       conf.setMapRunnerClass(shim.getPentahoMapReduceMapRunnerClass());
 
       if(inputFormatClass != null) {
-        String inputFormatClassS = environmentSubstitute(inputFormatClass);
+        String inputFormatClassS = environmentSubstitute(inputFormatClass).trim();
         Class<?> inputFormat = loader.loadClass(inputFormatClassS);
         conf.setInputFormat(inputFormat);
       }
       if(outputFormatClass != null) {
-        String outputFormatClassS = environmentSubstitute(outputFormatClass);
+        String outputFormatClassS = environmentSubstitute(outputFormatClass).trim();
         Class<?> outputFormat = loader.loadClass(outputFormatClassS);
         conf.setOutputFormat(outputFormat);
       }


### PR DESCRIPTION
added call to trim() when processing InputFormat and OutputFormat class names
