### PR TITLE
[SP-1830][TEST] - PMR: Bad Results in Group-By if an entire key is filtered earlier

### DIFF
--- a/samples/jobs/hadoop/Pentaho MapReduce - weblogs.kjb
+++ b/samples/jobs/hadoop/Pentaho MapReduce - weblogs.kjb
@@ -47,11 +47,12 @@
       <combiner_trans_repo_file/>
       <combiner_trans_repo_reference/>
       <combiner_trans/>
+      <combiner_single_threaded>N</combiner_single_threaded>
       <reduce_trans_repo_dir/>
       <reduce_trans_repo_file/>
       <reduce_trans_repo_reference/>
       <reduce_trans>${Internal.Job.Filename.Directory}&#47;weblogs-reducer.ktr</reduce_trans>
-      <reduce_single_threaded>Y</reduce_single_threaded>
+      <reduce_single_threaded>N</reduce_single_threaded>
       <map_input_step_name>Hadoop Input</map_input_step_name>
       <map_output_step_name>Hadoop Output</map_output_step_name>
       <combiner_input_step_name/>

--- a/samples/jobs/hadoop/Pentaho MapReduce - wordcount.kjb
+++ b/samples/jobs/hadoop/Pentaho MapReduce - wordcount.kjb
@@ -47,11 +47,12 @@
       <combiner_trans_repo_file/>
       <combiner_trans_repo_reference/>
       <combiner_trans/>
+      <combiner_single_threaded>N</combiner_single_threaded>
       <reduce_trans_repo_dir/>
       <reduce_trans_repo_file/>
       <reduce_trans_repo_reference/>
       <reduce_trans>${Internal.Job.Filename.Directory}&#47;wordcount-reducer.ktr</reduce_trans>
-      <reduce_single_threaded>Y</reduce_single_threaded>
+      <reduce_single_threaded>N</reduce_single_threaded>
       <map_input_step_name>Hadoop Input</map_input_step_name>
       <map_output_step_name>Hadoop Output</map_output_step_name>
       <combiner_input_step_name/>


### PR DESCRIPTION
* Deleted unit test. Was discussed in http://jira.pentaho.com/browse/PDI-12749 and resulted to forbid using "GroupBy" step in singleThreaded mode.