### PR TITLE
[BACKLOG-670] CLONE - Hadoop Job Executor doesn`t work with variables provided in path to jar

### DIFF
--- a/src/org/pentaho/di/job/entries/hadoopjobexecutor/JobEntryHadoopJobExecutor.java
+++ b/src/org/pentaho/di/job/entries/hadoopjobexecutor/JobEntryHadoopJobExecutor.java
@@ -51,6 +51,8 @@ import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.ui.job.entries.hadoopjobexecutor.UserDefinedItem;
+import org.pentaho.hadoop.shim.ConfigurationException;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
 import org.pentaho.hadoop.shim.api.Configuration;
 import org.pentaho.hadoop.shim.api.fs.FileSystem;
 import org.pentaho.hadoop.shim.api.fs.Path;
@@ -332,8 +334,7 @@ public class JobEntryHadoopJobExecutor extends JobEntryBase implements Cloneable
         logDetailed( BaseMessages.getString( PKG, "JobEntryHadoopJobExecutor.ResolvedJar", resolvedJarUrl
             .toExternalForm() ) );
       }
-      HadoopShim shim =
-          HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration().getHadoopShim();
+      HadoopShim shim = getHadoopConfiguration().getHadoopShim();
 
       if ( isSimple ) {
         String simpleLoggingIntervalS = environmentSubstitute( getSimpleLoggingInterval() );
@@ -510,7 +511,7 @@ public class JobEntryHadoopJobExecutor extends JobEntryBase implements Cloneable
           }
         }
 
-        conf.setJar( jarUrl );
+        conf.setJar( environmentSubstitute( jarUrl ) );
 
         String numMapTasksS = environmentSubstitute( numMapTasks );
         String numReduceTasksS = environmentSubstitute( numReduceTasks );
@@ -951,5 +952,17 @@ public class JobEntryHadoopJobExecutor extends JobEntryBase implements Cloneable
 
   public void setSimpleBlocking( boolean simpleBlocking ) {
     this.simpleBlocking = simpleBlocking;
+  }
+
+  /**
+   * Get the {@link org.pentaho.hadoop.shim.HadoopConfiguration} to use when executing. This is by default loaded from
+   * {@link HadoopConfigurationRegistry}.
+   *
+   * @return a valid Hadoop configuration
+   * @throws org.pentaho.hadoop.shim.ConfigurationException
+   *           Error locating a valid hadoop configuration
+   */
+  protected HadoopConfiguration getHadoopConfiguration() throws ConfigurationException {
+    return HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration();
   }
 }

--- a/test-src/org/pentaho/di/job/entries/hadoopjobexecutor/JobEntryHadoopJobExecutorTest.java
+++ b/test-src/org/pentaho/di/job/entries/hadoopjobexecutor/JobEntryHadoopJobExecutorTest.java
@@ -1,0 +1,135 @@
+/*
+ * ! ******************************************************************************
+ *  *
+ *  * Pentaho Data Integration
+ *  *
+ *  * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *  *
+ *  *******************************************************************************
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  *
+ *  *****************************************************************************
+ */
+package org.pentaho.di.job.entries.hadoopjobexecutor;
+
+import org.apache.commons.vfs.VFS;
+import org.pentaho.hadoop.shim.api.mapred.TaskCompletionEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.Result;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.job.Job;
+import org.pentaho.hadoop.shim.ConfigurationException;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
+import org.pentaho.hadoop.shim.api.Configuration;
+import org.pentaho.hadoop.shim.api.fs.Path;
+import org.pentaho.hadoop.shim.api.mapred.RunningJob;
+import org.pentaho.hadoop.shim.common.CommonHadoopShim;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.*;
+
+/**
+ * User: Dzmitry Stsiapanau Date: 9/11/14 Time: 1:36 PM
+ */
+public class JobEntryHadoopJobExecutorTest {
+  @Before
+  public void setUp() throws Exception {
+    KettleEnvironment.init();
+  }
+
+  @Test
+  public void testExecuteSubstituteJobUrl() {
+    File file = null;
+    try {
+      file = File.createTempFile( "hadoopJobExecutorTest", ".txt" );
+    } catch ( IOException e ) {
+      e.printStackTrace();
+      fail( e.getMessage() );
+    }
+    final String path = file.getAbsolutePath();
+    Job job = new Job();
+    job.injectVariables( System.getenv() );
+    JobEntryHadoopJobExecutor jobExecutor = new JobEntryHadoopJobExecutor() {
+      protected HadoopConfiguration getHadoopConfiguration() throws ConfigurationException {
+        try {
+          CommonHadoopShim shim = Mockito.spy( new CommonHadoopShim() );
+          HadoopConfiguration hc = new HadoopConfiguration( VFS.getManager().resolveFile( "ram:///" ), "test", "test",
+            shim );
+          hc = Mockito.spy( hc );
+          Configuration conf = Mockito.spy( shim.createConfiguration() );
+          doAnswer( new Answer() {
+            @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
+              String jobUrl = (String) invocation.getArguments()[ 0 ];
+              if ( path.equals( jobUrl ) ) {
+                return null;
+              } else {
+                throw new ConfigurationException(
+                  "Unsubstituted job url was set to conf \n Path = " + path + "\n jobUrl = " + jobUrl );
+              }
+            }
+          } ).when( conf ).setJar( (String) anyObject() );
+          doNothing().when( conf ).setInputPaths( (Path[]) anyObject() );
+          doNothing().when( conf ).setOutputPath( (Path) anyObject() );
+          when( shim.createConfiguration() ).thenReturn( conf );
+          doAnswer( new Answer<Object>() {
+            @Override public Object answer( InvocationOnMock invocation ) throws Throwable {
+              RunningJob rj = mock( RunningJob.class );
+              when( rj.isComplete() ).thenReturn( true );
+              when( rj.isSuccessful() ).thenReturn( true );
+              when( rj.getTaskCompletionEvents( anyInt() ) ).thenReturn( new TaskCompletionEvent[ 0 ] );
+              return rj;
+            }
+          } ).when( shim ).submitJob( (Configuration) anyObject() );
+          return hc;
+        } catch ( Exception ex ) {
+          throw new ConfigurationException( "Error creating mock hadoop configuration", ex );
+        }
+      }
+    };
+    jobExecutor.setParentJob( job );
+    jobExecutor.initializeVariablesFrom( jobExecutor.getParentVariableSpace() );
+    jobExecutor.setHadoopJobName( "hadoop job name" );
+    jobExecutor.setOutputKeyClass( getClass().getName() );
+    jobExecutor.setOutputValueClass( getClass().getName() );
+    jobExecutor.setHdfsHostname( "hostname" );
+    jobExecutor.setHdfsPort( "8020" );
+    jobExecutor.setJobTrackerHostname( "hostname" );
+    jobExecutor.setJobTrackerPort( "50030" );
+    jobExecutor.setInputPath( "/" );
+    jobExecutor.setOutputPath( "/" );
+    jobExecutor.setBlocking( true );
+
+    file.deleteOnExit();
+    jobExecutor.setJarUrl( "${java.io.tmpdir}" + file.getName() );
+    jobExecutor.setSimple( false );
+    Result result = new Result();
+    try {
+      jobExecutor.execute( result, 0 );
+    } catch ( KettleException e ) {
+      e.printStackTrace();
+      fail( e.getMessage() );
+    }
+    assertTrue( result.getResult() );
+  }
+}


### PR DESCRIPTION
- Added environmentSubstitute( jarUrl ) 
- Added unit test
