### PR TITLE
[BAD-176] - Compile CDH 5.3 Shim

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -49,7 +49,7 @@
     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-hadoop-20-package" rev="${dependency.hadoop-shims-hadoop-20.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-hadoop-20-package" type="zip"/>
     </dependency>
-    <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh52-package" rev="${dependency.hadoop-shims-cdh52.revision}" changing="true">
+    <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-cdh53-package" rev="${dependency.hadoop-shims-cdh52.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-cdh52-package" type="zip"/>
     </dependency>
     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-hdp22-package" rev="${dependency.hadoop-shims-hdp22.revision}" changing="true">


### PR DESCRIPTION
replace cdh52 shim by the new cdh53 one
should be merged after the following two have been merged:
https://github.com/pentaho/pentaho-big-data-ee/pull/57
https://github.com/pentaho/pentaho-hadoop-shims/pull/207

@mattyb149 @brosander could you please review/merge?
@lgrill-pentaho keeping you in the loop since there are some items to be done for build process for new shim
@mbradbury2014 FYI :)