### PR TITLE
PDI-12215

### DIFF
--- a/src/org/pentaho/amazon/s3/S3FileOutput.java
+++ b/src/org/pentaho/amazon/s3/S3FileOutput.java
@@ -67,7 +67,7 @@ public class S3FileOutput extends TextFileOutput {
     try {
       FileSystemOptions opts = new FileSystemOptions();
       S3FileOutputMeta s3Meta = (S3FileOutputMeta) meta;
-      DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator(opts,
+      DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator( opts,
         new StaticUserAuthenticator( null,
             Encr.decryptPasswordOptionallyEncrypted( environmentSubstitute( s3Meta.getAccessKey() ) ),
             Encr.decryptPasswordOptionallyEncrypted( environmentSubstitute( s3Meta.getSecretKey() ) ) ) );


### PR DESCRIPTION
Allow environment variables with encrypted passwords for AWS credentials

The [s3csvinput.jar](https://github.com/pentaho/pentaho-kettle/blob/master/assembly/package-res/plugins/steps/S3CsvInput/s3csvinput.jar) stored in Pentaho Kettle also needs to be updated to allow for Encr.decryptPasswordOptionallyDecrypted() in `org.pentaho.di.trans.steps.s3csvinput.S3CsvInputMeta.getS3Service()`.  The jar's source is not checked into the Pentaho GitHub account.
