### PR TITLE
[SP-1612] - Regression of PDI-13082 - Regression: MapReduce Input is missing Serializable Data Type (5.2 Suite)

### DIFF
--- a/src/org/pentaho/di/ui/trans/steps/hadoopenter/HadoopEnterDialog.java
+++ b/src/org/pentaho/di/ui/trans/steps/hadoopenter/HadoopEnterDialog.java
@@ -51,7 +51,7 @@ public class HadoopEnterDialog extends BaseStepXulDialog implements StepDialogIn
     super( "org/pentaho/di/ui/trans/steps/hadoopenter/dialog.xul", parent, (BaseStepMeta) in, tr, sname );
 
     typeList = new ArrayList<String>();
-    for ( String type : ValueMeta.getTypes() ) {
+    for ( String type : ValueMeta.getAllTypes() ) {
       typeList.add( type );
     }
 


### PR DESCRIPTION
No Unit tests since this is pure UI change - could break nothing.

@mattcasters @mattyb149 @brosander could you please review?

this is a 5.2 backport for https://github.com/pentaho/big-data-plugin/pull/273
