### PR TITLE
[BAD-220] - Extend BD functionality to S3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -16,6 +16,7 @@ dependency.hadoop-shims-hdp21.revision=TRUNK-SNAPSHOT
 dependency.hadoop-shims-hdp22.revision=TRUNK-SNAPSHOT
 dependency.hadoop-shims-mapr31.revision=TRUNK-SNAPSHOT
 dependency.hadoop-shims-mapr401.revision=TRUNK-SNAPSHOT
+dependency.hadoop-shims-emr32.revision=TRUNK-SNAPSHOT
 
 dependency.pentaho-hadoop.revision=0.20.2
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -60,6 +60,9 @@
     <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-mapr401-package" rev="${dependency.hadoop-shims-mapr401.revision}" changing="true">
       <artifact name="pentaho-hadoop-shims-mapr401-package" type="zip"/>
     </dependency>
+    <dependency conf="shim->default" org="pentaho" name="pentaho-hadoop-shims-emr32-package" rev="${dependency.hadoop-shims-emr32.revision}" changing="true">
+      <artifact name="pentaho-hadoop-shims-emr32-package" type="zip"/>
+    </dependency>
   
     <dependency org="commons-httpclient" name="commons-httpclient" rev="${dependency.commons-httpclient.revision}" />
     
@@ -81,7 +84,9 @@
     <dependency org="pentaho" name="pentaho-vfs-browser" rev="${dependency.pentaho-vfs-browser.revision}" transitive="false" conf="default->default"
       changing="true" />
     <dependency org="pentaho" name="pentaho-s3-vfs" rev="${dependency.pentaho-s3-vfs.revision}" transitive="false" conf="default->default" changing="true" />
-    <dependency org="net.java.dev.jets3t" name="jets3t" rev="0.7.4" transitive="false" conf="default->default"/>
+    <dependency org="net.java.dev.jets3t" name="jets3t" rev="0.9.3" transitive="false" conf="default->default"/>
+    <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.4" transitive="false" conf="default->default"/>
+    <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4" transitive="false" conf="default->default"/>
     <dependency org="com.amazonaws" name="aws-java-sdk" rev="1.0.008" transitive="false"/>
       
 	<dependency org="dom4j"              name="dom4j"              rev="1.6.1">


### PR DESCRIPTION
* Updated jets3t version
* included required httpclient dependencies
* Also include emr32 shim
Related to https://github.com/pentaho/pentaho-s3-vfs/pull/4 and should be merged after https://github.com/pentaho/pentaho-hadoop-shims/pull/231