### PR TITLE
Updated Kettle revision to TRUNK-SNAPSHOT for master branch

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -6,7 +6,7 @@ project.revision=TRUNK-SNAPSHOT
 
 junit.maxmemory=500M
 
-dependency.kettle.revision=4.4.0-GA
+dependency.kettle.revision=TRUNK-SNAPSHOT
 dependency.kettle5-log4j.revision=TRUNK-SNAPSHOT
 kettle-distrib-artifact-name=pdi-ce-${dependency.kettle.revision}
 kettle-distrib-with-plugin-name=${kettle-distrib-artifact-name}-big-data


### PR DESCRIPTION
big-data-plugin for PDI 4.4 has been branched to 1.4, so the master branch should resolve and build with PDI TRUNK-SNAPSHOT
