### PR TITLE
[BACKLOG-644] - replace cloudera shims by newer versions in big-data-plugin distro

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -50,11 +50,8 @@
     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-hadoop-20-package" rev="${project.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-hadoop-20-package" type="zip"/>
     </dependency>
-    <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh42-package" rev="${project.revision}" changing="true">
-      <artifact name="pentaho-hadoop-shims-cdh42-package" type="zip"/>
-    </dependency>
-    <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh50-package" rev="${project.revision}" changing="true">
-      <artifact name="pentaho-hadoop-shims-cdh50-package" type="zip"/>
+    <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh47-package" rev="${project.revision}" changing="true">
+      <artifact name="pentaho-hadoop-shims-cdh47-package" type="zip"/>
     </dependency>
      <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh51-package" rev="${project.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-cdh51-package" type="zip"/>


### PR DESCRIPTION
make cdh51 and cdh47 replace cdh50 and cdh42 respectively
