### PR TITLE
PDI-11989 - When using the Sqoop Export Job Entry, the Dialog is placing un-needed entries onto the command line string that is generated.

### DIFF
--- a/src/org/pentaho/di/job/ArgumentWrapper.java
+++ b/src/org/pentaho/di/job/ArgumentWrapper.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.di.job;
 
@@ -38,11 +38,11 @@ public class ArgumentWrapper implements XulEventSource {
   private Method getter;
   private Method setter;
 
-  public ArgumentWrapper(String name, String displayName, boolean flag, Object target, Method getter, Method setter) {
-    if (name == null || target == null || getter == null || setter == null) {
+  public ArgumentWrapper( String name, String displayName, boolean flag, Object target, Method getter, Method setter ) {
+    if ( name == null || target == null || getter == null || setter == null ) {
       throw new NullPointerException();
     }
-    validateAccessors(getter, setter);
+    validateAccessors( getter, setter );
 
     this.name = name;
     this.displayName = displayName;
@@ -52,12 +52,12 @@ public class ArgumentWrapper implements XulEventSource {
     this.setter = setter;
   }
 
-  private void validateAccessors(Method getter, Method setter) {
-    if (getter.getReturnType() != String.class) {
-      throw new IllegalArgumentException("Invalid getter method. Method must return a String,");
+  private void validateAccessors( Method getter, Method setter ) {
+    if ( getter.getReturnType() != String.class ) {
+      throw new IllegalArgumentException( "Invalid getter method. Method must return a String," );
     }
-    if (setter.getParameterTypes().length < 1 || setter.getParameterTypes()[0] != String.class) {
-      throw new IllegalArgumentException("Invalid setter method. Method must accept a single String parameter.");
+    if ( setter.getParameterTypes().length < 1 || setter.getParameterTypes()[ 0 ] != String.class ) {
+      throw new IllegalArgumentException( "Invalid setter method. Method must accept a single String parameter." );
     }
   }
 
@@ -65,7 +65,7 @@ public class ArgumentWrapper implements XulEventSource {
     return name;
   }
 
-  public void setName(String name) {
+  public void setName( String name ) {
     this.name = name;
   }
 
@@ -73,23 +73,27 @@ public class ArgumentWrapper implements XulEventSource {
     return displayName;
   }
 
-  public void setDisplayName(String displayName) {
+  public void setDisplayName( String displayName ) {
     this.displayName = displayName;
   }
 
-  public void setValue(String value) {
+  public void setValue( String value ) {
     try {
-      setter.invoke(target, value);
-    } catch (Exception ex) {
-      throw new RuntimeException("error setting value for argument " + getName(), ex);
+      if ( "".equals( value ) ) {
+        value = null;
+      }
+
+      setter.invoke( target, value );
+    } catch ( Exception ex ) {
+      throw new RuntimeException( "error setting value for argument " + getName(), ex );
     }
   }
 
   public String getValue() {
     try {
-      return String.class.cast(getter.invoke(target));
-    } catch (Exception ex) {
-      throw new RuntimeException("error retrieving value for argument " + getName(), ex);
+      return String.class.cast( getter.invoke( target ) );
+    } catch ( Exception ex ) {
+      throw new RuntimeException( "error retrieving value for argument " + getName(), ex );
     }
   }
 
@@ -97,7 +101,7 @@ public class ArgumentWrapper implements XulEventSource {
     return flag;
   }
 
-  public void setFlag(boolean flag) {
+  public void setFlag( boolean flag ) {
     this.flag = flag;
   }
 
@@ -108,13 +112,17 @@ public class ArgumentWrapper implements XulEventSource {
    * @return {@code true} if {@code o} is an {@link ArgumentWrapper} and its name equals this argument's name
    */
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+  public boolean equals( Object o ) {
+    if ( this == o ) {
+      return true;
+    }
+    if ( o == null || getClass() != o.getClass() ) {
+      return false;
+    }
 
     ArgumentWrapper that = (ArgumentWrapper) o;
 
-    return this.name.equals(that.name);
+    return this.name.equals( that.name );
   }
 
   @Override
@@ -123,12 +131,12 @@ public class ArgumentWrapper implements XulEventSource {
   }
 
   @Override
-  public void addPropertyChangeListener(PropertyChangeListener listener) {
+  public void addPropertyChangeListener( PropertyChangeListener listener ) {
     // Do nothing, this object is a wrapper and firing events here propagates to too many objects
   }
 
   @Override
-  public void removePropertyChangeListener(PropertyChangeListener listener) {
+  public void removePropertyChangeListener( PropertyChangeListener listener ) {
     // Do nothing, this object is a wrapper and firing events here propagates to too many objects
   }
 }

--- a/src/org/pentaho/di/job/CommandLineArgument.java
+++ b/src/org/pentaho/di/job/CommandLineArgument.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.di.job;
 
@@ -28,8 +28,8 @@ import java.lang.annotation.*;
  * Marks a field as a command line argument.
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Retention( RetentionPolicy.RUNTIME )
+@Target( ElementType.FIELD )
 public @interface CommandLineArgument {
   /**
    * @return the name of the command line argument (full name), e.g. --table

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopConfig.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopConfig.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.di.job.entries.sqoop;
 
@@ -95,96 +95,105 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
   private String mode;
 
   // Common arguments
-  @CommandLineArgument(name = CONNECT)
+  @CommandLineArgument( name = CONNECT )
   private String connect;
 
-  @CommandLineArgument(name = "connection-manager")
+  @CommandLineArgument( name = "connection-manager" )
   private String connectionManager;
-  @CommandLineArgument(name = DRIVER)
+  @CommandLineArgument( name = DRIVER )
   private String driver;
-  @CommandLineArgument(name = USERNAME)
+  @CommandLineArgument( name = USERNAME )
   private String username;
-  @CommandLineArgument(name = PASSWORD)
+  @CommandLineArgument( name = PASSWORD )
   @Password
   private String password;
-  @CommandLineArgument(name = VERBOSE, flag = true)
+  @CommandLineArgument( name = VERBOSE, flag = true )
   private String verbose;
-  @CommandLineArgument(name = "connection-param-file")
+  @CommandLineArgument( name = "connection-param-file" )
   private String connectionParamFile;
-  @CommandLineArgument(name = "hadoop-home")
+  @CommandLineArgument( name = "hadoop-home" )
   private String hadoopHome;
   // Output line formatting arguments
-  @CommandLineArgument(name = "enclosed-by")
+  @CommandLineArgument( name = "enclosed-by" )
   private String enclosedBy;
 
-  @CommandLineArgument(name = "escaped-by")
+  @CommandLineArgument( name = "escaped-by" )
   private String escapedBy;
-  @CommandLineArgument(name = "fields-terminated-by")
+  @CommandLineArgument( name = "fields-terminated-by" )
   private String fieldsTerminatedBy;
-  @CommandLineArgument(name = "lines-terminated-by")
+  @CommandLineArgument( name = "lines-terminated-by" )
   private String linesTerminatedBy;
-  @CommandLineArgument(name = "optionally-enclosed-by")
+  @CommandLineArgument( name = "optionally-enclosed-by" )
   private String optionallyEnclosedBy;
-  @CommandLineArgument(name = "mysql-delimiters", flag = true)
+  @CommandLineArgument( name = "mysql-delimiters", flag = true )
   private String mysqlDelimiters;
   // Input parsing arguments
-  @CommandLineArgument(name = "input-enclosed-by")
+  @CommandLineArgument( name = "input-enclosed-by" )
   private String inputEnclosedBy;
 
-  @CommandLineArgument(name = "input-escaped-by")
+  @CommandLineArgument( name = "input-escaped-by" )
   private String inputEscapedBy;
-  @CommandLineArgument(name = "input-fields-terminated-by")
+  @CommandLineArgument( name = "input-fields-terminated-by" )
   private String inputFieldsTerminatedBy;
-  @CommandLineArgument(name = "input-lines-terminated-by")
+  @CommandLineArgument( name = "input-lines-terminated-by" )
   private String inputLinesTerminatedBy;
-  @CommandLineArgument(name = "input-optionally-enclosed-by")
+  @CommandLineArgument( name = "input-optionally-enclosed-by" )
   private String inputOptionallyEnclosedBy;
   // Code generation arguments
-  @CommandLineArgument(name = "bindir")
+  @CommandLineArgument( name = "bindir" )
   private String binDir;
 
-  @CommandLineArgument(name = "class-name")
+  @CommandLineArgument( name = "class-name" )
   private String className;
-  @CommandLineArgument(name = "jar-file")
+  @CommandLineArgument( name = "jar-file" )
   private String jarFile;
-  @CommandLineArgument(name = OUTDIR)
+  @CommandLineArgument( name = OUTDIR )
   private String outdir;
-  @CommandLineArgument(name = "package-name")
+  @CommandLineArgument( name = "package-name" )
   private String packageName;
-  @CommandLineArgument(name = "map-column-java")
+  @CommandLineArgument( name = "map-column-java" )
   private String mapColumnJava;
 
   // Shared Input/Export options
-  @CommandLineArgument(name = TABLE)
+  @CommandLineArgument( name = TABLE )
   private String table;
-  @CommandLineArgument(name = "num-mappers")
+  @CommandLineArgument( name = "num-mappers" )
   private String numMappers;
   private String commandLine;
 
   /**
    * @return all known arguments for this config object. Some arguments may be synthetic and represent properties
-   *         directly set on this config object for the purpose of showing them in the list view of the UI.
+   * directly set on this config object for the purpose of showing them in the list view of the UI.
    */
   public AbstractModelList<ArgumentWrapper> getAdvancedArgumentsList() {
     final AbstractModelList<ArgumentWrapper> items = new AbstractModelList<ArgumentWrapper>();
 
-    items.addAll(SqoopUtils.findAllArguments(this));
+    items.addAll( SqoopUtils.findAllArguments( this ) );
 
     try {
-      items.add(new ArgumentWrapper(NAMENODE_HOST, BaseMessages.getString(getClass(), "NamenodeHost.Label"), false, this,
-        getClass().getMethod("getNamenodeHost"), getClass().getMethod("setNamenodeHost", String.class)));
-      items.add(new ArgumentWrapper(NAMENODE_PORT, BaseMessages.getString(getClass(), "NamenodePort.Label"), false, this,
-        getClass().getMethod("getNamenodePort"), getClass().getMethod("setNamenodePort", String.class)));
-      items.add(new ArgumentWrapper(JOBTRACKER_HOST, BaseMessages.getString(getClass(), "JobtrackerHost.Label"), false, this,
-        getClass().getMethod("getJobtrackerHost"), getClass().getMethod("setJobtrackerHost", String.class)));
-      items.add(new ArgumentWrapper(JOBTRACKER_PORT, BaseMessages.getString(getClass(), "JobtrackerPort.Label"), false, this,
-        getClass().getMethod("getJobtrackerPort"), getClass().getMethod("setJobtrackerPort", String.class)));
-      items.add(new ArgumentWrapper(BLOCKING_EXECUTION, BaseMessages.getString(getClass(), "BlockingExecution.Label"), false, this,
-        getClass().getMethod("getBlockingExecution"), getClass().getMethod("setBlockingExecution", String.class)));
-      items.add(new ArgumentWrapper(BLOCKING_POLLING_INTERVAL, BaseMessages.getString(getClass(), "BlockingPollingInterval.Label"), false, this,
-        getClass().getMethod("getBlockingPollingInterval"), getClass().getMethod("setBlockingPollingInterval", String.class)));
-    } catch (NoSuchMethodException ex) {
-      throw new RuntimeException(ex);
+      items.add(
+        new ArgumentWrapper( NAMENODE_HOST, BaseMessages.getString( getClass(), "NamenodeHost.Label" ), false, this,
+          getClass().getMethod( "getNamenodeHost" ), getClass().getMethod( "setNamenodeHost", String.class ) ) );
+      items.add(
+        new ArgumentWrapper( NAMENODE_PORT, BaseMessages.getString( getClass(), "NamenodePort.Label" ), false, this,
+          getClass().getMethod( "getNamenodePort" ), getClass().getMethod( "setNamenodePort", String.class ) ) );
+      items.add(
+        new ArgumentWrapper( JOBTRACKER_HOST, BaseMessages.getString( getClass(), "JobtrackerHost.Label" ), false, this,
+          getClass().getMethod( "getJobtrackerHost" ), getClass().getMethod( "setJobtrackerHost", String.class ) ) );
+      items.add(
+        new ArgumentWrapper( JOBTRACKER_PORT, BaseMessages.getString( getClass(), "JobtrackerPort.Label" ), false, this,
+          getClass().getMethod( "getJobtrackerPort" ), getClass().getMethod( "setJobtrackerPort", String.class ) ) );
+      items.add(
+        new ArgumentWrapper( BLOCKING_EXECUTION, BaseMessages.getString( getClass(), "BlockingExecution.Label" ), false,
+          this,
+          getClass().getMethod( "getBlockingExecution" ),
+          getClass().getMethod( "setBlockingExecution", String.class ) ) );
+      items.add( new ArgumentWrapper( BLOCKING_POLLING_INTERVAL,
+        BaseMessages.getString( getClass(), "BlockingPollingInterval.Label" ), false, this,
+        getClass().getMethod( "getBlockingPollingInterval" ),
+        getClass().getMethod( "setBlockingPollingInterval", String.class ) ) );
+    } catch ( NoSuchMethodException ex ) {
+      throw new RuntimeException( ex );
     }
 
     return items;
@@ -199,11 +208,11 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
    * Silently set the following properties: {@code database, connect, username, password}.
    *
    * @param database Database name
-   * @param connect Connection string (JDBC connection URL)
+   * @param connect  Connection string (JDBC connection URL)
    * @param username Username
    * @param password Password
    */
-  public void setConnectionInfo(String database, String connect, String username, String password) {
+  public void setConnectionInfo( String database, String connect, String username, String password ) {
     this.database = database;
     this.connect = connect;
     this.username = username;
@@ -221,13 +230,13 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
   }
 
   /**
-   * Copy the current connection information into the "advanced" fields. These are temporary session properties
-   * used to aid the user during configuration via UI.
+   * Copy the current connection information into the "advanced" fields. These are temporary session properties used to
+   * aid the user during configuration via UI.
    */
   public void copyConnectionInfoToAdvanced() {
-    setConnectFromAdvanced(getConnect());
-    setUsernameFromAdvanced(getUsername());
-    setPasswordFromAdvanced(getPassword());
+    setConnectFromAdvanced( getConnect() );
+    setUsernameFromAdvanced( getUsername() );
+    setPasswordFromAdvanced( getPassword() );
   }
 
   // All getters/setters below this line
@@ -236,97 +245,97 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
     return namenodeHost;
   }
 
-  public void setNamenodeHost(String namenodeHost) {
+  public void setNamenodeHost( String namenodeHost ) {
     String old = this.namenodeHost;
     this.namenodeHost = namenodeHost;
-    pcs.firePropertyChange(NAMENODE_HOST, old, this.namenodeHost);
+    pcs.firePropertyChange( NAMENODE_HOST, old, this.namenodeHost );
   }
 
   public String getNamenodePort() {
     return namenodePort;
   }
 
-  public void setNamenodePort(String namenodePort) {
+  public void setNamenodePort( String namenodePort ) {
     String old = this.namenodePort;
     this.namenodePort = namenodePort;
-    pcs.firePropertyChange(NAMENODE_PORT, old, this.namenodePort);
+    pcs.firePropertyChange( NAMENODE_PORT, old, this.namenodePort );
   }
 
   public String getJobtrackerHost() {
     return jobtrackerHost;
   }
 
-  public void setJobtrackerHost(String jobtrackerHost) {
+  public void setJobtrackerHost( String jobtrackerHost ) {
     String old = this.jobtrackerHost;
     this.jobtrackerHost = jobtrackerHost;
-    pcs.firePropertyChange(JOBTRACKER_HOST, old, this.jobtrackerHost);
+    pcs.firePropertyChange( JOBTRACKER_HOST, old, this.jobtrackerHost );
   }
 
   public String getJobtrackerPort() {
     return jobtrackerPort;
   }
 
-  public void setJobtrackerPort(String jobtrackerPort) {
+  public void setJobtrackerPort( String jobtrackerPort ) {
     String old = this.jobtrackerPort;
     this.jobtrackerPort = jobtrackerPort;
-    pcs.firePropertyChange(JOBTRACKER_PORT, old, this.jobtrackerPort);
+    pcs.firePropertyChange( JOBTRACKER_PORT, old, this.jobtrackerPort );
   }
 
   public String getDatabase() {
     return database;
   }
 
-  public void setDatabase(String database) {
+  public void setDatabase( String database ) {
     String old = this.database;
     this.database = database;
-    pcs.firePropertyChange(DATABASE, old, this.database);
+    pcs.firePropertyChange( DATABASE, old, this.database );
   }
 
   public String getSchema() {
     return schema;
   }
 
-  public void setSchema(String schema) {
+  public void setSchema( String schema ) {
     String old = this.schema;
     this.schema = schema;
-    pcs.firePropertyChange(SCHEMA, old, this.schema);
+    pcs.firePropertyChange( SCHEMA, old, this.schema );
   }
 
   public String getConnect() {
     return connect;
   }
 
-  public void setConnect(String connect) {
+  public void setConnect( String connect ) {
     String old = this.connect;
     this.connect = connect;
-    pcs.firePropertyChange(CONNECT, old, this.connect);
+    pcs.firePropertyChange( CONNECT, old, this.connect );
   }
 
   public String getUsername() {
     return username;
   }
 
-  public void setUsername(String username) {
+  public void setUsername( String username ) {
     String old = this.username;
     this.username = username;
-    pcs.firePropertyChange(USERNAME, old, this.username);
+    pcs.firePropertyChange( USERNAME, old, this.username );
   }
 
   public String getPassword() {
     return password;
   }
 
-  public void setPassword(String password) {
+  public void setPassword( String password ) {
     String old = this.password;
     this.password = password;
-    pcs.firePropertyChange(PASSWORD, old, this.password);
+    pcs.firePropertyChange( PASSWORD, old, this.password );
   }
 
   public String getConnectFromAdvanced() {
     return connectFromAdvanced;
   }
 
-  public void setConnectFromAdvanced(String connectFromAdvanced) {
+  public void setConnectFromAdvanced( String connectFromAdvanced ) {
     this.connectFromAdvanced = connectFromAdvanced;
   }
 
@@ -334,7 +343,7 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
     return usernameFromAdvanced;
   }
 
-  public void setUsernameFromAdvanced(String usernameFromAdvanced) {
+  public void setUsernameFromAdvanced( String usernameFromAdvanced ) {
     this.usernameFromAdvanced = usernameFromAdvanced;
   }
 
@@ -342,7 +351,7 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
     return passwordFromAdvanced;
   }
 
-  public void setPasswordFromAdvanced(String passwordFromAdvanced) {
+  public void setPasswordFromAdvanced( String passwordFromAdvanced ) {
     this.passwordFromAdvanced = passwordFromAdvanced;
   }
 
@@ -350,250 +359,250 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
     return connectionManager;
   }
 
-  public void setConnectionManager(String connectionManager) {
+  public void setConnectionManager( String connectionManager ) {
     String old = this.connectionManager;
     this.connectionManager = connectionManager;
-    pcs.firePropertyChange(CONNECTION_MANAGER, old, this.connectionManager);
+    pcs.firePropertyChange( CONNECTION_MANAGER, old, this.connectionManager );
   }
 
   public String getDriver() {
     return driver;
   }
 
-  public void setDriver(String driver) {
+  public void setDriver( String driver ) {
     String old = this.driver;
     this.driver = driver;
-    pcs.firePropertyChange(DRIVER, old, this.driver);
+    pcs.firePropertyChange( DRIVER, old, this.driver );
   }
 
   public String getVerbose() {
     return verbose;
   }
 
-  public void setVerbose(String verbose) {
+  public void setVerbose( String verbose ) {
     String old = this.verbose;
     this.verbose = verbose;
-    pcs.firePropertyChange(VERBOSE, old, this.verbose);
+    pcs.firePropertyChange( VERBOSE, old, this.verbose );
   }
 
   public String getConnectionParamFile() {
     return connectionParamFile;
   }
 
-  public void setConnectionParamFile(String connectionParamFile) {
+  public void setConnectionParamFile( String connectionParamFile ) {
     String old = this.connectionParamFile;
     this.connectionParamFile = connectionParamFile;
-    pcs.firePropertyChange(CONNECTION_PARAM_FILE, old, this.connectionParamFile);
+    pcs.firePropertyChange( CONNECTION_PARAM_FILE, old, this.connectionParamFile );
   }
 
   public String getHadoopHome() {
     return hadoopHome;
   }
 
-  public void setHadoopHome(String hadoopHome) {
+  public void setHadoopHome( String hadoopHome ) {
     String old = this.hadoopHome;
     this.hadoopHome = hadoopHome;
-    pcs.firePropertyChange(HADOOP_HOME, old, this.hadoopHome);
+    pcs.firePropertyChange( HADOOP_HOME, old, this.hadoopHome );
   }
 
   public String getEnclosedBy() {
     return enclosedBy;
   }
 
-  public void setEnclosedBy(String enclosedBy) {
+  public void setEnclosedBy( String enclosedBy ) {
     String old = this.enclosedBy;
     this.enclosedBy = enclosedBy;
-    pcs.firePropertyChange(ENCLOSED_BY, old, this.enclosedBy);
+    pcs.firePropertyChange( ENCLOSED_BY, old, this.enclosedBy );
   }
 
   public String getEscapedBy() {
     return escapedBy;
   }
 
-  public void setEscapedBy(String escapedBy) {
+  public void setEscapedBy( String escapedBy ) {
     String old = this.escapedBy;
     this.escapedBy = escapedBy;
-    pcs.firePropertyChange(ESCAPED_BY, old, this.escapedBy);
+    pcs.firePropertyChange( ESCAPED_BY, old, this.escapedBy );
   }
 
   public String getFieldsTerminatedBy() {
     return fieldsTerminatedBy;
   }
 
-  public void setFieldsTerminatedBy(String fieldsTerminatedBy) {
+  public void setFieldsTerminatedBy( String fieldsTerminatedBy ) {
     String old = this.fieldsTerminatedBy;
     this.fieldsTerminatedBy = fieldsTerminatedBy;
-    pcs.firePropertyChange(FIELDS_TERMINATED_BY, old, this.fieldsTerminatedBy);
+    pcs.firePropertyChange( FIELDS_TERMINATED_BY, old, this.fieldsTerminatedBy );
   }
 
   public String getLinesTerminatedBy() {
     return linesTerminatedBy;
   }
 
-  public void setLinesTerminatedBy(String linesTerminatedBy) {
+  public void setLinesTerminatedBy( String linesTerminatedBy ) {
     String old = this.linesTerminatedBy;
     this.linesTerminatedBy = linesTerminatedBy;
-    pcs.firePropertyChange(LINES_TERMINATED_BY, old, this.linesTerminatedBy);
+    pcs.firePropertyChange( LINES_TERMINATED_BY, old, this.linesTerminatedBy );
   }
 
   public String getOptionallyEnclosedBy() {
     return optionallyEnclosedBy;
   }
 
-  public void setOptionallyEnclosedBy(String optionallyEnclosedBy) {
+  public void setOptionallyEnclosedBy( String optionallyEnclosedBy ) {
     String old = this.optionallyEnclosedBy;
     this.optionallyEnclosedBy = optionallyEnclosedBy;
-    pcs.firePropertyChange(OPTIONALLY_ENCLOSED_BY, old, this.optionallyEnclosedBy);
+    pcs.firePropertyChange( OPTIONALLY_ENCLOSED_BY, old, this.optionallyEnclosedBy );
   }
 
   public String getMysqlDelimiters() {
     return mysqlDelimiters;
   }
 
-  public void setMysqlDelimiters(String mysqlDelimiters) {
+  public void setMysqlDelimiters( String mysqlDelimiters ) {
     String old = this.mysqlDelimiters;
     this.mysqlDelimiters = mysqlDelimiters;
-    pcs.firePropertyChange(MYSQL_DELIMITERS, old, this.mysqlDelimiters);
+    pcs.firePropertyChange( MYSQL_DELIMITERS, old, this.mysqlDelimiters );
   }
 
   public String getInputEnclosedBy() {
     return inputEnclosedBy;
   }
 
-  public void setInputEnclosedBy(String inputEnclosedBy) {
+  public void setInputEnclosedBy( String inputEnclosedBy ) {
     String old = this.inputEnclosedBy;
     this.inputEnclosedBy = inputEnclosedBy;
-    pcs.firePropertyChange(INPUT_ENCLOSED_BY, old, this.inputEnclosedBy);
+    pcs.firePropertyChange( INPUT_ENCLOSED_BY, old, this.inputEnclosedBy );
   }
 
   public String getInputEscapedBy() {
     return inputEscapedBy;
   }
 
-  public void setInputEscapedBy(String inputEscapedBy) {
+  public void setInputEscapedBy( String inputEscapedBy ) {
     String old = this.inputEscapedBy;
     this.inputEscapedBy = inputEscapedBy;
-    pcs.firePropertyChange(INPUT_ESCAPED_BY, old, this.inputEscapedBy);
+    pcs.firePropertyChange( INPUT_ESCAPED_BY, old, this.inputEscapedBy );
   }
 
   public String getInputFieldsTerminatedBy() {
     return inputFieldsTerminatedBy;
   }
 
-  public void setInputFieldsTerminatedBy(String inputFieldsTerminatedBy) {
+  public void setInputFieldsTerminatedBy( String inputFieldsTerminatedBy ) {
     String old = this.inputFieldsTerminatedBy;
     this.inputFieldsTerminatedBy = inputFieldsTerminatedBy;
-    pcs.firePropertyChange(INPUT_FIELDS_TERMINATED_BY, old, this.inputFieldsTerminatedBy);
+    pcs.firePropertyChange( INPUT_FIELDS_TERMINATED_BY, old, this.inputFieldsTerminatedBy );
   }
 
   public String getInputLinesTerminatedBy() {
     return inputLinesTerminatedBy;
   }
 
-  public void setInputLinesTerminatedBy(String inputLinesTerminatedBy) {
+  public void setInputLinesTerminatedBy( String inputLinesTerminatedBy ) {
     String old = this.inputLinesTerminatedBy;
     this.inputLinesTerminatedBy = inputLinesTerminatedBy;
-    pcs.firePropertyChange(INPUT_LINES_TERMINATED_BY, old, this.inputLinesTerminatedBy);
+    pcs.firePropertyChange( INPUT_LINES_TERMINATED_BY, old, this.inputLinesTerminatedBy );
   }
 
   public String getInputOptionallyEnclosedBy() {
     return inputOptionallyEnclosedBy;
   }
 
-  public void setInputOptionallyEnclosedBy(String inputOptionallyEnclosedBy) {
+  public void setInputOptionallyEnclosedBy( String inputOptionallyEnclosedBy ) {
     String old = this.inputOptionallyEnclosedBy;
     this.inputOptionallyEnclosedBy = inputOptionallyEnclosedBy;
-    pcs.firePropertyChange(INPUT_OPTIONALLY_ENCLOSED_BY, old, this.inputOptionallyEnclosedBy);
+    pcs.firePropertyChange( INPUT_OPTIONALLY_ENCLOSED_BY, old, this.inputOptionallyEnclosedBy );
   }
 
   public String getBinDir() {
     return binDir;
   }
 
-  public void setBinDir(String binDir) {
+  public void setBinDir( String binDir ) {
     String old = this.binDir;
     this.binDir = binDir;
-    pcs.firePropertyChange(BIN_DIR, old, this.binDir);
+    pcs.firePropertyChange( BIN_DIR, old, this.binDir );
   }
 
   public String getClassName() {
     return className;
   }
 
-  public void setClassName(String className) {
+  public void setClassName( String className ) {
     String old = this.className;
     this.className = className;
-    pcs.firePropertyChange(CLASS_NAME, old, this.className);
+    pcs.firePropertyChange( CLASS_NAME, old, this.className );
   }
 
   public String getJarFile() {
     return jarFile;
   }
 
-  public void setJarFile(String jarFile) {
+  public void setJarFile( String jarFile ) {
     String old = this.jarFile;
     this.jarFile = jarFile;
-    pcs.firePropertyChange(JAR_FILE, old, this.jarFile);
+    pcs.firePropertyChange( JAR_FILE, old, this.jarFile );
   }
 
   public String getOutdir() {
     return outdir;
   }
 
-  public void setOutdir(String outdir) {
+  public void setOutdir( String outdir ) {
     String old = this.outdir;
     this.outdir = outdir;
-    pcs.firePropertyChange(OUTDIR, old, this.outdir);
+    pcs.firePropertyChange( OUTDIR, old, this.outdir );
   }
 
   public String getPackageName() {
     return packageName;
   }
 
-  public void setPackageName(String packageName) {
+  public void setPackageName( String packageName ) {
     String old = this.packageName;
     this.packageName = packageName;
-    pcs.firePropertyChange(PACKAGE_NAME, old, this.packageName);
+    pcs.firePropertyChange( PACKAGE_NAME, old, this.packageName );
   }
 
   public String getMapColumnJava() {
     return mapColumnJava;
   }
 
-  public void setMapColumnJava(String mapColumnJava) {
+  public void setMapColumnJava( String mapColumnJava ) {
     String old = this.mapColumnJava;
     this.mapColumnJava = mapColumnJava;
-    pcs.firePropertyChange(MAP_COLUMN_JAVA, old, this.mapColumnJava);
+    pcs.firePropertyChange( MAP_COLUMN_JAVA, old, this.mapColumnJava );
   }
 
   public String getTable() {
     return table;
   }
 
-  public void setTable(String table) {
+  public void setTable( String table ) {
     String old = this.table;
     this.table = table;
-    pcs.firePropertyChange(TABLE, old, this.table);
+    pcs.firePropertyChange( TABLE, old, this.table );
   }
 
   public String getNumMappers() {
     return numMappers;
   }
 
-  public void setNumMappers(String numMappers) {
+  public void setNumMappers( String numMappers ) {
     String old = this.numMappers;
     this.numMappers = numMappers;
-    pcs.firePropertyChange(NUM_MAPPERS, old, this.numMappers);
+    pcs.firePropertyChange( NUM_MAPPERS, old, this.numMappers );
   }
 
   public String getCommandLine() {
     return commandLine;
   }
 
-  public void setCommandLine(String commandLine) {
+  public void setCommandLine( String commandLine ) {
     String old = this.commandLine;
     this.commandLine = commandLine;
-    pcs.firePropertyChange(COMMAND_LINE, old, this.commandLine);
+    pcs.firePropertyChange( COMMAND_LINE, old, this.commandLine );
   }
 
   public String getMode() {
@@ -602,8 +611,8 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
 
   public JobEntryMode getModeAsEnum() {
     try {
-      return JobEntryMode.valueOf(getMode());
-    } catch (Exception ex) {
+      return JobEntryMode.valueOf( getMode() );
+    } catch ( Exception ex ) {
       // Not a valid ui mode, return the default
       return JobEntryMode.QUICK_SETUP;
     }
@@ -611,15 +620,16 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
 
   /**
    * Sets the mode based on the enum value
+   *
    * @param mode
    */
-  public void setMode(JobEntryMode mode) {
-    setMode(mode.name());
+  public void setMode( JobEntryMode mode ) {
+    setMode( mode.name() );
   }
 
-  public void setMode(String mode) {
+  public void setMode( String mode ) {
     String old = this.mode;
     this.mode = mode;
-    pcs.firePropertyChange(MODE, old, this.mode);
+    pcs.firePropertyChange( MODE, old, this.mode );
   }
 }

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
@@ -1,24 +1,24 @@
 /*******************************************************************************
-*
-* Pentaho Big Data
-*
-* Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
-*
-*******************************************************************************
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License. You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-******************************************************************************/
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
 
 package org.pentaho.di.job.entries.sqoop;
 
@@ -58,16 +58,16 @@ public class SqoopUtils {
   // Properties used to escape/unescape strings for command line string (de)serialization
   private static final String WHITESPACE = " ";
   private static final String QUOTE = "\"";
-  private static final Pattern WHITESPACE_PATTERN = Pattern.compile(" ");
-  private static final Pattern QUOTE_PATTERN = Pattern.compile("\"");
-  private static final Pattern BACKSLASH_PATTERN = Pattern.compile("\\\\");
+  private static final Pattern WHITESPACE_PATTERN = Pattern.compile( " " );
+  private static final Pattern QUOTE_PATTERN = Pattern.compile( "\"" );
+  private static final Pattern BACKSLASH_PATTERN = Pattern.compile( "\\\\" );
   // Simple map of Patterns that match an escape sequence and a replacement string to replace them with to escape them
   private static final Object[][] ESCAPE_SEQUENCES = new Object[][] {
-      new Object[] { Pattern.compile("\t"), "\\\\t" },
-      new Object[] { Pattern.compile("\b"), "\\\\b" },
-      new Object[] { Pattern.compile("\n"), "\\\\n" },
-      new Object[] { Pattern.compile("\r"), "\\\\r" },
-      new Object[] { Pattern.compile("\f"), "\\\\f" }
+    new Object[] { Pattern.compile( "\t" ), "\\\\t" },
+    new Object[] { Pattern.compile( "\b" ), "\\\\b" },
+    new Object[] { Pattern.compile( "\n" ), "\\\\n" },
+    new Object[] { Pattern.compile( "\r" ), "\\\\r" },
+    new Object[] { Pattern.compile( "\f" ), "\\\\f" }
   };
 
   /**
@@ -77,23 +77,23 @@ public class SqoopUtils {
    * @param config Sqoop configuration to update
    * @param c      Hadoop configuration to parse connection information from
    */
-  public static void configureConnectionInformation(SqoopConfig config, HadoopShim shim, Configuration c) {
-    String[] namenodeInfo = shim.getNamenodeConnectionInfo(c);
-    if (namenodeInfo != null) {
-      if (namenodeInfo[0] != null) {
-        config.setNamenodeHost(namenodeInfo[0]);
+  public static void configureConnectionInformation( SqoopConfig config, HadoopShim shim, Configuration c ) {
+    String[] namenodeInfo = shim.getNamenodeConnectionInfo( c );
+    if ( namenodeInfo != null ) {
+      if ( namenodeInfo[ 0 ] != null ) {
+        config.setNamenodeHost( namenodeInfo[ 0 ] );
       }
-      if (!"-1".equals(namenodeInfo[1])) {
-        config.setNamenodePort(namenodeInfo[1]);
+      if ( !"-1".equals( namenodeInfo[ 1 ] ) ) {
+        config.setNamenodePort( namenodeInfo[ 1 ] );
       }
     }
-    String[] jobtrackerInfo = shim.getJobtrackerConnectionInfo(c);
-    if (jobtrackerInfo != null) {
-      if (jobtrackerInfo[0] != null) {
-        config.setJobtrackerHost(jobtrackerInfo[0]);
+    String[] jobtrackerInfo = shim.getJobtrackerConnectionInfo( c );
+    if ( jobtrackerInfo != null ) {
+      if ( jobtrackerInfo[ 0 ] != null ) {
+        config.setJobtrackerHost( jobtrackerInfo[ 0 ] );
       }
-      if (jobtrackerInfo[1] != null) {
-        config.setJobtrackerPort(jobtrackerInfo[1]);
+      if ( jobtrackerInfo[ 1 ] != null ) {
+        config.setJobtrackerPort( jobtrackerInfo[ 1 ] );
       }
     }
   }
@@ -101,54 +101,59 @@ public class SqoopUtils {
   /**
    * Parse a string into arguments as if it were provided on the command line.
    *
-   * @param commandLineString A command line string, e.g. "sqoop import --table test --connect jdbc:mysql://bogus/bogus"
-   * @param variableSpace Context for resolving variable names. If {@code null}, no variable resolution we happen.
-   * @param ignoreSqoopCommand If set, the first "sqoop <tool>" arguments will be ignored, e.g. "sqoop import" or "sqoop export".
+   * @param commandLineString  A command line string, e.g. "sqoop import --table test --connect
+   *                           jdbc:mysql://bogus/bogus"
+   * @param variableSpace      Context for resolving variable names. If {@code null}, no variable resolution we happen.
+   * @param ignoreSqoopCommand If set, the first "sqoop <tool>" arguments will be ignored, e.g. "sqoop import" or "sqoop
+   *                           export".
    * @return List of parsed arguments
    * @throws IOException when the command line could not be parsed
    */
-  public static List<String> parseCommandLine(String commandLineString, VariableSpace variableSpace, boolean ignoreSqoopCommand) throws IOException {
+  public static List<String> parseCommandLine( String commandLineString, VariableSpace variableSpace,
+                                               boolean ignoreSqoopCommand ) throws IOException {
     List<String> args = new ArrayList<String>();
-    StringReader reader = new StringReader(commandLineString);
+    StringReader reader = new StringReader( commandLineString );
     try {
-      StreamTokenizer tokenizer = new StreamTokenizer(reader);
+      StreamTokenizer tokenizer = new StreamTokenizer( reader );
       // Treat a dash as an ordinary character so it gets included in the token
-      tokenizer.ordinaryChar('-');
-      tokenizer.ordinaryChar('.');
-      tokenizer.ordinaryChars('0', '9');
+      tokenizer.ordinaryChar( '-' );
+      tokenizer.ordinaryChar( '.' );
+      tokenizer.ordinaryChars( '0', '9' );
       // Treat all characters as word characters so nothing is parsed out
-      tokenizer.wordChars('\u0000','\uFFFF');
+      tokenizer.wordChars( '\u0000', '\uFFFF' );
 
       // Re-add whitespace characters
-      tokenizer.whitespaceChars(0, ' ');
+      tokenizer.whitespaceChars( 0, ' ' );
 
       // Use " and ' as quote characters
-      tokenizer.quoteChar('"');
-      tokenizer.quoteChar('\'');
+      tokenizer.quoteChar( '"' );
+      tokenizer.quoteChar( '\'' );
 
-      // Flag to indicate if the next token needs to be skipped (used to control skipping of the first two arguments, e.g. "sqoop <tool>")
+      // Flag to indicate if the next token needs to be skipped (used to control skipping of the first two arguments,
+      // e.g. "sqoop <tool>")
       boolean skipToken = false;
       // Add all non-null string values tokenized from the string to the argument list
-      while (tokenizer.nextToken() != StreamTokenizer.TT_EOF) {
-        if (tokenizer.sval != null) {
+      while ( tokenizer.nextToken() != StreamTokenizer.TT_EOF ) {
+        if ( tokenizer.sval != null ) {
           String s = tokenizer.sval;
-          if (variableSpace != null) {
-            s = variableSpace.environmentSubstitute(s);
+          if ( variableSpace != null ) {
+            s = variableSpace.environmentSubstitute( s );
           }
-          if (ignoreSqoopCommand && args.isEmpty()) {
-            // If we encounter "sqoop <name>" we should skip the first two arguments so we can support copy/paste of arguments directly
+          if ( ignoreSqoopCommand && args.isEmpty() ) {
+            // If we encounter "sqoop <name>" we should skip the first two arguments so we can support copy/paste of
+            // arguments directly
             // from a working command line
-            if ("sqoop".equals(s)) {
+            if ( "sqoop".equals( s ) ) {
               skipToken = true;
               continue; // skip this one and the next
-            } else if (skipToken) {
+            } else if ( skipToken ) {
               ignoreSqoopCommand = false; // Don't attempt to ignore any more commands
               // Skip this token too, reset the flag so we no longer skip any tokens, and continue parsing
               skipToken = false;
               continue;
             }
           }
-          args.add(escapeEscapeSequences(s));
+          args.add( escapeEscapeSequences( s ) );
         }
       }
     } finally {
@@ -158,51 +163,52 @@ public class SqoopUtils {
   }
 
   /**
-   * Configure a {@link SqoopConfig} object from a command line string. Variables will be replaced if {@code variableSpace}
-   * is provided.
+   * Configure a {@link SqoopConfig} object from a command line string. Variables will be replaced if {@code
+   * variableSpace} is provided.
    *
-   * @param config Configuration to update
-   * @param commandLineString Command line string to parse and update config with (string will be parsed via {@link #parseCommandLine(String, org.pentaho.di.core.variables.VariableSpace, boolean)})
-   * @param variableSpace Context for variable substitution
-   *
-   * @throws IOException error parsing command line string
+   * @param config            Configuration to update
+   * @param commandLineString Command line string to parse and update config with (string will be parsed via {@link
+   *                          #parseCommandLine(String, org.pentaho.di.core.variables.VariableSpace, boolean)})
+   * @param variableSpace     Context for variable substitution
+   * @throws IOException     error parsing command line string
    * @throws KettleException Error setting properties from parsed command line arguments
    */
-  public static void configureFromCommandLine(SqoopConfig config, String commandLineString, VariableSpace variableSpace) throws IOException, KettleException {
-    List<String> args = parseCommandLine(commandLineString, variableSpace, true);
+  public static void configureFromCommandLine( SqoopConfig config, String commandLineString,
+                                               VariableSpace variableSpace ) throws IOException, KettleException {
+    List<String> args = parseCommandLine( commandLineString, variableSpace, true );
 
     Map<String, String> argValues = new HashMap<String, String>();
     int i = 0;
     int peekAhead = i;
-    while (i < args.size()) {
-      String arg = args.get(i);
-      if (isArgName(arg)) {
-        arg = arg.substring(ARG_PREFIX.length());
+    while ( i < args.size() ) {
+      String arg = args.get( i );
+      if ( isArgName( arg ) ) {
+        arg = arg.substring( ARG_PREFIX.length() );
       }
 
       String value = null;
       peekAhead = i + 1;
-      if (peekAhead < args.size()) {
-        value = args.get(peekAhead);
+      if ( peekAhead < args.size() ) {
+        value = args.get( peekAhead );
       }
 
-      if (isArgName(value)) {
-        // Current arg is a boolean flag, set value to Boolean.TRUE
-        value = Boolean.TRUE.toString();
+      if ( isArgName( value ) ) {
+        // Current arg is possibly a boolean flag, set value to null now
+        value = null;
         // We're only consuming one element
         i += 1;
       } else {
         // value is a real value, make sure to substitute variables if we can
-        if (variableSpace != null) {
-          value = variableSpace.environmentSubstitute(value);
+        if ( variableSpace != null ) {
+          value = variableSpace.environmentSubstitute( value );
         }
         i += 2;
       }
 
-      argValues.put(arg, value);
+      argValues.put( arg, value );
     }
 
-    setArgumentStringValues(config, argValues);
+    setArgumentStringValues( config, argValues );
   }
 
   /**
@@ -211,33 +217,35 @@ public class SqoopUtils {
    * @param s Possible argument name
    * @return {@code true} if the string represents an argument name (is prefixed with ARG_PREFIX)
    */
-  private static boolean isArgName(String s) {
-    return s != null && s.startsWith(ARG_PREFIX) && s.length() > ARG_PREFIX.length();
+  private static boolean isArgName( String s ) {
+    return s != null && s.startsWith( ARG_PREFIX ) && s.length() > ARG_PREFIX.length();
   }
 
   /**
-   * Updates arguments of {@code config} based on the map of argument values. All other arguments will be cleared from {@code config}.
+   * Updates arguments of {@code config} based on the map of argument values. All other arguments will be cleared from
+   * {@code config}.
    *
    * @param config Configuration object to update
-   * @param args Argument name and value pairs
-   * @throws KettleException when we cannot set the value of the argument either because it doesn't exist or any other reason
+   * @param args   Argument name and value pairs
+   * @throws KettleException when we cannot set the value of the argument either because it doesn't exist or any other
+   *                         reason
    */
-  protected static void setArgumentStringValues(SqoopConfig config, Map<String, String> args) throws KettleException {
+  protected static void setArgumentStringValues( SqoopConfig config, Map<String, String> args ) throws KettleException {
     Class<?> aClass = config.getClass();
 
-    while(aClass != null) {
-      for(Field field : aClass.getDeclaredFields()) {
-        if (field.isAnnotationPresent(CommandLineArgument.class)) {
-          CommandLineArgument arg = field.getAnnotation(CommandLineArgument.class);
-          // Set the value to null unless we have a different value in our map of argument values
-          // Remove the value from the map to indicate it has been processed
-          String value = args.remove(arg.name());
+    while ( aClass != null ) {
+      for ( Field field : aClass.getDeclaredFields() ) {
+        if ( field.isAnnotationPresent( CommandLineArgument.class ) ) {
+          CommandLineArgument arg = field.getAnnotation( CommandLineArgument.class );
+
+          String value = pickupArgumentValueFor( arg, args );
+
           try {
-            String fieldName = field.getName().substring(0, 1).toUpperCase() + field.getName().substring(1);
-            Method setter = findMethod(config.getClass(), fieldName, new Class [] { String.class }, "set");
-            setter.invoke(config, value);
-          } catch (Exception ex) {
-            throw new KettleException("Cannot set value of argument \"" +  arg.name() + "\" to \"" + value + "\"", ex);
+            String fieldName = field.getName().substring( 0, 1 ).toUpperCase() + field.getName().substring( 1 );
+            Method setter = findMethod( config.getClass(), fieldName, new Class[] { String.class }, "set" );
+            setter.invoke( config, value );
+          } catch ( Exception ex ) {
+            throw new KettleException( "Cannot set value of argument \"" + arg.name() + "\" to \"" + value + "\"", ex );
           }
         }
       }
@@ -245,17 +253,41 @@ public class SqoopUtils {
     }
 
     // If any arguments weren't handled report them as errors
-    if (!args.isEmpty()) {
+    if ( !args.isEmpty() ) {
       StringBuilder sb = new StringBuilder();
       Iterator<String> i = args.keySet().iterator();
-      while (i.hasNext()) {
-        sb.append(i.next());
-        if (i.hasNext()) {
-          sb.append(", ");
+      while ( i.hasNext() ) {
+        sb.append( i.next() );
+        if ( i.hasNext() ) {
+          sb.append( ", " );
         }
       }
-      throw new KettleException(BaseMessages.getString(AbstractSqoopJobEntry.class, "ErrorUnknownArguments", sb));
+      throw new KettleException( BaseMessages.getString( AbstractSqoopJobEntry.class, "ErrorUnknownArguments", sb ) );
     }
+  }
+
+  private static String pickupArgumentValueFor( CommandLineArgument arg, Map<String, String> args )
+    throws KettleException {
+    String argumentName = arg.name();
+    if ( args.containsKey( argumentName ) ) {
+
+      // Remove the value from the map to indicate it has been processed
+      String value = args.remove( argumentName );
+
+      if ( arg.flag() ) {
+        return Boolean.TRUE.toString();
+      }
+
+      if ( StringUtil.isEmpty( value ) ) {
+        throw new KettleException(
+          BaseMessages.getString( AbstractSqoopJobEntry.class, "ErrorProhibitedEmptyString", argumentName )
+        );
+      }
+
+      return value;
+    }
+
+    return null;
   }
 
   /**
@@ -264,51 +296,53 @@ public class SqoopUtils {
    * @param config        Sqoop configuration to build a list of command line arguments from
    * @param variableSpace Variable space to look up argument values from. May be {@code null}
    * @return All the command line arguments for this configuration object
-   *
-   * @throws IOException when config mode is {@link org.pentaho.di.job.JobEntryMode#ADVANCED_COMMAND_LINE} and the command line could not be parsed
+   * @throws IOException when config mode is {@link org.pentaho.di.job.JobEntryMode#ADVANCED_COMMAND_LINE} and the
+   *                     command line could not be parsed
    */
-  public static List<String> getCommandLineArgs(SqoopConfig config, VariableSpace variableSpace) throws IOException {
+  public static List<String> getCommandLineArgs( SqoopConfig config, VariableSpace variableSpace ) throws IOException {
     List<String> args = new ArrayList<String>();
 
-    if (JobEntryMode.ADVANCED_COMMAND_LINE.equals(config.getModeAsEnum())) {
-      return parseCommandLine(config.getCommandLine(), variableSpace, true);
+    if ( JobEntryMode.ADVANCED_COMMAND_LINE.equals( config.getModeAsEnum() ) ) {
+      return parseCommandLine( config.getCommandLine(), variableSpace, true );
     }
 
-    appendArguments(args, SqoopUtils.findAllArguments(config), variableSpace);
+    appendArguments( args, SqoopUtils.findAllArguments( config ), variableSpace );
 
     return args;
   }
 
   /**
-   * Generate a command line string for the given configuration. Replace variables with the values from {@code variableSpace} if provided.
+   * Generate a command line string for the given configuration. Replace variables with the values from {@code
+   * variableSpace} if provided.
    *
-   * @param config Sqoop configuration
+   * @param config        Sqoop configuration
    * @param variableSpace Context for variable substitutions
-   * @return String-representation of the current configuration values. Variable tokens will be replaced if {@code variableSpace} is provided.
+   * @return String-representation of the current configuration values. Variable tokens will be replaced if {@code
+   * variableSpace} is provided.
    */
-  public static String generateCommandLineString(SqoopConfig config, VariableSpace variableSpace) {
+  public static String generateCommandLineString( SqoopConfig config, VariableSpace variableSpace ) {
     StringBuilder sb = new StringBuilder();
     List<List<String>> buffers = new ArrayList<List<String>>();
 
-    for (ArgumentWrapper arg : SqoopUtils.findAllArguments(config)) {
-      List<String> buffer = new ArrayList<String>(4);
-      appendArgument(buffer, arg, variableSpace);
-      if (!buffer.isEmpty()) {
-        buffers.add(buffer);
+    for ( ArgumentWrapper arg : SqoopUtils.findAllArguments( config ) ) {
+      List<String> buffer = new ArrayList<String>( 4 );
+      appendArgument( buffer, arg, variableSpace );
+      if ( !buffer.isEmpty() ) {
+        buffers.add( buffer );
       }
     }
 
     Iterator<List<String>> buffersIter = buffers.iterator();
-    while (buffersIter.hasNext()) {
+    while ( buffersIter.hasNext() ) {
       List<String> buffer = buffersIter.next();
-      sb.append(buffer.get(0));
-      if (buffer.size() == 2) {
-        sb.append(WHITESPACE);
+      sb.append( buffer.get( 0 ) );
+      if ( buffer.size() == 2 ) {
+        sb.append( WHITESPACE );
         // Escape value and add
-        sb.append(quote(buffer.get(1)));
+        sb.append( quote( buffer.get( 1 ) ) );
       }
-      if (buffersIter.hasNext()) {
-        sb.append(WHITESPACE);
+      if ( buffersIter.hasNext() ) {
+        sb.append( WHITESPACE );
       }
     }
 
@@ -316,14 +350,15 @@ public class SqoopUtils {
   }
 
   /**
-   * Escapes known Java escape sequences. See {@link #ESCAPE_SEQUENCES} for the list of escape sequences we escape here.
+   * Escapes known Java escape sequences. See {@link #ESCAPE_SEQUENCES} for the list of escape sequences we escape
+   * here.
    *
    * @param s String to escape
    * @return Escaped string where all escape sequences are properly escaped
    */
-  protected static String escapeEscapeSequences(String s) {
-    for (Object[] escapeSequence : ESCAPE_SEQUENCES) {
-      s = ((Pattern) escapeSequence[0]).matcher(s).replaceAll((String) escapeSequence[1]);
+  protected static String escapeEscapeSequences( String s ) {
+    for ( Object[] escapeSequence : ESCAPE_SEQUENCES ) {
+      s = ( (Pattern) escapeSequence[ 0 ] ).matcher( s ).replaceAll( (String) escapeSequence[ 1 ] );
     }
     return s;
   }
@@ -334,11 +369,11 @@ public class SqoopUtils {
    * @param s String to quote
    * @return A quoted version of {@code s} if whitespace exists in the string, otherwise unmodified {@code s}.
    */
-  protected static String quote(String s) {
+  protected static String quote( String s ) {
     final String orig = s;
-    s = QUOTE_PATTERN.matcher(s).replaceAll("\\\\\"");
+    s = QUOTE_PATTERN.matcher( s ).replaceAll( "\\\\\"" );
     // Make sure the string is quoted if it contains a quote character, whitespace or has a backslash
-    if (!orig.equals(s) || WHITESPACE_PATTERN.matcher(s).find() || BACKSLASH_PATTERN.matcher(s).find()) {
+    if ( !orig.equals( s ) || WHITESPACE_PATTERN.matcher( s ).find() || BACKSLASH_PATTERN.matcher( s ).find() ) {
       s = QUOTE + s + QUOTE;
     }
     return s;
@@ -351,9 +386,10 @@ public class SqoopUtils {
    * @param arguments     Arguments to append
    * @param variableSpace Variable space to look up argument values from. May be {@code null}.
    */
-  protected static void appendArguments(List<String> args, Set<? extends ArgumentWrapper> arguments, VariableSpace variableSpace) {
-    for (ArgumentWrapper ai : arguments) {
-      appendArgument(args, ai, variableSpace);
+  protected static void appendArguments( List<String> args, Set<? extends ArgumentWrapper> arguments,
+                                         VariableSpace variableSpace ) {
+    for ( ArgumentWrapper ai : arguments ) {
+      appendArgument( args, ai, variableSpace );
     }
   }
 
@@ -362,16 +398,18 @@ public class SqoopUtils {
    *
    * @param args List of arguments to append to
    */
-  protected static void appendArgument(List<String> args, ArgumentWrapper arg, VariableSpace variableSpace) {
+  protected static void appendArgument( List<String> args, ArgumentWrapper arg, VariableSpace variableSpace ) {
     String value = arg.getValue();
-    if (variableSpace != null) {
-      value = variableSpace.environmentSubstitute(value);
+    if ( variableSpace != null ) {
+      value = variableSpace.environmentSubstitute( value );
     }
-    if (arg.isFlag() && Boolean.parseBoolean(value)) {
-      args.add(ARG_PREFIX + arg.getName());
-    } else if (!arg.isFlag() && value != null) {
-      args.add(ARG_PREFIX + arg.getName());
-      args.add(value);
+    if ( arg.isFlag() && Boolean.parseBoolean( value ) ) {
+      args.add( ARG_PREFIX + arg.getName() );
+    } else if ( !arg.isFlag() && value != null ) {
+      if ( !StringUtil.isEmpty( value ) ) {
+        args.add( ARG_PREFIX + arg.getName() );
+        args.add( value );
+      }
     }
   }
 
@@ -382,18 +420,18 @@ public class SqoopUtils {
    * @param o Object to look for arguments in
    * @return Ordered set of arguments representing all {@link CommandLineArgument}-annotated fields in {@code o}
    */
-  public static Set<? extends ArgumentWrapper> findAllArguments(Object o) {
+  public static Set<? extends ArgumentWrapper> findAllArguments( Object o ) {
     Set<ArgumentWrapper> arguments = new LinkedHashSet<ArgumentWrapper>();
 
     Class<?> aClass = o.getClass();
-    while (aClass != null) {
-      for (Field f : aClass.getDeclaredFields()) {
-        if (f.isAnnotationPresent(CommandLineArgument.class)) {
-          CommandLineArgument anno = f.getAnnotation(CommandLineArgument.class);
-          String fieldName = f.getName().substring(0, 1).toUpperCase() + f.getName().substring(1);
-          Method getter = findMethod(aClass, fieldName, null, "get", "is");
-          Method setter = findMethod(aClass, fieldName, new Class<?>[]{f.getType()}, "set");
-          arguments.add(new ArgumentWrapper(anno.name(), getDisplayName(anno), anno.flag(), o, getter, setter));
+    while ( aClass != null ) {
+      for ( Field f : aClass.getDeclaredFields() ) {
+        if ( f.isAnnotationPresent( CommandLineArgument.class ) ) {
+          CommandLineArgument anno = f.getAnnotation( CommandLineArgument.class );
+          String fieldName = f.getName().substring( 0, 1 ).toUpperCase() + f.getName().substring( 1 );
+          Method getter = findMethod( aClass, fieldName, null, "get", "is" );
+          Method setter = findMethod( aClass, fieldName, new Class<?>[] { f.getType() }, "set" );
+          arguments.add( new ArgumentWrapper( anno.name(), getDisplayName( anno ), anno.flag(), o, getter, setter ) );
         }
       }
       aClass = aClass.getSuperclass();
@@ -406,14 +444,16 @@ public class SqoopUtils {
    * Determine the display name for the command line argument.
    *
    * @param anno Command line argument
-   * @return {@link org.pentaho.di.job.CommandLineArgument#displayName()} or, if not set, {@link org.pentaho.di.job.CommandLineArgument#name()}
+   * @return {@link org.pentaho.di.job.CommandLineArgument#displayName()} or, if not set, {@link
+   * org.pentaho.di.job.CommandLineArgument#name()}
    */
-  public static String getDisplayName(CommandLineArgument anno) {
-    return StringUtil.isEmpty(anno.displayName()) ? anno.name() : anno.displayName();
+  public static String getDisplayName( CommandLineArgument anno ) {
+    return StringUtil.isEmpty( anno.displayName() ) ? anno.name() : anno.displayName();
   }
 
   /**
-   * Finds a method in the given class or any super class with the name {@code prefix + methodName} that accepts 0 parameters.
+   * Finds a method in the given class or any super class with the name {@code prefix + methodName} that accepts 0
+   * parameters.
    *
    * @param aClass         Class to search for method in
    * @param methodName     Camelcase'd method name to search for with any of the provided prefixes
@@ -421,17 +461,17 @@ public class SqoopUtils {
    * @param prefixes       Prefixes to prepend to {@code methodName} when searching for method names, e.g. "get", "is"
    * @return The first method found to match the format {@code prefix + methodName}
    */
-  public static Method findMethod(Class<?> aClass, String methodName, Class<?>[] parameterTypes, String... prefixes) {
-    for (String prefix : prefixes) {
+  public static Method findMethod( Class<?> aClass, String methodName, Class<?>[] parameterTypes, String... prefixes ) {
+    for ( String prefix : prefixes ) {
       try {
-        return aClass.getDeclaredMethod(prefix + methodName, parameterTypes);
-      } catch (NoSuchMethodException ex) {
+        return aClass.getDeclaredMethod( prefix + methodName, parameterTypes );
+      } catch ( NoSuchMethodException ex ) {
         // ignore, continue searching prefixes
       }
     }
     // If no method found with any prefixes search the super class
     aClass = aClass.getSuperclass();
-    return aClass == null ? null : findMethod(aClass, methodName, parameterTypes, prefixes);
+    return aClass == null ? null : findMethod( aClass, methodName, parameterTypes, prefixes );
   }
 
 }

--- a/src/org/pentaho/di/job/entries/sqoop/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/job/entries/sqoop/messages/messages_en_US.properties
@@ -61,6 +61,7 @@ ErrorBrowsingDirectory=Error browsing for directory
 ErrorConfiguringFromCommandLine=Error configuring from command line. Please fix any errors to switch to another view.
 ErrorUnknownArguments=Unknown argument(s): {0}
 ErrorMustConfigureDatabaseConnectionFromList=Cannot perform this operation when the database connection information is provided via Advanced Options.
+ErrorProhibitedEmptyString="{0}" is not allowed to be initialized with an empty string.
 
 AvailableSchemas.Title=Available schemas
 AvailableSchemas.Message=Please select a schema name


### PR DESCRIPTION
@CommandLineArgument was enriched with new attribute that indicates whether the underlying property can be set to an empty string. The default value of the attribute is false (it prohibits empty-string values).
