### PR TITLE
[PDI-8560] Table Input does not work with lazy conversion when querying Hive: Method not supported

### DIFF
--- a/src/org/pentaho/di/core/database/Hive2DatabaseMeta.java
+++ b/src/org/pentaho/di/core/database/Hive2DatabaseMeta.java
@@ -302,4 +302,9 @@ public class Hive2DatabaseMeta extends BaseDatabaseMeta implements DatabaseInter
   public boolean supportsTimeStampToDateConversion() {
     return false;
   }
+
+  @Override
+  public boolean supportsLazyConversion() {
+    return false;
+  }
 }


### PR DESCRIPTION
It must be merge with pentaho/pentaho-kettle#1423