### PR TITLE
[PDI-12715] - Improvement: Sqoop Job Entries

### DIFF
--- a/src/org/pentaho/di/job/ArgumentWrapper.java
+++ b/src/org/pentaho/di/job/ArgumentWrapper.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,11 +34,16 @@ public class ArgumentWrapper implements XulEventSource {
   private String name;
   private String displayName;
   private boolean flag;
+  private String prefix;
+  private int order;
+
   private Object target;
   private Method getter;
   private Method setter;
 
-  public ArgumentWrapper( String name, String displayName, boolean flag, Object target, Method getter, Method setter ) {
+  public ArgumentWrapper( String name, String displayName,
+      boolean flag, String prefix, int order,
+      Object target, Method getter, Method setter ) {
     if ( name == null || target == null || getter == null || setter == null ) {
       throw new NullPointerException();
     }
@@ -47,6 +52,8 @@ public class ArgumentWrapper implements XulEventSource {
     this.name = name;
     this.displayName = displayName;
     this.flag = flag;
+    this.prefix = prefix;
+    this.order = order;
     this.target = target;
     this.getter = getter;
     this.setter = setter;
@@ -139,5 +146,21 @@ public class ArgumentWrapper implements XulEventSource {
   @Override
   public void removePropertyChangeListener( PropertyChangeListener listener ) {
     // Do nothing, this object is a wrapper and firing events here propagates to too many objects
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public void setPrefix( String prefix ) {
+    this.prefix = prefix;
+  }
+
+  public int getOrder() {
+    return order;
+  }
+
+  public void setOrder( int order ) {
+    this.order = order;
   }
 }

--- a/src/org/pentaho/di/job/CommandLineArgument.java
+++ b/src/org/pentaho/di/job/CommandLineArgument.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -59,4 +59,16 @@ public @interface CommandLineArgument {
    * @return true if this argument represents a flag or switch.
    */
   boolean flag() default false;
+
+  /**
+   * Arguments could be prefixed different in a different way (double dash by default)
+   * @return prefix to be used with the argument
+   */
+  String prefix() default "--";
+
+  /**
+   * Some arguments have to follow a particular precedence
+   * @return sort order for the argument
+   */
+  int order() default 100;
 }

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopConfig.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopConfig.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -85,6 +85,39 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
   public static final String COMMAND_LINE = "commandLine";
   public static final String MODE = "mode";
 
+  public static final String HADOOP_MAPRED_HOME = "hadoopMapredHome";
+  public static final String PASSWORD_ALIAS = "passwordAlias";
+  public static final String PASSWORD_FILE = "passwordFile";
+
+  public static final String RELAXED_ISOLATION = "relaxedIsolation";
+  public static final String SKIP_DIST_CACHE = "skipDistCache";
+  public static final String MAPREDUCE_JOB_NAME = "mapreduceJobName";
+  public static final String VALIDATE = "validate";
+  public static final String VALIDATION_FAILUREHANDLER = "validationFailurehandler";
+  public static final String VALIDATION_THRESHOLD = "validationThreshold";
+  public static final String VALIDATOR = "validator";
+
+  public static final String HCATALOG_DATABASE = "hcatalogDatabase";
+  public static final String HCATALOG_HOME = "hcatalogHome";
+  public static final String HCATALOG_PARTITION_KEYS = "hcatalogPartitionKeys";
+  public static final String HCATALOG_PARTITION_VALUES = "hcatalogPartitionValues";
+  public static final String HCATALOG_TABLE = "hcatalogTable";
+
+  public static final String HIVE_HOME = "hiveHome";
+  public static final String HIVE_PARTITION_KEY = "hivePartitionKey";
+  public static final String HIVE_PARTITION_VALUE = "hivePartitionValue";
+  public static final String MAP_COLUMN_HIVE = "mapColumnHive";
+
+  public static final String INPUT_NULL_STRING = "inputNullString";
+  public static final String INPUT_NULL_NON_STRING = "inputNullNonString";
+
+  public static final String NULL_STRING = "nullString";
+  public static final String NULL_NON_STRING = "nullNonString";
+
+  public static final String FILES = "files";
+  public static final String LIBJARS = "libjars";
+  public static final String ARCHIVES = "archives";
+
   private String namenodeHost;
   private String namenodePort;
   private String jobtrackerHost;
@@ -98,7 +131,67 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
   private transient String usernameFromAdvanced;
   private transient String passwordFromAdvanced;
 
-  // Represents the last visible state of the UI and the execution mode.
+  @CommandLineArgument( name = "hadoop-mapred-home" )
+  private String hadoopMapredHome;
+  @CommandLineArgument( name = "password-alias" )
+  private String passwordAlias;
+  @CommandLineArgument( name = "password-file" )
+  private String passwordFile;
+
+  @CommandLineArgument( name = "relaxed-isolation", flag = true )
+  private String relaxedIsolation;
+  @CommandLineArgument( name = "skip-dist-cache", flag = true )
+  private String skipDistCache;
+
+  @CommandLineArgument( name = "mapreduce-job-name" )
+  private String mapreduceJobName;
+
+  @CommandLineArgument( name = "validate", flag = true )
+  private String validate;
+  @CommandLineArgument( name = "validation-failurehandler" )
+  private String validationFailureHandler;
+  @CommandLineArgument( name = "validation-threshold" )
+  private String validationThreshold;
+  @CommandLineArgument( name = "validator" )
+  private String validator;
+
+  @CommandLineArgument( name = "hcatalog-database" )
+  private String hcatalogDatabase;
+  @CommandLineArgument( name = "hcatalog-home" )
+  private String hcatalogHome;
+  @CommandLineArgument( name = "hcatalog-partition-keys" )
+  private String hcatalogPartitionKeys;
+  @CommandLineArgument( name = "hcatalog-partition-values" )
+  private String hcatalogPartitionValues;
+  @CommandLineArgument( name = "hcatalog-table" )
+  private String hcatalogTable;
+
+  @CommandLineArgument( name = "hive-home" )
+  private String hiveHome;
+  @CommandLineArgument( name = "hive-partition-key" )
+  private String hivePartitionKey;
+  @CommandLineArgument( name = "hive-partition-value" )
+  private String hivePartitionValue;
+  @CommandLineArgument( name = "map-column-hive" )
+  private String mapColumnHive;
+
+  @CommandLineArgument( name = "input-null-string" )
+  private String inputNullString;
+  @CommandLineArgument( name = "input-null-non-string" )
+  private String inputNullNonString;
+  @CommandLineArgument( name = "null-string" )
+  private String nullString;
+  @CommandLineArgument( name = "null-non-string" )
+  private String nullNonString;
+
+  @CommandLineArgument( name = "files", order = 50, prefix = "-" )
+  private String files;
+  @CommandLineArgument( name = "libjars", order = 50, prefix = "-" )
+  private String libjars;
+  @CommandLineArgument( name = "archives", order = 50, prefix = "-" )
+  private String archives;
+
+// Represents the last visible state of the UI and the execution mode.
   private String mode;
 
   // Common arguments
@@ -181,20 +274,24 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
 
     try {
       items.add( new ArgumentWrapper( NAMENODE_HOST, BaseMessages.getString( getClass(), "NamenodeHost.Label" ), false,
+          "", 0,
           this, getClass().getMethod( "getNamenodeHost" ), getClass().getMethod( "setNamenodeHost", String.class ) ) );
       items.add( new ArgumentWrapper( NAMENODE_PORT, BaseMessages.getString( getClass(), "NamenodePort.Label" ), false,
+          "", 0,
           this, getClass().getMethod( "getNamenodePort" ), getClass().getMethod( "setNamenodePort", String.class ) ) );
       items.add( new ArgumentWrapper( JOBTRACKER_HOST, BaseMessages.getString( getClass(), "JobtrackerHost.Label" ),
-          false, this, getClass().getMethod( "getJobtrackerHost" ), getClass().getMethod( "setJobtrackerHost",
-              String.class ) ) );
+          false, "", 0, this,
+          getClass().getMethod( "getJobtrackerHost" ), getClass().getMethod( "setJobtrackerHost", String.class ) ) );
       items.add( new ArgumentWrapper( JOBTRACKER_PORT, BaseMessages.getString( getClass(), "JobtrackerPort.Label" ),
-          false, this, getClass().getMethod( "getJobtrackerPort" ), getClass().getMethod( "setJobtrackerPort",
-              String.class ) ) );
+          false, "", 0, this,
+          getClass().getMethod( "getJobtrackerPort" ), getClass().getMethod( "setJobtrackerPort", String.class ) ) );
       items.add( new ArgumentWrapper( BLOCKING_EXECUTION, BaseMessages
-          .getString( getClass(), "BlockingExecution.Label" ), false, this, getClass().getMethod(
-          "getBlockingExecution" ), getClass().getMethod( "setBlockingExecution", String.class ) ) );
+          .getString( getClass(), "BlockingExecution.Label" ),
+          false, "", 0, this,
+          getClass().getMethod("getBlockingExecution" ),
+          getClass().getMethod( "setBlockingExecution", String.class ) ) );
       items.add( new ArgumentWrapper( BLOCKING_POLLING_INTERVAL, BaseMessages.getString( getClass(),
-          "BlockingPollingInterval.Label" ), false, this, getClass().getMethod( "getBlockingPollingInterval" ),
+          "BlockingPollingInterval.Label" ), false, "", 0, this, getClass().getMethod( "getBlockingPollingInterval" ),
           getClass().getMethod( "setBlockingPollingInterval", String.class ) ) );
     } catch ( NoSuchMethodException ex ) {
       throw new RuntimeException( ex );
@@ -682,4 +779,263 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
     this.jobtrackerPort = jobtrackerPort;
     pcs.firePropertyChange( JOBTRACKER_PORT, old, this.jobtrackerPort );
   }
+
+  public String getHadoopMapredHome() {
+    return hadoopMapredHome;
+  }
+
+  public void setHadoopMapredHome( String hadoopMapredHome ) {
+    String old = this.hadoopMapredHome;
+    this.hadoopMapredHome = hadoopMapredHome;
+    pcs.firePropertyChange( HADOOP_MAPRED_HOME, old, this.hadoopMapredHome );
+  }
+
+  public String getPasswordAlias() {
+    return passwordAlias;
+  }
+
+  public void setPasswordAlias( String passwordAlias ) {
+    String old = this.passwordAlias;
+    this.passwordAlias = passwordAlias;
+    pcs.firePropertyChange( PASSWORD_ALIAS, old, this.passwordAlias );
+  }
+
+  public String getPasswordFile() {
+    return passwordFile;
+  }
+
+  public void setPasswordFile( String passwordFile ) {
+    String old = this.passwordFile;
+    this.passwordFile = passwordFile;
+    pcs.firePropertyChange( PASSWORD_FILE, old, this.passwordFile );
+  }
+
+  public String getRelaxedIsolation() {
+    return relaxedIsolation;
+  }
+
+  public void setRelaxedIsolation( String relaxedIsolation ) {
+    String old = this.relaxedIsolation;
+    this.relaxedIsolation = relaxedIsolation;
+    pcs.firePropertyChange( RELAXED_ISOLATION, old, this.relaxedIsolation );
+  }
+
+  public String getSkipDistCache() {
+    return skipDistCache;
+  }
+
+  public void setSkipDistCache( String skipDistCache ) {
+    String old = this.skipDistCache;
+    this.skipDistCache = skipDistCache;
+    pcs.firePropertyChange( SKIP_DIST_CACHE, old, this.skipDistCache );
+  }
+
+  public String getMapreduceJobName() {
+    return mapreduceJobName;
+  }
+
+  public void setMapreduceJobName( String mapreduceJobName ) {
+    String old = this.mapreduceJobName;
+    this.mapreduceJobName = mapreduceJobName;
+    pcs.firePropertyChange( MAPREDUCE_JOB_NAME, old, this.mapreduceJobName );
+  }
+
+  public String getValidate() {
+    return validate;
+  }
+
+  public void setValidate( String validate ) {
+    String old = this.validate;
+    this.validate = validate;
+    pcs.firePropertyChange( VALIDATE, old, this.validate );
+  }
+
+  public String getValidationFailureHandler() {
+    return validationFailureHandler;
+  }
+
+  public void setValidationFailureHandler( String validationFailureHandler ) {
+    String old = this.validationFailureHandler;
+    this.validationFailureHandler = validationFailureHandler;
+    pcs.firePropertyChange( VALIDATION_FAILUREHANDLER, old, this.validationFailureHandler );
+  }
+
+  public String getValidationThreshold() {
+    return validationThreshold;
+  }
+
+  public void setValidationThreshold( String validationThreshold ) {
+    String old = this.validationThreshold;
+    this.validationThreshold = validationThreshold;
+    pcs.firePropertyChange( VALIDATION_THRESHOLD, old, this.validationThreshold );
+  }
+
+  public String getValidator() {
+    return validator;
+  }
+
+  public void setValidator( String validator ) {
+    String old = this.validator;
+    this.validator = validator;
+    pcs.firePropertyChange( VALIDATOR, old, this.validator );
+  }
+
+  public String getHcatalogDatabase() {
+    return hcatalogDatabase;
+  }
+
+  public void setHcatalogDatabase( String hcatalogDatabase ) {
+    String old = this.hcatalogDatabase;
+    this.hcatalogDatabase = hcatalogDatabase;
+    pcs.firePropertyChange( HCATALOG_DATABASE, old, this.hcatalogDatabase );
+  }
+
+  public String getHcatalogHome() {
+    return hcatalogHome;
+  }
+
+  public void setHcatalogHome( String hcatalogHome ) {
+    String old = this.hcatalogHome;
+    this.hcatalogHome = hcatalogHome;
+    pcs.firePropertyChange( HCATALOG_HOME, old, this.hcatalogHome );
+  }
+
+  public String getHcatalogPartitionKeys() {
+    return hcatalogPartitionKeys;
+  }
+
+  public void setHcatalogPartitionKeys( String hcatalogPartitionKeys ) {
+    String old = this.hcatalogPartitionKeys;
+    this.hcatalogPartitionKeys = hcatalogPartitionKeys;
+    pcs.firePropertyChange( HCATALOG_PARTITION_KEYS, old, this.hcatalogPartitionKeys );
+  }
+
+  public String getHcatalogPartitionValues() {
+    return hcatalogPartitionValues;
+  }
+
+  public void setHcatalogPartitionValues( String hcatalogPartitionValues ) {
+    String old = this.hcatalogPartitionValues;
+    this.hcatalogPartitionValues = hcatalogPartitionValues;
+    pcs.firePropertyChange( HCATALOG_PARTITION_VALUES, old, this.hcatalogPartitionValues );
+  }
+
+  public String getHcatalogTable() {
+    return hcatalogTable;
+  }
+
+  public void setHcatalogTable( String hcatalogTable ) {
+    String old = this.hcatalogTable;
+    this.hcatalogTable = hcatalogTable;
+    pcs.firePropertyChange( HCATALOG_TABLE, old, this.hcatalogTable );
+  }
+
+  public String getHiveHome() {
+    return hiveHome;
+  }
+
+  public void setHiveHome( String hiveHome ) {
+    String old = this.hiveHome;
+    this.hiveHome = hiveHome;
+    pcs.firePropertyChange( HIVE_HOME, old, this.hiveHome );
+  }
+
+  public String getHivePartitionKey() {
+    return hivePartitionKey;
+  }
+
+  public void setHivePartitionKey( String hivePartitionKey ) {
+    String old = this.hivePartitionKey;
+    this.hivePartitionKey = hivePartitionKey;
+    pcs.firePropertyChange( HIVE_PARTITION_KEY, old, this.hivePartitionKey );
+  }
+
+  public String getHivePartitionValue() {
+    return hivePartitionValue;
+  }
+
+  public void setHivePartitionValue( String hivePartitionValue ) {
+    String old = this.hivePartitionValue;
+    this.hivePartitionValue = hivePartitionValue;
+    pcs.firePropertyChange( HIVE_PARTITION_VALUE, old, this.hivePartitionValue );
+  }
+
+  public String getMapColumnHive() {
+    return mapColumnHive;
+  }
+
+  public void setMapColumnHive( String mapColumnHive ) {
+    String old = this.mapColumnHive;
+    this.mapColumnHive = mapColumnHive;
+    pcs.firePropertyChange( MAP_COLUMN_HIVE, old, this.mapColumnHive );
+  }
+  public String getInputNullString() {
+    return inputNullString;
+  }
+
+  public void setInputNullString( String inputNullString ) {
+    String old = this.inputNullString;
+    this.inputNullString = inputNullString;
+    pcs.firePropertyChange( INPUT_NULL_STRING, old, this.inputNullString );
+  }
+
+  public String getInputNullNonString() {
+    return inputNullNonString;
+  }
+
+  public void setInputNullNonString( String inputNullNonString ) {
+    String old = this.inputNullNonString;
+    this.inputNullNonString = inputNullNonString;
+    pcs.firePropertyChange( INPUT_NULL_NON_STRING, old, this.inputNullNonString );
+  }
+  public String getNullString() {
+    return nullString;
+  }
+
+  public void setNullString( String nullString ) {
+    String old = this.nullString;
+    this.nullString = nullString;
+    pcs.firePropertyChange( NULL_STRING, old, this.nullString );
+  }
+
+  public String getNullNonString() {
+    return nullNonString;
+  }
+
+  public void setNullNonString( String nullNonString ) {
+    String old = this.nullNonString;
+    this.nullNonString = nullNonString;
+    pcs.firePropertyChange( NULL_NON_STRING, old, this.nullNonString );
+  }
+
+  public String getFiles() {
+    return files;
+  }
+
+  public void setFiles( String files ) {
+    String old = this.files;
+    this.files = files;
+    pcs.firePropertyChange( FILES, old, this.files );
+  }
+
+  public String getLibjars() {
+    return libjars;
+  }
+
+  public void setLibjars( String libjars ) {
+    String old = this.libjars;
+    this.libjars = libjars;
+    pcs.firePropertyChange( LIBJARS, old, this.libjars );
+  }
+
+  public String getArchives() {
+    return archives;
+  }
+
+  public void setArchives( String archives ) {
+    String old = this.archives;
+    this.archives = archives;
+    pcs.firePropertyChange( ARCHIVES, old, this.archives );
+  }
+
 }

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopExportConfig.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopExportConfig.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,12 +31,13 @@ public class SqoopExportConfig extends SqoopConfig {
   public static final String EXPORT_DIR = "exportDir";
   public static final String UPDATE_KEY = "updateKey";
   public static final String UPDATE_MODE = "updateMode";
-  public static final String INPUT_NULL_STRING = "inputNullString";
   public static final String DIRECT = "direct";
   public static final String STAGING_TABLE = "stagingTable";
   public static final String CLEAR_STAGING_TABLE = "clearStagingTable";
   public static final String BATCH = "batch";
-  public static final String INPUT_NULL_NON_STRING = "inputNullNonString";
+
+  public static final String CALL = "call";
+  public static final String COLUMNS = "columns";
 
   @CommandLineArgument( name = "export-dir" )
   private String exportDir;
@@ -52,10 +53,11 @@ public class SqoopExportConfig extends SqoopConfig {
   private String clearStagingTable;
   @CommandLineArgument( name = BATCH, flag = true )
   private String batch;
-  @CommandLineArgument( name = "input-null-string" )
-  private String inputNullString;
-  @CommandLineArgument( name = "input-null-non-string" )
-  private String inputNullNonString;
+
+  @CommandLineArgument( name = "call" )
+  private String call;
+  @CommandLineArgument( name = "columns" )
+  private String columns;
 
   public String getExportDir() {
     return exportDir;
@@ -127,23 +129,24 @@ public class SqoopExportConfig extends SqoopConfig {
     pcs.firePropertyChange( BATCH, old, this.batch );
   }
 
-  public String getInputNullString() {
-    return inputNullString;
+  public String getCall() {
+    return call;
   }
 
-  public void setInputNullString( String inputNullString ) {
-    String old = this.inputNullString;
-    this.inputNullString = inputNullString;
-    pcs.firePropertyChange( INPUT_NULL_STRING, old, this.inputNullString );
+  public void setCall( String call ) {
+    String old = this.call;
+    this.call = call;
+    pcs.firePropertyChange( CALL, old, this.call );
   }
 
-  public String getInputNullNonString() {
-    return inputNullNonString;
+  public String getColumns() {
+    return columns;
   }
 
-  public void setInputNullNonString( String inputNullNonString ) {
-    String old = this.inputNullNonString;
-    this.inputNullNonString = inputNullNonString;
-    pcs.firePropertyChange( INPUT_NULL_NON_STRING, old, this.inputNullNonString );
+  public void setColumns( String columns ) {
+    String old = this.columns;
+    this.columns = columns;
+    pcs.firePropertyChange( COLUMNS, old, this.columns );
   }
+
 }

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopImportConfig.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopImportConfig.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -48,8 +48,6 @@ public class SqoopImportConfig extends SqoopConfig {
   public static final String WHERE = "where";
   public static final String COMPRESS = "compress";
   public static final String COMPRESSION_CODEC = "compressionCodec";
-  public static final String NULL_STRING = "nullString";
-  public static final String NULL_NON_STRING = "nullNonString";
 
   // Incremental import arguments
   public static final String CHECK_COLUMN = "checkColumn";
@@ -57,16 +55,12 @@ public class SqoopImportConfig extends SqoopConfig {
   public static final String LAST_VALUE = "lastValue";
 
   // Hive arguments
-  public static final String HIVE_HOME = "hiveHome";
   public static final String HIVE_IMPORT = "hiveImport";
   public static final String HIVE_OVERWRITE = "hiveOverwrite";
   public static final String CREATE_HIVE_TABLE = "createHiveTable";
   public static final String HIVE_TABLE = "hiveTable";
   public static final String HIVE_DROP_IMPORT_DELIMS = "hiveDropImportDelims";
   public static final String HIVE_DELIMS_REPLACEMENT = "hiveDelimsReplacement";
-  public static final String HIVE_PARTITION_KEY = "hivePartitionKey";
-  public static final String HIVE_PARTITION_VALUE = "hivePartitionValue";
-  public static final String MAP_COLUMN_HIVE = "mapColumnHive";
 
   // HBase arguments
   public static final String COLUMN_FAMILY = "columnFamily";
@@ -75,6 +69,30 @@ public class SqoopImportConfig extends SqoopConfig {
   public static final String HBASE_TABLE = "hbaseTable";
   public static final String HBASE_ZOOKEEPER_QUORUM = "hbaseZookeeperQuorum";
   public static final String HBASE_ZOOKEEPER_CLIENT_PORT = "hbaseZookeeperClientPort";
+
+  public static final String AS_PARQUETFILE = "asParquetfile";
+  public static final String DELETE_TARGET_DIR = "deletTargetDir";
+
+  public static final String FETCH_SIZE = "fetchSize";
+  public static final String MERGE_KEY = "mergeKey";
+
+  public static final String HIVE_DATABASE = "hiveDatabase";
+  public static final String HBASE_BULKLOADER = "hbaseBulkload";
+
+  public static final String CREATE_HCATALOG_TABLE = "createHcatalogTable";
+  public static final String HCATALOG_STORAGE_STANZA = "hcatalogStorageStanza";
+
+  public static final String ACCUMULO_BATCH_SIZE = "accumuloBatchSize";
+  public static final String ACCUMULO_COLUMN_FAMILY = "accumuloColumnFamily";
+  public static final String ACCUMULO_CREATE_TABLE = "accumuloCreateTable";
+  public static final String ACCUMULO_INSTANCE = "accumuloInstance";
+  public static final String ACCUMULO_MAX_LATENCY = "accumuloMaxLatency";
+  public static final String ACCUMULO_PASSWORD = "accumuloPassword";
+  public static final String ACCUMULO_ROW_KEY = "accumuloRowKey";
+  public static final String ACCUMULO_TABLE = "accumuloTable";
+  public static final String ACCUMULO_USER = "accumuloUser";
+  public static final String ACCUMULO_VISIBILITY = "accumuloVisibility";
+  public static final String ACCUMULO_ZOOKEPERS = "accumuloZookeepers";
 
   // Import control arguments
   @CommandLineArgument( name = "target-dir" )
@@ -109,10 +127,6 @@ public class SqoopImportConfig extends SqoopConfig {
   private String compress;
   @CommandLineArgument( name = "compression-codec" )
   private String compressionCodec;
-  @CommandLineArgument( name = "null-string" )
-  private String nullString;
-  @CommandLineArgument( name = "null-non-string" )
-  private String nullNonString;
 
   // Incremental import arguments
   @CommandLineArgument( name = "check-column" )
@@ -123,8 +137,6 @@ public class SqoopImportConfig extends SqoopConfig {
   private String lastValue;
 
   // Hive arguments
-  @CommandLineArgument( name = "hive-home" )
-  private String hiveHome;
   @CommandLineArgument( name = "hive-import", flag = true )
   private String hiveImport;
   @CommandLineArgument( name = "hive-overwrite", flag = true )
@@ -137,12 +149,6 @@ public class SqoopImportConfig extends SqoopConfig {
   private String hiveDropImportDelims;
   @CommandLineArgument( name = "hive-delims-replacement" )
   private String hiveDelimsReplacement;
-  @CommandLineArgument( name = "hive-partition-key" )
-  private String hivePartitionKey;
-  @CommandLineArgument( name = "hive-partition-value" )
-  private String hivePartitionValue;
-  @CommandLineArgument( name = "map-column-hive" )
-  private String mapColumnHive;
 
   // HBase arguments
   @CommandLineArgument( name = "column-family" )
@@ -153,6 +159,55 @@ public class SqoopImportConfig extends SqoopConfig {
   private String hbaseRowKey;
   @CommandLineArgument( name = "hbase-table" )
   private String hbaseTable;
+
+  @CommandLineArgument( name = "as-parquetfile", flag = true )
+  private String asParquetfile;
+  @CommandLineArgument( name = "delete-target-dir", flag = true )
+  private String deleteTargetDir;
+
+  @CommandLineArgument( name = "fetch-size" )
+  private String fetchSize;
+  @CommandLineArgument( name = "merge-key" )
+  private String mergeKey;
+
+  @CommandLineArgument( name = "hive-database" )
+  private String hiveDatabase;
+
+  @CommandLineArgument( name = "hbase-bulkload", flag = true )
+  private String hbaseBulkload;
+
+  @CommandLineArgument( name = "create-hcatalog-table", flag = true )
+  private String createHcatalogTable;
+  @CommandLineArgument( name = "hcatalog-storage-stanza" )
+  private String hcatalogStorageStanza;
+
+  @CommandLineArgument( name = "accumulo-batch-size" )
+  private String accumuloBatchSize;
+  @CommandLineArgument( name = "accumulo-column-family" )
+  private String accumuloColumnFamily;
+  @CommandLineArgument( name = "accumulo-create-table", flag = true )
+  private String accumuloCreateTable;
+  @CommandLineArgument( name = "accumulo-instance" )
+  private String accumuloInstance;
+  @CommandLineArgument( name = "accumulo-max-latency" )
+  private String accumuloMaxLatency;
+  @CommandLineArgument( name = "accumulo-password" )
+  private String accumuloPassword;
+  @CommandLineArgument( name = "accumulo-row-key" )
+  private String accumuloRowKey;
+  @CommandLineArgument( name = "accumulo-table" )
+  private String accumuloTable;
+  @CommandLineArgument( name = "accumulo-user" )
+  private String accumuloUser;
+  @CommandLineArgument( name = "accumulo-visibility" )
+  private String accumuloVisibility;
+  @CommandLineArgument( name = "accumulo-zookeepers" )
+  private String accumuloZookeepers;
+
+  @CommandLineArgument( name = "input-null-non-string" )
+  private String inputNullNonString;
+  @CommandLineArgument( name = "input-null-string" )
+  private String inputNullString;
 
   // Non command line arguments for configuring HBase connection information
   private String hbaseZookeeperQuorum;
@@ -318,26 +373,6 @@ public class SqoopImportConfig extends SqoopConfig {
     pcs.firePropertyChange( COMPRESSION_CODEC, old, this.compressionCodec );
   }
 
-  public String getNullString() {
-    return nullString;
-  }
-
-  public void setNullString( String nullString ) {
-    String old = this.nullString;
-    this.nullString = nullString;
-    pcs.firePropertyChange( NULL_STRING, old, this.nullString );
-  }
-
-  public String getNullNonString() {
-    return nullNonString;
-  }
-
-  public void setNullNonString( String nullNonString ) {
-    String old = this.nullNonString;
-    this.nullNonString = nullNonString;
-    pcs.firePropertyChange( NULL_NON_STRING, old, this.nullNonString );
-  }
-
   public String getCheckColumn() {
     return checkColumn;
   }
@@ -366,16 +401,6 @@ public class SqoopImportConfig extends SqoopConfig {
     String old = this.lastValue;
     this.lastValue = lastValue;
     pcs.firePropertyChange( LAST_VALUE, old, this.lastValue );
-  }
-
-  public String getHiveHome() {
-    return hiveHome;
-  }
-
-  public void setHiveHome( String hiveHome ) {
-    String old = this.hiveHome;
-    this.hiveHome = hiveHome;
-    pcs.firePropertyChange( HIVE_HOME, old, this.hiveHome );
   }
 
   public String getHiveImport() {
@@ -436,36 +461,6 @@ public class SqoopImportConfig extends SqoopConfig {
     String old = this.hiveDelimsReplacement;
     this.hiveDelimsReplacement = hiveDelimsReplacement;
     pcs.firePropertyChange( HIVE_DELIMS_REPLACEMENT, old, this.hiveDelimsReplacement );
-  }
-
-  public String getHivePartitionKey() {
-    return hivePartitionKey;
-  }
-
-  public void setHivePartitionKey( String hivePartitionKey ) {
-    String old = this.hivePartitionKey;
-    this.hivePartitionKey = hivePartitionKey;
-    pcs.firePropertyChange( HIVE_PARTITION_KEY, old, this.hivePartitionKey );
-  }
-
-  public String getHivePartitionValue() {
-    return hivePartitionValue;
-  }
-
-  public void setHivePartitionValue( String hivePartitionValue ) {
-    String old = this.hivePartitionValue;
-    this.hivePartitionValue = hivePartitionValue;
-    pcs.firePropertyChange( HIVE_PARTITION_VALUE, old, this.hivePartitionValue );
-  }
-
-  public String getMapColumnHive() {
-    return mapColumnHive;
-  }
-
-  public void setMapColumnHive( String mapColumnHive ) {
-    String old = this.mapColumnHive;
-    this.mapColumnHive = mapColumnHive;
-    pcs.firePropertyChange( MAP_COLUMN_HIVE, old, this.mapColumnHive );
   }
 
   public String getColumnFamily() {
@@ -544,10 +539,12 @@ public class SqoopImportConfig extends SqoopConfig {
 
     try {
       items.add( index, new ArgumentWrapper( HBASE_ZOOKEEPER_QUORUM, BaseMessages.getString( getClass(),
-          "HBaseZookeeperQuorum.Label" ), false, this, getClass().getMethod( "getHbaseZookeeperQuorum" ), getClass()
+          "HBaseZookeeperQuorum.Label" ),
+          false, "", 0, this, getClass().getMethod( "getHbaseZookeeperQuorum" ), getClass()
             .getMethod( "setHbaseZookeeperQuorum", String.class ) ) );
       items.add( index + 1, new ArgumentWrapper( HBASE_ZOOKEEPER_CLIENT_PORT, BaseMessages.getString( getClass(),
-          "HBaseZookeeperClientPort.Label" ), false, this, getClass().getMethod( "getHbaseZookeeperClientPort" ),
+          "HBaseZookeeperClientPort.Label" ),
+          false, "", 0, this, getClass().getMethod( "getHbaseZookeeperClientPort" ),
           getClass().getMethod( "setHbaseZookeeperClientPort", String.class ) ) );
     } catch ( NoSuchMethodException ex ) {
       throw new RuntimeException( ex );
@@ -555,4 +552,195 @@ public class SqoopImportConfig extends SqoopConfig {
 
     return items;
   }
+
+  public String getAsParquetfile() {
+    return asParquetfile;
+  }
+
+  public void setAsParquetfile( String asParquetfile ) {
+    String old = this.asParquetfile;
+    this.asParquetfile = asParquetfile;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getDeleteTargetDir() {
+    return deleteTargetDir;
+  }
+
+  public void setDeleteTargetDir( String deleteTargetDir ) {
+    String old = this.asParquetfile;
+    this.deleteTargetDir = deleteTargetDir;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getFetchSize() {
+    return fetchSize;
+  }
+
+  public void setFetchSize( String fetchSize ) {
+    String old = this.asParquetfile;
+    this.fetchSize = fetchSize;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getMergeKey() {
+    return mergeKey;
+  }
+
+  public void setMergeKey( String mergeKey ) {
+    String old = this.asParquetfile;
+    this.mergeKey = mergeKey;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getHiveDatabase() {
+    return hiveDatabase;
+  }
+
+  public void setHiveDatabase( String hiveDatabase ) {
+    String old = this.asParquetfile;
+    this.hiveDatabase = hiveDatabase;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getHbaseBulkload() {
+    return hbaseBulkload;
+  }
+
+  public void setHbaseBulkload( String hbaseBulkload ) {
+    String old = this.asParquetfile;
+    this.hbaseBulkload = hbaseBulkload;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getCreateHcatalogTable() {
+    return createHcatalogTable;
+  }
+
+  public void setCreateHcatalogTable( String createHcatalogTable ) {
+    String old = this.asParquetfile;
+    this.createHcatalogTable = createHcatalogTable;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getHcatalogStorageStanza() {
+    return hcatalogStorageStanza;
+  }
+
+  public void setHcatalogStorageStanza( String hcatalogStorageStanza ) {
+    String old = this.asParquetfile;
+    this.hcatalogStorageStanza = hcatalogStorageStanza;
+    pcs.firePropertyChange( AS_PARQUETFILE, old, this.asParquetfile );
+  }
+
+  public String getAccumuloBatchSize() {
+    return accumuloBatchSize;
+  }
+
+  public void setAccumuloBatchSize( String accumuloBatchSize ) {
+    String old = this.accumuloBatchSize;
+    this.accumuloBatchSize = accumuloBatchSize;
+    pcs.firePropertyChange( ACCUMULO_BATCH_SIZE, old, this.accumuloBatchSize );
+  }
+
+  public String getAccumuloColumnFamily() {
+    return accumuloColumnFamily;
+  }
+
+  public void setAccumuloColumnFamily( String accumuloColumnFamily ) {
+    String old = this.accumuloColumnFamily;
+    this.accumuloColumnFamily = accumuloColumnFamily;
+    pcs.firePropertyChange( ACCUMULO_COLUMN_FAMILY, old, this.accumuloColumnFamily );
+  }
+
+  public String getAccumuloCreateTable() {
+    return accumuloCreateTable;
+  }
+
+  public void setAccumuloCreateTable( String accumuloCreateTable ) {
+    String old = this.accumuloCreateTable;
+    this.accumuloCreateTable = accumuloCreateTable;
+    pcs.firePropertyChange( ACCUMULO_CREATE_TABLE, old, this.accumuloCreateTable );
+  }
+
+  public String getAccumuloInstance() {
+    return accumuloInstance;
+  }
+
+  public void setAccumuloInstance( String accumuloInstance ) {
+    String old = this.accumuloInstance;
+    this.accumuloInstance = accumuloInstance;
+    pcs.firePropertyChange( ACCUMULO_INSTANCE, old, this.accumuloInstance );
+  }
+
+  public String getAccumuloMaxLatency() {
+    return accumuloMaxLatency;
+  }
+
+  public void setAccumuloMaxLatency( String accumuloMaxLatency ) {
+    String old = this.accumuloMaxLatency;
+    this.accumuloMaxLatency = accumuloMaxLatency;
+    pcs.firePropertyChange( ACCUMULO_MAX_LATENCY, old, this.accumuloMaxLatency );
+  }
+
+  public String getAccumuloPassword() {
+    return accumuloPassword;
+  }
+
+  public void setAccumuloPassword( String accumuloPassword ) {
+    String old = this.accumuloPassword;
+    this.accumuloPassword = accumuloPassword;
+    pcs.firePropertyChange( ACCUMULO_PASSWORD, old, this.accumuloPassword );
+  }
+
+  public String getAccumuloRowKey() {
+    return accumuloRowKey;
+  }
+
+  public void setAccumuloRowKey( String accumuloRowKey ) {
+    String old = this.accumuloRowKey;
+    this.accumuloRowKey = accumuloRowKey;
+    pcs.firePropertyChange( ACCUMULO_ROW_KEY, old, this.accumuloRowKey );
+  }
+
+  public String getAccumuloTable() {
+    return accumuloTable;
+  }
+
+  public void setAccumuloTable( String accumuloTable ) {
+    String old = this.accumuloTable;
+    this.accumuloTable = accumuloTable;
+    pcs.firePropertyChange( ACCUMULO_TABLE, old, this.accumuloTable );
+  }
+
+  public String getAccumuloUser() {
+    return accumuloUser;
+  }
+
+  public void setAccumuloUser( String accumuloUser ) {
+    String old = this.accumuloUser;
+    this.accumuloUser = accumuloUser;
+    pcs.firePropertyChange( ACCUMULO_USER, old, this.accumuloUser );
+  }
+
+  public String getAccumuloVisibility() {
+    return accumuloVisibility;
+  }
+
+  public void setAccumuloVisibility( String accumuloVisibility ) {
+    String old = this.accumuloVisibility;
+    this.accumuloVisibility = accumuloVisibility;
+    pcs.firePropertyChange( ACCUMULO_VISIBILITY, old, this.accumuloVisibility );
+  }
+
+  public String getAccumuloZookeepers() {
+    return accumuloZookeepers;
+  }
+
+  public void setAccumuloZookeepers( String accumuloZookeepers ) {
+    String old = this.accumuloZookeepers;
+    this.accumuloZookeepers = accumuloZookeepers;
+    pcs.firePropertyChange( ACCUMULO_ZOOKEPERS, old, this.accumuloZookeepers );
+  }
+
 }

--- a/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryController.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryController.java
@@ -153,14 +153,14 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
     CHOOSE_AVAILABLE_CLUSTER = new NamedCluster();
     CHOOSE_AVAILABLE_CLUSTER.setName( BaseMessages.getString( AbstractSqoopJobEntry.class,
         "DatabaseName.ChooseAvailable" ) );
-    CHOOSE_AVAILABLE_CLUSTER.setVariable("valid", "false");
+    CHOOSE_AVAILABLE_CLUSTER.setVariable( "valid", "false" );
 
     USE_ADVANCED_OPTIONS_CLUSTER = new NamedCluster();
     USE_ADVANCED_OPTIONS_CLUSTER.setName( BaseMessages.getString( AbstractSqoopJobEntry.class,
         "DatabaseName.UseAdvancedOptions" ) );
-    USE_ADVANCED_OPTIONS_CLUSTER.setVariable("valid", "false");
+    USE_ADVANCED_OPTIONS_CLUSTER.setVariable( "valid", "false" );
     Spoon spoon = Spoon.getInstance();
-    if( spoon != null ) {
+    if ( spoon != null ) {
       ncDelegate = new HadoopClusterDelegate( spoon );
     }
   }
@@ -687,7 +687,9 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
   protected void setUiMode( JobEntryMode mode ) {
     switch ( mode ) {
       case QUICK_SETUP:
-        if ( selectedNamedCluster != null && !this.selectedNamedCluster.equals( USE_ADVANCED_OPTIONS_CLUSTER ) && !suppressEventHandling ) {
+        if ( selectedNamedCluster != null
+          && !this.selectedNamedCluster.equals( USE_ADVANCED_OPTIONS_CLUSTER )
+          && !suppressEventHandling ) {
           config.clearAdvancedNamedConfigurationInfo();
         }
         toggleQuickMode( true );
@@ -732,7 +734,7 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
       }
     } else if ( JobEntryMode.ADVANCED_COMMAND_LINE.equals( newMode ) ) {
       // Sync config properties -> command line
-      getConfig().setCommandLine( SqoopUtils.generateCommandLineString( getConfig(), getJobEntry() ) );
+      getConfig().setCommandLine( SqoopUtils.generateCommandLineString( getConfig(), null ) );
     }
 
     if ( JobEntryMode.ADVANCED_LIST.equals( newMode ) ) {
@@ -770,7 +772,7 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
   protected boolean syncCommandLineToConfig() {
     try {
       // Sync command line -> config properties
-      SqoopUtils.configureFromCommandLine( getConfig(), getConfig().getCommandLine(), getJobEntry() );
+      SqoopUtils.configureFromCommandLine( getConfig(), getConfig().getCommandLine(), null );
       return true;
     } catch ( Exception ex ) {
       showErrorDialog( BaseMessages.getString( AbstractSqoopJobEntry.class, "Dialog.Error" ), BaseMessages.getString(
@@ -876,9 +878,9 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
       if ( null != schemas && schemas.length > 0 ) {
         schemas = Const.sortStrings( schemas );
         EnterSelectionDialog dialog =
-            new EnterSelectionDialog( getShell(), schemas, BaseMessages.getString( AbstractSqoopJobEntry.class,
-                "AvailableSchemas.Title" ), BaseMessages.getString( AbstractSqoopJobEntry.class,
-                "AvailableSchemas.Message" ) );
+          new EnterSelectionDialog( getShell(), schemas,
+              BaseMessages.getString( AbstractSqoopJobEntry.class, "AvailableSchemas.Title" ),
+              BaseMessages.getString( AbstractSqoopJobEntry.class, "AvailableSchemas.Message" ) );
         String schema = dialog.open();
         if ( schema != null ) {
           getConfig().setSchema( schema );
@@ -922,5 +924,5 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
         setSelectedNamedCluster( selectedNamedCluster );
       }
     }
-  }  
+  }
 }

--- a/test-src/org/pentaho/di/job/entries/sqoop/ArgumentWrapperTest.java
+++ b/test-src/org/pentaho/di/job/entries/sqoop/ArgumentWrapperTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -54,9 +54,9 @@ public class ArgumentWrapperTest {
 
   @Test
   public void testEquals() {
-    ArgumentWrapper a = new ArgumentWrapper( "arg", null, false, new SqoopImportConfig(), GETTER, SETTER );
-    ArgumentWrapper b = new ArgumentWrapper( "arg", null, true, new SqoopExportConfig(), GETTER, SETTER );
-    ArgumentWrapper c = new ArgumentWrapper( "arg2", null, true, new SqoopExportConfig(), GETTER, SETTER );
+    ArgumentWrapper a = new ArgumentWrapper( "arg", null, false, "", 0, new SqoopImportConfig(), GETTER, SETTER );
+    ArgumentWrapper b = new ArgumentWrapper( "arg", null, true, "", 0, new SqoopExportConfig(), GETTER, SETTER );
+    ArgumentWrapper c = new ArgumentWrapper( "arg2", null, true, "", 0, new SqoopExportConfig(), GETTER, SETTER );
 
     assertTrue( a.equals( a ) );
     assertTrue( a.equals( b ) );
@@ -67,9 +67,9 @@ public class ArgumentWrapperTest {
 
   @Test
   public void testHashCode() {
-    ArgumentWrapper a = new ArgumentWrapper( "arg", null, false, new SqoopImportConfig(), GETTER, SETTER );
-    ArgumentWrapper b = new ArgumentWrapper( "arg", null, true, new SqoopExportConfig(), GETTER, SETTER );
-    ArgumentWrapper c = new ArgumentWrapper( "arg2", null, true, new SqoopExportConfig(), GETTER, SETTER );
+    ArgumentWrapper a = new ArgumentWrapper( "arg", null, false, "", 0, new SqoopImportConfig(), GETTER, SETTER );
+    ArgumentWrapper b = new ArgumentWrapper( "arg", null, true, "", 0, new SqoopExportConfig(), GETTER, SETTER );
+    ArgumentWrapper c = new ArgumentWrapper( "arg2", null, true, "", 0, new SqoopExportConfig(), GETTER, SETTER );
 
     assertEquals( a.hashCode(), b.hashCode() );
     assertFalse( a.hashCode() == c.hashCode() );
@@ -77,68 +77,72 @@ public class ArgumentWrapperTest {
 
   @Test( expected = NullPointerException.class )
   public void instantiation_null_name() {
-    new ArgumentWrapper( null, "display", false, new SqoopImportConfig(), GETTER, SETTER );
+    new ArgumentWrapper( null, "display", false, "", 0, new SqoopImportConfig(), GETTER, SETTER );
   }
 
   @Test( expected = NullPointerException.class )
   public void instantiation_null_object() {
-    new ArgumentWrapper( "name", "display", false, null, GETTER, SETTER );
+    new ArgumentWrapper( "name", "display", false, "", 0, null, GETTER, SETTER );
   }
 
   @Test( expected = NullPointerException.class )
   public void instantiation_null_setter() {
-    new ArgumentWrapper( "name", "display", false, new SqoopExportConfig(), GETTER, null );
+    new ArgumentWrapper( "name", "display", false, "", 0, new SqoopExportConfig(), GETTER, null );
   }
 
   @Test( expected = NullPointerException.class )
   public void instantiation_null_getter() throws Exception {
-    new ArgumentWrapper( "name", "display", false, new SqoopExportConfig(), null, SETTER );
+    new ArgumentWrapper( "name", "display", false, "", 0, new SqoopExportConfig(), null, SETTER );
   }
 
   @Test( expected = IllegalArgumentException.class )
   public void instantiation_wrong_setter_method_parameters() throws NoSuchMethodException {
     Method m = getClass().getMethod( "instantiation_wrong_setter_method_parameters" );
     assertNotNull( m );
-    new ArgumentWrapper( "name", "display", false, new SqoopExportConfig(), GETTER, m );
+    new ArgumentWrapper( "name", "display", false, "", 0, new SqoopExportConfig(), GETTER, m );
   }
 
   @Test( expected = IllegalArgumentException.class )
   public void instantiation_wrong_setter_method_parameters2() throws NoSuchMethodException {
     Method m = TestInterface.class.getMethod( "testSetter", Boolean.class );
     assertNotNull( m );
-    new ArgumentWrapper( "name", "display", false, new SqoopExportConfig(), GETTER, m );
+    new ArgumentWrapper( "name", "display", false, "", 0, new SqoopExportConfig(), GETTER, m );
   }
 
   @Test( expected = IllegalArgumentException.class )
   public void instantiation_wrong_getter_method_return_type() throws NoSuchMethodException {
     Method m = getClass().getMethod( "instantiation_wrong_getter_method_return_type" );
     assertNotNull( m );
-    new ArgumentWrapper( "name", "display", false, new SqoopExportConfig(), m, SETTER );
+    new ArgumentWrapper( "name", "display", false, "", 0, new SqoopExportConfig(), m, SETTER );
   }
 
   @Test
   public void instantiation() {
     SqoopImportConfig testObj = new SqoopImportConfig();
-    ArgumentWrapper arg1 = new ArgumentWrapper( "name1", "display1", false, testObj, GETTER, SETTER );
-    ArgumentWrapper arg2 = new ArgumentWrapper( "name2", "display2", true, testObj, GETTER, SETTER );
+    ArgumentWrapper arg1 = new ArgumentWrapper( "name1", "display1", false, "--", 50, testObj, GETTER, SETTER );
+    ArgumentWrapper arg2 = new ArgumentWrapper( "name2", "display2", true, "-", 100, testObj, GETTER, SETTER );
 
     assertNotNull( arg1 );
     assertEquals( "name1", arg1.getName() );
     assertEquals( "display1", arg1.getDisplayName() );
     assertFalse( arg1.isFlag() );
     assertNull( arg1.getValue() );
+    assertEquals( "--", arg1.getPrefix() );
+    assertEquals( 50, arg1.getOrder() );
 
     assertNotNull( arg2 );
     assertEquals( "name2", arg2.getName() );
     assertEquals( "display2", arg2.getDisplayName() );
     assertTrue( arg2.isFlag() );
     assertNull( arg2.getValue() );
+    assertEquals( "-", arg2.getPrefix() );
+    assertEquals( 100, arg2.getOrder() );
   }
 
   @Test
   public void setName() {
     SqoopImportConfig testObj = new SqoopImportConfig();
-    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, testObj, GETTER, SETTER );
+    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, "", 0, testObj, GETTER, SETTER );
     arg.setName( "testing" );
     assertEquals( "testing", arg.getName() );
   }
@@ -146,7 +150,7 @@ public class ArgumentWrapperTest {
   @Test
   public void setDisplayName() {
     SqoopImportConfig testObj = new SqoopImportConfig();
-    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, testObj, GETTER, SETTER );
+    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, "", 0, testObj, GETTER, SETTER );
     arg.setDisplayName( "testing" );
     assertEquals( "testing", arg.getDisplayName() );
   }
@@ -156,7 +160,7 @@ public class ArgumentWrapperTest {
     SqoopImportConfig testObj = new SqoopImportConfig();
     PersistentPropertyChangeListener listener = new PersistentPropertyChangeListener();
     testObj.addPropertyChangeListener( FIELD_NAME, listener );
-    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, testObj, GETTER, SETTER );
+    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, "", 0, testObj, GETTER, SETTER );
     assertNull( testObj.getJobEntryName() );
     arg.setValue( "testing" );
     assertEquals( "testing", testObj.getJobEntryName() );
@@ -167,14 +171,14 @@ public class ArgumentWrapperTest {
   public void getValue() {
     SqoopImportConfig testObj = new SqoopImportConfig();
     testObj.setJobEntryName( "testing" );
-    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, testObj, GETTER, SETTER );
+    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, "", 0, testObj, GETTER, SETTER );
     assertEquals( "testing", arg.getValue() );
   }
 
   @Test
   public void setFlag() {
     SqoopImportConfig testObj = new SqoopImportConfig();
-    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, testObj, GETTER, SETTER );
+    ArgumentWrapper arg = new ArgumentWrapper( "name", "display", false, "", 0, testObj, GETTER, SETTER );
     assertFalse( arg.isFlag() );
     arg.setFlag( true );
     assertTrue( arg.isFlag() );

--- a/test-src/org/pentaho/di/job/entries/sqoop/SqoopConfigTest.java
+++ b/test-src/org/pentaho/di/job/entries/sqoop/SqoopConfigTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -81,7 +81,7 @@ public class SqoopConfigTest {
     };
 
     AbstractModelList<ArgumentWrapper> args = config.getAdvancedArgumentsList();
-    assertEquals( 33, args.size() );
+    assertEquals( 59, args.size() );
 
     PersistentPropertyChangeListener l = new PersistentPropertyChangeListener();
     config.addPropertyChangeListener( l );
@@ -94,7 +94,7 @@ public class SqoopConfigTest {
     }
 
     // We should have received one event for every property changed
-    assertEquals( 33, l.getReceivedEvents().size() );
+    assertEquals( 59, l.getReceivedEvents().size() );
   }
 
   @Test

--- a/test-src/org/pentaho/di/job/entries/sqoop/SqoopImportConfigTest.java
+++ b/test-src/org/pentaho/di/job/entries/sqoop/SqoopImportConfigTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -41,16 +41,16 @@ public class SqoopImportConfigTest {
     Method dummyGetter = getClass().getMethod( "toString" );
     Method dummySetter = SqoopImportConfig.class.getMethod( "setHbaseZookeeperQuorum", String.class );
     ArgumentWrapper hbaseZookeeperQuorum =
-        new ArgumentWrapper( SqoopImportConfig.HBASE_ZOOKEEPER_QUORUM, null, false, this, dummyGetter, dummySetter );
+        new ArgumentWrapper( SqoopImportConfig.HBASE_ZOOKEEPER_QUORUM, null, false, "--", 0, this, dummyGetter, dummySetter );
     ArgumentWrapper hbaseZookeeperClientPort =
-        new ArgumentWrapper( SqoopImportConfig.HBASE_ZOOKEEPER_CLIENT_PORT, null, false, this, dummyGetter, dummySetter );
+        new ArgumentWrapper( SqoopImportConfig.HBASE_ZOOKEEPER_CLIENT_PORT, null, false, "--", 0, this, dummyGetter, dummySetter );
 
     AbstractModelList<ArgumentWrapper> items = c.getAdvancedArgumentsList();
-    assertEquals( 70, items.size() );
+    assertEquals( 109, items.size() );
     int indexOf = items.indexOf( hbaseZookeeperQuorum );
-    assertEquals( "Expected to find HBase Zookeeper Quorum property grouped with others", 35, indexOf );
+    assertEquals( "Expected to find HBase Zookeeper Quorum property grouped with others", 46, indexOf );
     indexOf = items.indexOf( hbaseZookeeperClientPort );
-    assertEquals( "Expected to find HBase Zookeeper Client Port grouped with others", 36, indexOf );
+    assertEquals( "Expected to find HBase Zookeeper Client Port grouped with others", 47, indexOf );
 
   }
 

--- a/test-src/org/pentaho/di/trans/steps/hadoopexit/HadoopExitMetaTest.java
+++ b/test-src/org/pentaho/di/trans/steps/hadoopexit/HadoopExitMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -69,9 +69,9 @@ public class HadoopExitMetaTest {
       meta.getFields( rowMeta, null, null, null, null );
       fail( "expected exception" );
     } catch ( Exception ex ) {
-      assertEquals( "\n"
-          + BaseMessages.getString( HadoopExitMeta.class, "Error.InvalidKeyField", meta.getOutKeyFieldname() ) + "\n",
-          ex.getMessage() );
+      assertEquals(
+          BaseMessages.getString( HadoopExitMeta.class, "Error.InvalidKeyField", meta.getOutKeyFieldname() ).trim(),
+          ex.getMessage().trim() );
     }
 
     // Check that the meta was not modified
@@ -98,9 +98,9 @@ public class HadoopExitMetaTest {
       meta.getFields( rowMeta, null, null, null, null );
       fail( "expected exception" );
     } catch ( Exception ex ) {
-      assertEquals( "\n"
-          + BaseMessages.getString( HadoopExitMeta.class, "Error.InvalidValueField", meta.getOutValueFieldname() )
-          + "\n", ex.getMessage() );
+      assertEquals(
+          BaseMessages.getString( HadoopExitMeta.class, "Error.InvalidValueField", meta.getOutValueFieldname() ).trim(),
+          ex.getMessage().trim() );
     }
 
     // Check that the meta was not modified


### PR DESCRIPTION
1. Added a number of new parameters previously not supported by Kettle
2. Parameters were regrouped (those common for both import and export were moved to SqoopConfig)
3. Added support for single-dash params (Hadoop generic arguments for sqoop)
4. Added support for ordering parameters:
	- to provide order on UI
	- to make sure Hadoop single-dashed params are always specified before Sqoop specific ones
5. unit tests
6. check style
7. license header (copyright year - 2015)

@mattyb149 @brosander please ...