### PR TITLE
[ENGOPS-712] removed oss license report

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -18,7 +18,6 @@ dependency.pentaho-database.revision=TRUNK-SNAPSHOT
 dependency.json.revision=3.1.1
 dependency.pentaho-vfs-browser.revision=TRUNK-SNAPSHOT
 dependency.pentaho-s3-vfs.revision=TRUNK-SNAPSHOT
-dependency.oss-licenses.revision=5.1.0.0
 dependency.pentaho-hadoop.revision=0.20.2
 dependency.apache-hbase.revision=0.90.3
 dependency.apache-zookeeper.revision=3.3.2

--- a/build.xml
+++ b/build.xml
@@ -47,7 +47,7 @@
     FOUND IN subfloor.xml.
   --> 
 
-  <target name="resolve" depends="subfloor.resolve,resolve-pmr,resolve-oss-licenses"/>
+  <target name="resolve" depends="subfloor.resolve,resolve-pmr"/>
 
   <target name="clean-pmr">
     <delete dir="${stage.pmr.dir}"/>
@@ -63,11 +63,6 @@
     <delete dir="${resolve.shims.dir}"/>
     <ivy:resolve file="${ivyfile}" conf="shim" />
     <ivy:retrieve conf="shim" pattern="${resolve.shims.dir}/[module]-[revision](-[classifier]).[ext]" symlink="true" />
-  </target>
-	
-  <target name="resolve-oss-licenses" depends="install-ivy">
-    <ivy:resolve file="${ivyfile}" conf="oss-licenses" />
-    <ivy:retrieve conf="oss-licenses" pattern="${bin.dir}/[module].[ext]" />
   </target>
 
 	<target name="dist-noresolve" depends="jar,package" description="Builds and packages the application" />
@@ -86,17 +81,6 @@
     <mkdir dir="${stage.dir}/${ivy.artifact.id}" />
   </target>
 	
-  <target name="assemble" depends="assemble.init,assemble.copy-libs">
-    <copy todir="${approot.stage.dir}" overwrite="true">
-      <fileset dir="${package.resdir}" />
-    </copy>
-    <unzip src="${bin.dir}/oss-licenses.zip" dest="${approot.stage.dir}">
-      <patternset>
-        <include name="PentahoBigDataPlugin_OSS_Licenses.html"/>
-      </patternset>
-    </unzip>  	
-    <chmod perm="a+x" dir="${stage.dir}" includes="**/*.sh" />
-  </target>
 
   <!-- Assemble the Hadoop Shim zips by first resolving them then extracting them
        into the package stage directory at hadoop-configurations/.

--- a/ivy.xml
+++ b/ivy.xml
@@ -9,7 +9,6 @@
     <conf name="zip" />
     <conf name="pmr" />
     <conf name="shim" />
-    <conf name="oss-licenses" />
   </configurations>
 
   <publications>
@@ -205,10 +204,6 @@
     <dependency org="pentaho-library" name="libformula" rev="${dependency.libformula.revision}" conf="pmr->default"
                 transitive="false"/>
                 
-	<!--  OSS Licenses file -->
-	<dependency org="pentaho" name="oss-licenses" rev="${dependency.oss-licenses.revision}" conf="oss-licenses->default">
-		<artifact name="oss-licenses" type="zip" />
-	</dependency>              
 
     <!-- Our modified Hive driver (need to include it until changes are accepted into main Hive project) -->
     <!-- <dependency org="org.apache.hadoop.hive" name="hive-jdbc" rev="${dependency.hive-jdbc.revision}" changing="true"


### PR DESCRIPTION
file is no longer published and will cause the 5.2 release to fail if not removed
