### PR TITLE
[PDI-11049] PDI fails to connect to different Hive databases other that "default"

### DIFF
--- a/src/org/pentaho/di/core/database/HiveDatabaseMeta.java
+++ b/src/org/pentaho/di/core/database/HiveDatabaseMeta.java
@@ -24,10 +24,11 @@ package org.pentaho.di.core.database;
 
 import java.sql.Driver;
 
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.exception.KettleDatabaseException;
 import org.pentaho.di.core.plugins.DatabaseMetaPlugin;
 import org.pentaho.di.core.row.ValueMetaInterface;
+
+import static org.pentaho.di.core.Const.*;
 
 @DatabaseMetaPlugin( type = "HIVE", typeDescription = "Hadoop Hive" )
 public class HiveDatabaseMeta extends BaseDatabaseMeta implements DatabaseInterface {
@@ -154,7 +155,7 @@ public class HiveDatabaseMeta extends BaseDatabaseMeta implements DatabaseInterf
   @Override
   public String getURL( String hostname, String port, String databaseName ) throws KettleDatabaseException {
 
-    if ( Const.isEmpty( port ) ) {
+    if ( isEmpty( port ) ) {
       Integer.toString( getDefaultDatabasePort() );
     }
 
@@ -294,5 +295,33 @@ public class HiveDatabaseMeta extends BaseDatabaseMeta implements DatabaseInterf
   @Override
   public boolean supportsBatchUpdates() {
     return false;
+  }
+
+  private StringBuilder getConnectSqlForNotDefaultDatabaseName() {
+    StringBuilder sql = new StringBuilder( "use " );
+    sql.append( getDatabaseName() ).append( ';' ).append( ' ' );
+    return sql;
+  }
+
+  /**
+   * @return The SQL to execute right after connecting
+   */
+  @Override
+  public String getConnectSQL() {
+    StringBuilder sql = getConnectSqlForNotDefaultDatabaseName();
+    String superSql = super.getConnectSQL();
+    if ( !isEmpty( superSql ) ) {
+      return sql.append( superSql ).toString();
+    }
+    return sql.toString();
+  }
+
+  /**
+   * @param sql
+   *          The SQL to execute right after connecting
+   */
+  @Override
+  public void setConnectSQL( String sql ) {
+    super.setConnectSQL( sql.replaceAll( getConnectSqlForNotDefaultDatabaseName().toString(), "" ) );
   }
 }

--- a/test-src/org/pentaho/di/core/database/TestHiveDatabaseMeta.java
+++ b/test-src/org/pentaho/di/core/database/TestHiveDatabaseMeta.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Properties;
+
 public class TestHiveDatabaseMeta {
 
   @Before
@@ -59,5 +61,14 @@ public class TestHiveDatabaseMeta {
 
     alias = dbm.generateColumnAlias( 2, "alias2" );
     assertEquals( "_col2", alias );
+  }
+
+
+  @Test
+  public void testGetConnectSQL() throws Throwable {
+    HiveDatabaseMeta dbm = new HiveDatabaseMeta( 0, 5 );
+    dbm.setAttributes( new Properties() );
+    dbm.setDatabaseName( "default" );
+    assertEquals( dbm.getConnectSQL(), "use default; " );
   }
 }


### PR DESCRIPTION
Big data part (generate "use $database_name;" connect sql to enable using undefault schemas for hive 1)
related to https://github.com/pentaho/pentaho-kettle/pull/670
