### PR TITLE
[BACKLOG-3242] - Sqoop Import/Export jobs are failing on DI Server

### DIFF
--- a/src/org/pentaho/di/job/entries/sqoop/AbstractSqoopJobEntry.java
+++ b/src/org/pentaho/di/job/entries/sqoop/AbstractSqoopJobEntry.java
@@ -39,6 +39,7 @@ import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.hadoop.HadoopConfigurationBootstrap;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.namedcluster.NamedClusterManager;
 import org.pentaho.di.core.namedcluster.model.NamedCluster;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.i18n.BaseMessages;
@@ -49,12 +50,12 @@ import org.pentaho.di.job.LoggingProxy;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
-import org.pentaho.di.ui.core.namedcluster.NamedClusterUIHelper;
 import org.pentaho.hadoop.shim.ConfigurationException;
 import org.pentaho.hadoop.shim.HadoopConfiguration;
 import org.pentaho.hadoop.shim.api.Configuration;
 import org.pentaho.hadoop.shim.spi.HadoopShim;
 import org.pentaho.hadoop.shim.spi.SqoopShim;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.w3c.dom.Node;
 
 /**
@@ -113,9 +114,9 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
   protected final S createJobConfig() {
     S config = buildSqoopConfig();
     try {
-      HadoopShim shim =
-          HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration().getHadoopShim();
+      HadoopShim shim = getActiveHadoopConfiguration().getHadoopShim();
       Configuration hadoopConfig = shim.createConfiguration();
+      loadNamedCluster( config );
       SqoopUtils.configureConnectionInformation( config, shim, hadoopConfig );
     } catch ( Exception ex ) {
       // Error loading connection information from Hadoop Configuration. Just log the error and leave the configuration
@@ -247,8 +248,7 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
   @Override
   protected Runnable getExecutionRunnable( final Result jobResult ) throws KettleException {
     try {
-      HadoopConfiguration activeConfig =
-          HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration();
+      HadoopConfiguration activeConfig = getActiveHadoopConfiguration();
       final HadoopShim hadoopShim = activeConfig.getHadoopShim();
       final SqoopShim sqoopShim = activeConfig.getSqoopShim();
 
@@ -346,9 +346,8 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
     try {
       List<String> messages = new ArrayList<String>();
 
-      String clusterName = sqoopConfig.getClusterName();
-      if ( clusterName != null ) {
-        NamedCluster nc = NamedClusterUIHelper.getNamedCluster( clusterName );
+      NamedCluster nc = loadNamedCluster( sqoopConfig );
+      if ( nc != null ) {
         if ( nc.isMapr() ) {
           shim.configureConnectionInformation( "", "", "", "", conf, messages );
         } else {
@@ -383,5 +382,23 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
   public boolean isDatabaseSupported( Class<? extends DatabaseInterface> databaseType ) {
     // For now all database types are supported
     return true;
+  }
+
+  NamedCluster loadNamedCluster( S config ) {
+    if ( rep != null && !Const.isEmpty( config.getClusterName() ) ) {
+      try {
+        config.setNamedCluster( NamedClusterManager.getInstance().read( config.getClusterName(), rep.getMetaStore() ) );
+      } catch ( MetaStoreException e ) {
+        logError( BaseMessages.getString(
+            AbstractSqoopJobEntry.class, "ErrorLoadNamedCluster", config.getClusterName() ),
+            e );
+      }
+    }
+
+    return config.getNamedCluster();
+  }
+
+  protected HadoopConfiguration getActiveHadoopConfiguration() throws ConfigurationException {
+    return HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration();
   }
 }

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopConfig.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopConfig.java
@@ -29,8 +29,6 @@ import org.pentaho.di.job.BlockableJobConfig;
 import org.pentaho.di.job.CommandLineArgument;
 import org.pentaho.di.job.JobEntryMode;
 import org.pentaho.di.job.Password;
-import org.pentaho.di.ui.core.namedcluster.NamedClusterUIHelper;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.ui.xul.XulEventSource;
 import org.pentaho.ui.xul.util.AbstractModelList;
 
@@ -263,6 +261,8 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
 
   private String clusterName;
 
+  private NamedCluster namedCluster;
+
   /**
    * @return all known arguments for this config object. Some arguments may be synthetic and represent properties
    *         directly set on this config object for the purpose of showing them in the list view of the UI.
@@ -300,15 +300,11 @@ public abstract class SqoopConfig extends BlockableJobConfig implements XulEvent
   }
 
   public NamedCluster getNamedCluster() {
-    NamedCluster namedCluster = null;
-    try {
-      if ( clusterName != null ) {
-        namedCluster = NamedClusterUIHelper.getNamedCluster( clusterName );
-      }
-    } catch ( MetaStoreException ex ) {
-      throw new RuntimeException( ex );
-    }
     return namedCluster;
+  }
+
+  public void setNamedCluster( NamedCluster namedCluster ) {
+    this.namedCluster = namedCluster;
   }
 
   public void clearAdvancedNamedConfigurationInfo() {

--- a/src/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
+++ b/src/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
@@ -38,17 +38,14 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.namedcluster.model.NamedCluster;
 import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.ArgumentWrapper;
 import org.pentaho.di.job.CommandLineArgument;
 import org.pentaho.di.job.JobEntryMode;
-import org.pentaho.di.ui.core.namedcluster.NamedClusterUIHelper;
 import org.pentaho.hadoop.shim.api.Configuration;
 import org.pentaho.hadoop.shim.spi.HadoopShim;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
 
 /**
  * Collection of utility methods used to support integration with Apache Sqoop.
@@ -82,32 +79,24 @@ public class SqoopUtils {
    *          Hadoop configuration to parse connection information from
    */
   public static void configureConnectionInformation( SqoopConfig config, HadoopShim shim, Configuration c ) {
-
-    try {
-      String clusterName = config.getClusterName();
-      NamedCluster nc = NamedClusterUIHelper.getNamedCluster( clusterName );
-
-      String[] namenodeInfo = shim.getNamenodeConnectionInfo( c );
-      if ( namenodeInfo != null ) {
-        if ( namenodeInfo[0] != null ) {
-          nc.setHdfsHost( namenodeInfo[0] );
-        }
-        if ( !"-1".equals( namenodeInfo[1] ) ) {
-          nc.setHdfsPort( namenodeInfo[1] );
-        }
+    String[] namenodeInfo = shim.getNamenodeConnectionInfo( c );
+    if ( namenodeInfo != null ) {
+      if ( namenodeInfo[0] != null ) {
+        config.setNamenodeHost( namenodeInfo[0] );
       }
-
-      String[] jobtrackerInfo = shim.getJobtrackerConnectionInfo( c );
-      if ( jobtrackerInfo != null ) {
-        if ( jobtrackerInfo[0] != null ) {
-          nc.setJobTrackerHost( jobtrackerInfo[0] );
-        }
-        if ( jobtrackerInfo[1] != null ) {
-          nc.setJobTrackerPort( jobtrackerInfo[1] );
-        }
+      if ( !"-1".equals( namenodeInfo[1] ) ) {
+        config.setNamenodePort( namenodeInfo[1] );
       }
-    } catch ( MetaStoreException e ) {
-      // ignore
+    }
+
+    String[] jobtrackerInfo = shim.getJobtrackerConnectionInfo( c );
+    if ( jobtrackerInfo != null ) {
+      if ( jobtrackerInfo[0] != null ) {
+        config.setJobtrackerHost( jobtrackerInfo[0] );
+      }
+      if ( jobtrackerInfo[1] != null ) {
+        config.setJobtrackerPort( jobtrackerInfo[1] );
+      }
     }
   }
 

--- a/src/org/pentaho/di/job/entries/sqoop/messages/messages_en_US.properties
+++ b/src/org/pentaho/di/job/entries/sqoop/messages/messages_en_US.properties
@@ -66,6 +66,7 @@ ErrorConfiguringFromCommandLine=Error configuring from command line. Please fix 
 ErrorUnknownArguments=Unknown argument(s): {0}
 ErrorMustConfigureDatabaseConnectionFromList=Cannot perform this operation when the database connection information is provided via Advanced Options.
 ErrorProhibitedEmptyString="{0}" is not allowed to be initialized with an empty string.
+ErrorLoadNamedCluster=Failed to load named cluster "{0}". Falling back to one stored within the job.
 
 AvailableSchemas.Title=Available schemas
 AvailableSchemas.Message=Please select a schema name

--- a/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryController.java
+++ b/src/org/pentaho/di/ui/job/entries/sqoop/AbstractSqoopJobEntryController.java
@@ -142,10 +142,12 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
    * @param bindingFactory
    *          Binding factory to generate bindings
    */
+  @SuppressWarnings( "unchecked" )
   public AbstractSqoopJobEntryController( JobMeta jobMeta, XulDomContainer container, E jobEntry,
       BindingFactory bindingFactory ) {
     super( jobMeta, container, jobEntry, bindingFactory );
     this.config = (S) jobEntry.getJobConfig().clone();
+
     this.advancedArguments = new AbstractModelList<ArgumentWrapper>();
     this.databaseConnections = new AbstractModelList<DatabaseItem>();
     this.namedClusters = new AbstractModelList<NamedCluster>();
@@ -269,13 +271,13 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
     if ( !suppressEventHandling ) {
       if ( namedCluster != null && !namedCluster.equals( CHOOSE_AVAILABLE_CLUSTER )
           && !namedCluster.equals( USE_ADVANCED_OPTIONS_CLUSTER ) ) {
-        config.setClusterName( namedCluster.getName() );
+        setClusterToConfig( namedCluster, config );
         config.clearAdvancedNamedConfigurationInfo();
       } else if ( namedCluster != null && namedCluster.equals( CHOOSE_AVAILABLE_CLUSTER ) ) {
-        config.setClusterName( null );
+        setClusterToConfig( null, config );
         config.clearAdvancedNamedConfigurationInfo();
       } else {
-        config.setClusterName( null );
+        setClusterToConfig( null, config );
       }
 
       suppressEventHandling = true;
@@ -285,6 +287,15 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
         suppressEventHandling = false;
       }
     }
+  }
+
+  private void setClusterToConfig( NamedCluster namedCluster, SqoopConfig config ) {
+    String name = null;
+    if ( namedCluster != null ) {
+      name = namedCluster.getName();
+    }
+    config.setClusterName( name );
+    config.setNamedCluster( namedCluster );
   }
 
   public boolean isSelectedNamedCluster() {
@@ -377,6 +388,7 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
     }
   }
 
+
   public void setAdvancedNamedConfiguration( String value ) {
     if ( !suppressEventHandling ) {
       if ( value != null ) {
@@ -437,7 +449,6 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
    */
   public void setSelectedDatabaseConnection( DatabaseItem selectedDatabaseConnection ) {
     if ( !suppressEventHandling ) {
-      DatabaseItem old = this.selectedDatabaseConnection;
       this.selectedDatabaseConnection = selectedDatabaseConnection;
       DatabaseMeta databaseMeta =
           this.selectedDatabaseConnection == null ? null : jobMeta.findDatabase( this.selectedDatabaseConnection

--- a/test-src/org/pentaho/di/job/entries/sqoop/AbstractSqoopJobEntryTest.java
+++ b/test-src/org/pentaho/di/job/entries/sqoop/AbstractSqoopJobEntryTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,12 +41,19 @@ import org.pentaho.di.core.database.HiveDatabaseMeta;
 import org.pentaho.di.core.database.MySQLDatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.namedcluster.NamedClusterManager;
+import org.pentaho.di.core.namedcluster.model.NamedCluster;
 import org.pentaho.di.job.Job;
 import org.pentaho.di.job.JobEntryMode;
 import org.pentaho.di.job.JobMeta;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.hadoop.shim.ConfigurationException;
+import org.pentaho.hadoop.shim.HadoopConfiguration;
 import org.pentaho.hadoop.shim.api.Configuration;
 import org.pentaho.hadoop.shim.spi.HadoopShim;
 import org.pentaho.hadoop.shim.spi.SqoopShim;
+import org.pentaho.metastore.api.IMetaStore;
+import org.pentaho.metastore.stores.memory.MemoryMetaStore;
 
 public class AbstractSqoopJobEntryTest {
   private LogChannelInterface mockLogChannelInterface;
@@ -293,5 +301,75 @@ public class AbstractSqoopJobEntryTest {
     assertEquals( "uri should be as DBMeta in QUICK_SETUP mode",      URI + SUFFIX, conf.getConnect() );
     assertEquals( "user should be as DBMeta in QUICK_SETUP mode",     USER + SUFFIX, conf.getUsername() );
     assertEquals( "password should be as DBMeta in QUICK_SETUP mode", PASSWORD + SUFFIX, conf.getPassword() );
+  }
+
+  @Test
+  public void createJobConfigTest() throws Exception {
+    final String NNH = "nameNodeHost";
+    final String NNP = "8020";
+    final String JTH = "jobTrackerHost";
+    final String JTP = "8232";
+
+    final HadoopShim shim = mock( HadoopShim.class );
+    when( shim.getNamenodeConnectionInfo( any( Configuration.class ) ) )
+      .thenReturn( new String[] { NNH, NNP } );
+    when( shim.getJobtrackerConnectionInfo( any( Configuration.class ) ) )
+      .thenReturn( new String[] { JTH, JTP } );
+
+    final HadoopConfiguration hc = mock(HadoopConfiguration.class );
+    when( hc.getHadoopShim( ) ).thenReturn( shim );
+
+    AbstractSqoopJobEntry<SqoopConfig> jobEntry = new TestSqoopJobEntry( 10, mockLogChannelInterface ) {
+      @Override
+      protected HadoopConfiguration getActiveHadoopConfiguration() throws ConfigurationException {
+        return hc;
+      }
+    };
+
+    SqoopConfig config = jobEntry.createJobConfig();
+
+    assertEquals( "name-node-host check failed", NNH, config.getNamenodeHost() );
+    assertEquals( "name-node-port check failed", NNP, config.getNamenodePort() );
+
+    assertEquals( "job-tracker-host check failed", JTH, config.getJobtrackerHost() );
+    assertEquals( "job-tracker-port check failed", JTP, config.getJobtrackerPort() );
+  }
+
+  @Test
+  public void loadNamedClusterTest_no_rep() throws Exception {
+    AbstractSqoopJobEntry<SqoopConfig> jobEntry = new TestSqoopJobEntry( 10, mockLogChannelInterface );
+    NamedCluster nc = new NamedCluster();
+    SqoopConfig config = new SqoopConfig() { };
+    config.setNamedCluster( nc );
+
+    NamedCluster res = jobEntry.loadNamedCluster( config );
+
+    assertEquals( "if rep is not set the internally saved NC should be returned", nc, res );
+  }
+
+  @Test
+  public void loadNamedClusterTest_with_rep() throws Exception {
+    final String NAME = "special_name_for named cluster";
+
+    NamedCluster nc = new NamedCluster();
+    nc.setName( NAME );
+    IMetaStore ms = new MemoryMetaStore();
+    NamedClusterManager.getInstance().create( nc, ms );
+
+    nc.setName( "this is another name to distiguish from one saved in the rep" );
+
+    Repository rep = mock( Repository.class );
+    when( rep.getMetaStore() ).thenReturn( ms );
+
+    SqoopConfig config = new SqoopConfig() { };
+    config.setNamedCluster( nc );
+    config.setClusterName( NAME );
+
+    AbstractSqoopJobEntry<SqoopConfig> jobEntry = new TestSqoopJobEntry( 10, mockLogChannelInterface );
+    jobEntry.setRepository( rep );
+
+    NamedCluster res = jobEntry.loadNamedCluster( config );
+
+    assertEquals( "if rep is set the NC from the rep should be returned", NAME, res.getName() );
   }
 }


### PR DESCRIPTION
the cause of the issue it that Spoon.getInstance().getMetaStore() is used what would apparently not work in environment other than Spoon (DI/BA Server, PMR etc.)
Alternative approach has been implemented similar to user BigData JobEntries:
store NamedCluster within the Job and use this if repository (MetaStore) is not available.

The only drawback: the Sqoop Entries stored after the NamedCluster had been incorporated should be re-saved in Spoon.

@mdamour1976 @e-cuellar @mattyb149 @brosander @deinspanjer please - take a look