### PR TITLE
[PDI-8986] Don't close appender referencing to System.out

### DIFF
--- a/src/org/pentaho/di/job/entries/pig/JobEntryPigScriptExecutor.java
+++ b/src/org/pentaho/di/job/entries/pig/JobEntryPigScriptExecutor.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.di.job.entries.pig;
 
@@ -103,25 +103,35 @@ public class JobEntryPigScriptExecutor extends JobEntryBase implements Cloneable
     public KettleLoggingPrintWriter() {
       super(System.out);
     }
-    
+
+    @Override
     public void println(String string) {
       logBasic(string);
     }
-    
+
+    @Override
     public void println(Object obj) {
       println(obj.toString());
     }
-    
+
+    @Override
     public void write(String string) {
       println(string);
     }
-    
+
+    @Override
     public void print(String string) {
       println(string);
     }
-    
+
+    @Override
     public void print(Object obj) {
       print(obj.toString());
+    }
+
+    @Override
+    public void close() {
+      flush();
     }
   }  
   


### PR DESCRIPTION
An appender is writing to System.out, hence, we can't close it to let next steps/job entries write to the stream.

Unit test is not attached as the I'm not sure it's reasonable in this case: the fix is trivial, and it doesn't affect any sensitive area. Please let me know if you have other opinion.
