### PR TITLE
[BACKLOG-3560] - REG:Hadoop File Input fails to read from S3 storage - MASTER

### DIFF
--- a/src/org/pentaho/di/ui/trans/steps/hadoopfileinput/HadoopFileInputDialog.java
+++ b/src/org/pentaho/di/ui/trans/steps/hadoopfileinput/HadoopFileInputDialog.java
@@ -1441,7 +1441,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
         VfsFileChooserDialog fileChooserDialog = Spoon.getInstance().getVfsFileChooserDialog( rootFile, initialFile );
         fileChooserDialog.defaultInitialFile = defaultInitialFile;
         FileObject selectedFile =
-            fileChooserDialog.open( shell, null, HadoopSpoonPlugin.HDFS_SCHEME, true, null, new String[] { "*.*" },
+            fileChooserDialog.open( shell, null, HadoopSpoonPlugin.HDFS_SCHEME, false, null, new String[] { "*.*" },
                 ALL_FILES_TYPE, VfsFileChooserDialog.VFS_DIALOG_OPEN_DIRECTORY );
         if ( selectedFile != null ) {
           if ( !selectedFile.getType().equals( FileType.FOLDER ) ) {
@@ -2015,7 +2015,9 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
               clusterName.startsWith( HadoopFileInputMeta.STATIC_SOURCE_FILE ) ? STATIC_ENVIRONMENT : clusterName;
           clusterName = clusterName.startsWith( HadoopFileInputMeta.S3_SOURCE_FILE ) ? S3_ENVIRONMENT : clusterName;
           sourceUrl =
-              clusterName.equals( LOCAL_ENVIRONMENT ) || clusterName.equals( STATIC_ENVIRONMENT ) ? sourceUrl
+              clusterName.equals( LOCAL_ENVIRONMENT ) ||
+              clusterName.equals( STATIC_ENVIRONMENT ) ||
+              clusterName.equals( S3_ENVIRONMENT ) ? sourceUrl
                   : hadoopFileInputMeta.getUrlPath( sourceUrl );
         }
 
@@ -2969,11 +2971,11 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
           if ( clusterName.equals( LOCAL_ENVIRONMENT ) ) {
             selectedFile =
                 fileChooserDialog.open( shell, new String[] { "file" }, "file", true, path, fileFilters,
-                    fileFilterNames, true, VfsFileChooserDialog.VFS_DIALOG_OPEN_FILE_OR_DIRECTORY, false, false );
+                    fileFilterNames, false, VfsFileChooserDialog.VFS_DIALOG_OPEN_FILE_OR_DIRECTORY, false, false );
           } else if ( clusterName.equals( S3_ENVIRONMENT ) ) {
             selectedFile =
                 fileChooserDialog.open( shell, new String[] { S3FileProvider.SCHEME }, S3FileProvider.SCHEME, true,
-                    path, fileFilters, fileFilterNames, true, VfsFileChooserDialog.VFS_DIALOG_OPEN_FILE_OR_DIRECTORY,
+                    path, fileFilters, fileFilterNames, false, VfsFileChooserDialog.VFS_DIALOG_OPEN_FILE_OR_DIRECTORY,
                     false, true );
           } else {
             NamedCluster namedCluster =
@@ -2982,7 +2984,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
               if ( namedCluster.isMapr() ) {
                 selectedFile =
                     fileChooserDialog.open( shell, new String[] { HadoopSpoonPlugin.MAPRFS_SCHEME },
-                        HadoopSpoonPlugin.MAPRFS_SCHEME, true, path, fileFilters, fileFilterNames, true,
+                        HadoopSpoonPlugin.MAPRFS_SCHEME, true, path, fileFilters, fileFilterNames, false,
                         VfsFileChooserDialog.VFS_DIALOG_OPEN_FILE_OR_DIRECTORY, false, false );
               } else {
                 List<CustomVfsUiPanel> customPanels = fileChooserDialog.getCustomVfsUiPanels();
@@ -3000,7 +3002,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
                 }
                 selectedFile =
                     fileChooserDialog.open( shell, new String[] { HadoopSpoonPlugin.HDFS_SCHEME },
-                        HadoopSpoonPlugin.HDFS_SCHEME, true, path, fileFilters, fileFilterNames, true,
+                        HadoopSpoonPlugin.HDFS_SCHEME, false, path, fileFilters, fileFilterNames, true,
                         VfsFileChooserDialog.VFS_DIALOG_OPEN_FILE_OR_DIRECTORY, false, false );
               }
 


### PR DESCRIPTION
forward-port of https://github.com/pentaho/big-data-plugin/pull/394 to master

1. make creds be saved along with S3 URL (the same as for BACKLOG-3474)
2. do not cut out S3 scheme while filling in input-file-grid

@kcruzada @e-cuellar 