### PR TITLE
[PDI-13380]Allow Hadoop Job Executor dialog to open if Driver Class is not found

### DIFF
--- a/src/org/pentaho/di/ui/job/entries/hadoopjobexecutor/JobEntryHadoopJobExecutorController.java
+++ b/src/org/pentaho/di/ui/job/entries/hadoopjobexecutor/JobEntryHadoopJobExecutorController.java
@@ -893,7 +893,12 @@ public class JobEntryHadoopJobExecutorController extends AbstractXulEventHandler
       }
       if ( Const.isEmpty( driverClass ) ) {
         setDriverClasses( driverClasses );
-        final Class<?> mainClass = jarUtil.getMainClassFromManifest( resolvedJarUrl, shim.getClass().getClassLoader() );
+        Class<?> mainClass;
+        try {
+          mainClass = jarUtil.getMainClassFromManifest( resolvedJarUrl, shim.getClass().getClassLoader() );
+        } catch ( Exception e ) {
+          mainClass = null;
+        }
         if ( mainClass != null ) {
           setDriverClass( mainClass.getName() );
         } else if ( !driverClasses.isEmpty() ) {


### PR DESCRIPTION
Dialog failed to open if jar could not be read or if driver class is not found.
E.g. if jar path is parameterized

http://jira.pentaho.com/browse/PDI-13380