### PR TITLE
[BACKLOG-331][CHECKSTYLE]: CLONE - Spoon Fails to start if the designated shim doesn't load properly

### DIFF
--- a/test-src/org/pentaho/di/core/hadoop/HadoopConfigurationBootstrapTest.java
+++ b/test-src/org/pentaho/di/core/hadoop/HadoopConfigurationBootstrapTest.java
@@ -340,7 +340,7 @@ public class HadoopConfigurationBootstrapTest {
           .getMessage() );
     }
   }
-  
+
   @Test
   public void testLifecycleExceptionWithSevereFalseThrows_WhenConfigurationExceptionOccursOnEnvInit() throws Exception {
     HadoopConfigurationBootstrap hadoopConfigurationBootstrap = new HadoopConfigurationBootstrap();
@@ -353,6 +353,6 @@ public class HadoopConfigurationBootstrapTest {
       assertFalse( lcExc.isSevere() );
     }
   }
-  
+
 
 }


### PR DESCRIPTION
Checkstyle fixes for unit test.
