### PR TITLE
[BACKLOG-115] Certify support for Kerberos for CDH 5.1

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -56,6 +56,9 @@
     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh50-package" rev="${project.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-cdh50-package" type="zip"/>
     </dependency>
+     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh51-package" rev="${project.revision}" changing="true">
+      <artifact name="pentaho-hadoop-shims-cdh51-package" type="zip"/>
+    </dependency>
     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-hdp21-package" rev="${project.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-hdp21-package" type="zip"/>
     </dependency>


### PR DESCRIPTION
Initial version of CDH51 shim.
Working: HDFS, Hive, Hadoop Job Executor, SqoopExport
Failing: HBase, PMR, SqoopImport, Pig, Oozie
Not testsd: Yarn Cluster
