### PR TITLE
[ENGOPS-124]: Corrected case of edtftpj dependency

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -178,7 +178,7 @@
     <dependency org="ascsapjco3wrp" name="ascsapjco3wrp" rev="20100529" conf="pmr->default" transitive="false"/>
     <dependency org="jcifs" name="jcifs" rev="1.3.3" conf="pmr->default" transitive="false"/>
     <dependency org="com.jcraft" name="jsch" rev="0.1.46" conf="pmr->default" transitive="false"/>
-    <dependency org="com.enterprisedt" name="edtFTPj" rev="2.1.0" conf="pmr->default" transitive="false"/>
+    <dependency org="com.enterprisedt" name="edtftpj" rev="2.1.0" conf="pmr->default" transitive="false"/>
     <dependency org="jdom" name="jdom" rev="1.0" conf="pmr->default" transitive="false"/>
     <dependency org="javadbf" name="javadbf" rev="20081125" conf="pmr->default" transitive="false"/>
     <dependency org="org.ini4j" name="ini4j" rev="0.5.1" conf="pmr->default" transitive="false"/>


### PR DESCRIPTION
The edtftpj JAR has been published to our own third-party artifactory, and the name is now lowercase.
