### PR TITLE
SP-785 Backport of PDI-10113 - Unable to output a text file using the 'S3 file output' step (5.0)

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -178,7 +178,7 @@
     <dependency org="ascsapjco3wrp" name="ascsapjco3wrp" rev="20100529" conf="pmr->default" transitive="false"/>
     <dependency org="jcifs" name="jcifs" rev="1.3.3" conf="pmr->default" transitive="false"/>
     <dependency org="com.jcraft" name="jsch" rev="0.1.46" conf="pmr->default" transitive="false"/>
-    <dependency org="com.enterprisedt" name="edtFTPj" rev="2.1.0" conf="pmr->default" transitive="false"/>
+    <dependency org="com.enterprisedt" name="edtftpj" rev="2.1.0" conf="pmr->default" transitive="false"/>
     <dependency org="jdom" name="jdom" rev="1.0" conf="pmr->default" transitive="false"/>
     <dependency org="javadbf" name="javadbf" rev="20081125" conf="pmr->default" transitive="false"/>
     <dependency org="org.ini4j" name="ini4j" rev="0.5.1" conf="pmr->default" transitive="false"/>

--- a/src/org/pentaho/amazon/s3/S3FileOutput.java
+++ b/src/org/pentaho/amazon/s3/S3FileOutput.java
@@ -1,0 +1,84 @@
+/*
+ * ! ******************************************************************************
+ *  *
+ *  * Pentaho Data Integration
+ *  *
+ *  * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *  *
+ *  *******************************************************************************
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  *
+ *  *****************************************************************************
+ */
+
+package org.pentaho.amazon.s3;
+
+import org.apache.commons.vfs.FileObject;
+import org.apache.commons.vfs.FileSystemException;
+import org.apache.commons.vfs.FileSystemOptions;
+import org.apache.commons.vfs.auth.StaticUserAuthenticator;
+import org.apache.commons.vfs.impl.DefaultFileSystemConfigBuilder;
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.vfs.KettleVFS;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.steps.textfileoutput.TextFileOutput;
+
+import java.io.OutputStream;
+
+public class S3FileOutput extends TextFileOutput {
+
+  private FileSystemOptions fsOptions;
+
+  public S3FileOutput( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
+                         Trans trans ) {
+    super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
+  }
+
+  protected FileObject getFileObject( String vfsFilename ) throws KettleFileException {
+    return KettleVFS.getFileObject( vfsFilename, getFsOptions() );
+  }
+
+  protected FileObject getFileObject( String vfsFilename, VariableSpace space ) throws KettleFileException {
+    return KettleVFS.getFileObject( vfsFilename, space, getFsOptions() );
+  }
+
+  protected OutputStream getOutputStream( String vfsFilename, VariableSpace space, boolean append )
+    throws KettleFileException {
+    return KettleVFS.getOutputStream( vfsFilename, space, getFsOptions() , append );
+  }
+
+  protected FileSystemOptions createFileSystemOptions() throws KettleFileException {
+    try {
+      FileSystemOptions opts = new FileSystemOptions();
+      S3FileOutputMeta s3Meta = (S3FileOutputMeta) meta;
+      DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator(opts,
+        new StaticUserAuthenticator( null, s3Meta.getAccessKey(),  s3Meta.getSecretKey() ) );
+      return opts;
+    } catch ( FileSystemException e ) {
+      throw new KettleFileException( e );
+    }
+  }
+
+  protected FileSystemOptions getFsOptions() throws KettleFileException {
+    if ( fsOptions == null ) {
+      fsOptions = createFileSystemOptions();
+    }
+    return fsOptions;
+  }
+
+}

--- a/src/org/pentaho/amazon/s3/S3FileOutputMeta.java
+++ b/src/org/pentaho/amazon/s3/S3FileOutputMeta.java
@@ -1,34 +1,61 @@
 /*******************************************************************************
- *
- * Pentaho Big Data
- *
- * Copyright (C) 2002-2012 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- ******************************************************************************/
+*
+* Pentaho Big Data
+*
+* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+*
+*******************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License. You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+******************************************************************************/
 
 package org.pentaho.amazon.s3;
 
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.annotations.Step;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.encryption.Encr;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepInterface;
+import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.steps.textfileoutput.TextFileOutputMeta;
+
+import org.pentaho.metastore.api.IMetaStore;
+import org.w3c.dom.Node;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Step( id = "S3FileOutputPlugin", image = "S3O.png", name = "S3 File Output",
   description = "Create files in an S3 location", categoryDescription = "Output" )
 public class S3FileOutputMeta extends TextFileOutputMeta {
+
+  private static final String ACCESS_KEY_TAG = "access_key";
+  private static final String SECRET_KEY_TAG = "secret_key";
+  private static final String FILE_TAG = "file";
+  private static final String NAME_TAG = "name";
+
+  private static final Pattern OLD_STYLE_FILENAME =  Pattern.compile( "^[s|S]3:\\/\\/([0-9a-zA-Z]{20}):(.+)@(.+)$" );
 
   private String accessKey = null;
   private String secretKey = null;
@@ -69,6 +96,97 @@ public class S3FileOutputMeta extends TextFileOutputMeta {
     //      retval = AmazonSpoonPlugin.S3_SCHEME + "://" + authPart + "@s3" + retval.substring(retval.indexOf("@s3")+3);
     //    }
     return retval;
+  }
+
+  @Override
+  public String getXML() {
+    StringBuffer retval = new StringBuffer( 1000 );
+
+    retval.append( super.getXML() );
+    retval.append( "      " )
+      .append( XMLHandler.addTagValue( ACCESS_KEY_TAG, Encr.encryptPasswordIfNotUsingVariables( accessKey ) ) );
+    retval.append( "      " )
+      .append( XMLHandler.addTagValue( SECRET_KEY_TAG, Encr.encryptPasswordIfNotUsingVariables( secretKey ) ) );
+
+    return retval.toString();
+  }
+
+  @Override
+  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step )
+    throws KettleException {
+    try {
+      super.saveRep( rep, metaStore, id_transformation, id_step );
+      rep.saveStepAttribute( id_transformation, id_step, ACCESS_KEY_TAG,
+        Encr.encryptPasswordIfNotUsingVariables( accessKey ) );
+      rep.saveStepAttribute( id_transformation, id_step, SECRET_KEY_TAG,
+        Encr.encryptPasswordIfNotUsingVariables( secretKey ) );
+    } catch ( Exception e ) {
+      throw new KettleException( "Unable to save step information to the repository for id_step=" + id_step, e );
+    }
+  }
+
+  @Override
+  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
+    throws KettleException {
+    try {
+      super.readRep( rep, metaStore, id_step, databases );
+      setAccessKey( Encr.decryptPasswordOptionallyEncrypted( rep.getStepAttributeString( id_step, ACCESS_KEY_TAG ) ) );
+      setSecretKey( Encr.decryptPasswordOptionallyEncrypted( rep.getStepAttributeString( id_step, SECRET_KEY_TAG ) ) );
+      String filename = rep.getStepAttributeString( id_step, "file_name" );
+      processFilename( filename );
+    } catch ( Exception e ) {
+      throw new KettleException( "Unexpected error reading step information from the repository", e );
+    }
+  }
+
+  @Override
+  public void readData( Node stepnode ) throws KettleXMLException {
+    try {
+      super.readData( stepnode );
+      accessKey = Encr.decryptPasswordOptionallyEncrypted( XMLHandler.getTagValue( stepnode, ACCESS_KEY_TAG ) );
+      secretKey = Encr.decryptPasswordOptionallyEncrypted( XMLHandler.getTagValue( stepnode, SECRET_KEY_TAG ) );
+      String filename = XMLHandler.getTagValue( stepnode, FILE_TAG, NAME_TAG );
+      processFilename( filename );
+    } catch ( Exception e ) {
+      throw new KettleXMLException( "Unable to load step info from XML", e );
+    }
+  }
+
+  @Override
+  public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int cnr, TransMeta transMeta,
+                                Trans trans ) {
+    return new S3FileOutput( stepMeta, stepDataInterface, cnr, transMeta, trans );
+  }
+
+  /**
+   * New filenames obey the rule s3://<any_string>/<s3_bucket_name>/<path>. However, we maintain old filenames
+   * s3://<access_key>:<secret_key>@s3/<s3_bucket_name>/<path>
+   *
+   * @param filename
+   * @return
+   */
+  protected void processFilename( String filename ) throws Exception {
+    if ( Const.isEmpty( filename ) ) {
+      setFileName( filename );
+      return;
+    }
+    // it it's an old-style filename - use and then remove keys from the filename
+    Matcher matcher = OLD_STYLE_FILENAME.matcher( filename );
+    if ( matcher.matches() ) {
+      // old style filename is URL encoded
+      accessKey = decodeAccessKey( matcher.group( 1 ) );
+      secretKey = decodeAccessKey( matcher.group( 2 ) );
+      setFileName( "s3://" + matcher.group( 3 ) );
+    } else {
+      setFileName( filename );
+    }
+  }
+
+  protected String decodeAccessKey( String key ) {
+    if ( Const.isEmpty( key ) ) {
+      return key;
+    }
+    return key.replaceAll( "%2B", "\\+" ).replaceAll( "%2F", "/" );
   }
 
 }

--- a/test-src/org/pentaho/amazon/s3/S3FileOutputMetaProcessFilenameTest.java
+++ b/test-src/org/pentaho/amazon/s3/S3FileOutputMetaProcessFilenameTest.java
@@ -1,0 +1,86 @@
+/*
+ * ! ******************************************************************************
+ *  *
+ *  * Pentaho Data Integration
+ *  *
+ *  * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *  *
+ *  *******************************************************************************
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  *
+ *  *****************************************************************************
+ */
+
+package org.pentaho.amazon.s3;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class S3FileOutputMetaProcessFilenameTest {
+
+  private S3FileOutputMeta meta = null;
+
+  @Before
+  public void beforeTest() {
+    meta = new S3FileOutputMeta();
+    meta.setAccessKey( "" );
+    meta.setSecretKey( "" );
+    meta.setFileName( "" );
+  }
+
+  @Test
+  public void testProcessFilenameOldStyleNotEncoded() throws Exception {
+    String name = "s3://AAAAAAABBBBBBBBB333A:Qqqqqqqqqqq+uP777777/RRRRRRRRRRRR+dWvhzS@s3/dbahdano/empty";
+    meta.processFilename( name );
+    check( "AAAAAAABBBBBBBBB333A", "Qqqqqqqqqqq+uP777777/RRRRRRRRRRRR+dWvhzS", "s3://s3/dbahdano/empty" );
+  }
+
+  @Test
+  public void testProcessFilenameCapitalLetter() throws Exception {
+    String name = "S3://AAAAAAABBBBBBBBB333A:Qqqqqqqqqqq+uP777777/RRRRRRRRRRRR+dWvhzS@s3/dbahdano/empty";
+    meta.processFilename( name );
+    check( "AAAAAAABBBBBBBBB333A", "Qqqqqqqqqqq+uP777777/RRRRRRRRRRRR+dWvhzS", "s3://s3/dbahdano/empty" );
+  }
+
+  @Test
+  public void testProcessFilenameOldStyleEncoded() throws Exception {
+    String name = "s3://AAAAAAABBBBBBBBB333A:Q123456789%2BqwertyUIO%2FREFfJUW7FdNY%2BdWvhzS@s3/dbahdano/empty";
+    meta.processFilename( name );
+    check( "AAAAAAABBBBBBBBB333A", "Q123456789+qwertyUIO/REFfJUW7FdNY+dWvhzS", "s3://s3/dbahdano/empty" );
+  }
+
+  @Test
+  public void testProcessFilenameNewStyle1() throws Exception {
+    String name = "s3://s3/dbahdano/empty";
+    meta.processFilename( name );
+    check( "", "", "s3://s3/dbahdano/empty" );
+  }
+
+  @Test
+  public void testProcessFilenameNewStyle2() throws Exception {
+    String name = "s3://s/dbahdano/empty";
+    meta.processFilename( name );
+    check( "", "", "s3://s/dbahdano/empty" );
+  }
+
+  private void check( String expectedAccessKey, String expectedSecretKey,
+                      String expectedFilename ) throws Exception {
+    assertEquals( "Access keys are not equal", expectedAccessKey, meta.getAccessKey() );
+    assertEquals( "Secret keys are not equal", expectedSecretKey, meta.getSecretKey() );
+    assertEquals( "File names are not equal", expectedFilename, meta.getFileName() );
+
+  }
+}


### PR DESCRIPTION
This is the part of the complex fix which affects 3 repositories: pentaho-s3-vfs, pentaho-kettle, big-data-plugin - and, hence, different jar files. So before running Ci jobs, please make sure that local Ivy cache is clean to use up-to-date jars.
