### PR TITLE
BACKLOG-674 - CLONE - REG: HDP21:Hive: if we change the db-scheme, then ...

### DIFF
--- a/src/org/pentaho/di/core/database/HiveDatabaseMeta.java
+++ b/src/org/pentaho/di/core/database/HiveDatabaseMeta.java
@@ -310,6 +310,17 @@ public class HiveDatabaseMeta extends BaseDatabaseMeta implements DatabaseInterf
     StringBuilder sql = getConnectSqlForNotDefaultDatabaseName();
     String superSql = super.getConnectSQL();
     if ( !Const.isEmpty( superSql ) ) {
+      int startPos = superSql.indexOf( "use " );
+      if( startPos >= 0 ){
+        int endPos = superSql.indexOf( ";", startPos );
+        if( endPos >= 0 ){
+          if( endPos <superSql.length() ) {
+            endPos++;
+          }
+          String superSql1 = superSql.substring( 0, startPos ) + superSql.substring( endPos );
+          superSql = superSql1;
+        }
+      }
       return sql.append( superSql ).toString();
     }
     return sql.toString();

--- a/test-src/org/pentaho/di/core/database/HiveDatabaseMetaTest.java
+++ b/test-src/org/pentaho/di/core/database/HiveDatabaseMetaTest.java
@@ -23,13 +23,14 @@
 package org.pentaho.di.core.database;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Properties;
 
-public class TestHiveDatabaseMeta {
+public class HiveDatabaseMetaTest {
 
   @Before
   public void setup() {
@@ -70,5 +71,29 @@ public class TestHiveDatabaseMeta {
     dbm.setAttributes( new Properties() );
     dbm.setDatabaseName( "default" );
     assertEquals( dbm.getConnectSQL(), "use default; " );
+  }
+  
+  @Test
+  public void testGetConnectSQL2() throws Throwable {
+    HiveDatabaseMeta dbm = new HiveDatabaseMeta( 0, 5 );
+    dbm.setAttributes( new Properties() );
+    dbm.setDatabaseName( "default" );
+    assertEquals( dbm.getConnectSQL(), "use default; " );
+    dbm.setDatabaseName( "hdp" );
+    assertEquals( dbm.getConnectSQL().trim(), "use hdp;" );
+    assertFalse( dbm.getConnectSQL().equals( "use default; " ) );
+  }
+  
+  @Test
+  public void testGetConnectSQL3() throws Throwable {
+    HiveDatabaseMeta dbm = new HiveDatabaseMeta( 0, 5 );
+    dbm.setAttributes( new Properties() );
+    dbm.setDatabaseName( "default" );
+    assertEquals( dbm.getConnectSQL(), "use default; " );
+    String oldSql = dbm.getConnectSQL();
+    dbm.setDatabaseName( "hdp" );
+    dbm.setConnectSQL( oldSql );
+    assertEquals( dbm.getConnectSQL().trim(), "use hdp;" );
+    assertFalse( dbm.getConnectSQL().equals( "use default; " ) );
   }
 }


### PR DESCRIPTION
...it

won't be used until pooling connection has closed; the original will be
used instead.

What was done:
1) changed method to remove previously used "use" statement
2) added unit tests
