### PR TITLE
[PDI-13426] - Fix KettleFileAppender error

### DIFF
--- a/legacy/src/main/java/org/pentaho/di/job/entries/hadooptransjobexecutor/JobEntryHadoopTransJobExecutor.java
+++ b/legacy/src/main/java/org/pentaho/di/job/entries/hadooptransjobexecutor/JobEntryHadoopTransJobExecutor.java
@@ -504,7 +504,7 @@ public class JobEntryHadoopTransJobExecutor extends JobEntryBase implements Clon
     String logFileName = "pdi-" + this.getName(); //$NON-NLS-1$
 
     try {
-      appender = LogWriter.createFileAppender( logFileName, true, false );
+      appender = LogWriter.createFileAppender( logFileName, false, false );
       LogWriter.getInstance().addAppender( appender );
       log.setLogLevel( parentJob.getLogLevel() );
     } catch ( Exception e ) {


### PR DESCRIPTION
Store log file in user's temp directory, instead of in the current working directory in case the user does not have write permissions to the folder