### PR TITLE
[BAD-312] - Support for HBase 1.0

### DIFF
--- a/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseinput/HBaseInput.java
+++ b/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseinput/HBaseInput.java
@@ -242,6 +242,7 @@ public class HBaseInput extends BaseStep implements StepInterface {
     if ( !hasNext ) {
       try {
         m_hbAdmin.closeSourceTable();
+        m_hbAdmin.close();
       } catch ( Exception e ) {
         throw new KettleException( BaseMessages.getString( HBaseInputMeta.PKG,
             "HBaseInput.Error.ProblemClosingConnection", e.getMessage() ), e );
@@ -252,7 +253,7 @@ public class HBaseInput extends BaseStep implements StepInterface {
 
     if ( m_tableMapping.isTupleMapping() ) {
       List<Object[]> tupleRows =
-          m_data.getTupleOutputRows( m_hbAdmin, m_userOutputColumns, m_columnsMappedByAlias, m_tableMapping,
+          HBaseInputData.getTupleOutputRows( m_hbAdmin, m_userOutputColumns, m_columnsMappedByAlias, m_tableMapping,
               m_tupleHandler, m_data.getOutputRowMeta(), m_bytesUtil );
 
       for ( Object[] tuple : tupleRows ) {
@@ -261,7 +262,7 @@ public class HBaseInput extends BaseStep implements StepInterface {
       return true;
     } else {
       Object[] outRowData =
-          m_data.getOutputRow( m_hbAdmin, m_userOutputColumns, m_columnsMappedByAlias, m_tableMapping, m_data
+          HBaseInputData.getOutputRow( m_hbAdmin, m_userOutputColumns, m_columnsMappedByAlias, m_tableMapping, m_data
               .getOutputRowMeta(), m_bytesUtil );
       putRow( m_data.getOutputRowMeta(), outRowData );
       return true;
@@ -284,9 +285,9 @@ public class HBaseInput extends BaseStep implements StepInterface {
       logBasic( BaseMessages.getString( HBaseInputMeta.PKG, "HBaseInput.ClosingConnection" ) );
       try {
         m_hbAdmin.closeSourceTable();
+        m_hbAdmin.close();
       } catch ( Exception ex ) {
-        logError( BaseMessages.getString( HBaseInputMeta.PKG, "HBaseInput.Error.ProblemClosingConnection1", ex
-            .getMessage() ) );
+        logError( BaseMessages.getString( HBaseInputMeta.PKG, "HBaseInput.Error.ProblemClosingConnection1", ex ) );
       }
     }
   }

--- a/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseinput/HBaseInputMeta.java
+++ b/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseinput/HBaseInputMeta.java
@@ -78,7 +78,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /** NamedCluster name to pull zookeeper hosts/port from */
   protected String clusterName;
-  
+
   /** comma separated list of hosts that the zookeeper quorum is running on */
   protected String m_zookeeperHosts;
 
@@ -167,8 +167,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
    */
   public void setClusterName( String clusterName ) {
     this.clusterName = clusterName;
-  }  
-  
+  }
+
   /**
    * Set the list of hosts that the zookeeper quorum is running on. Either this OR the hbase-site.xml (and optionally
    * hbase-default.xml) can be used to establish a connection.
@@ -426,7 +426,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
     return vals.toString();
   }
-  
+
   private void loadClusterConfig( ObjectId id_jobentry, Repository rep, Node entrynode ) {
     boolean configLoaded = false;
     try {
@@ -435,23 +435,23 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
         setClusterName( XMLHandler.getTagValue( entrynode, "cluster_name" ) ); //$NON-NLS-1$
       } else if ( rep != null ) {
         setClusterName( rep.getJobEntryAttributeString( id_jobentry, "cluster_name" ) ); //$NON-NLS-1$ //$NON-NLS-2$
-      } 
+      }
 
       // load from system first, then fall back to copy stored with job (AbstractMeta)
       NamedCluster nc = null;
-      if ( rep != null && !StringUtils.isEmpty( getClusterName() ) && 
-          NamedClusterManager.getInstance().contains( getClusterName(), rep.getMetaStore() ) ) {
+      if ( rep != null && !StringUtils.isEmpty( getClusterName() )
+          && NamedClusterManager.getInstance().contains( getClusterName(), rep.getMetaStore() ) ) {
         // pull config from NamedCluster
         nc = NamedClusterManager.getInstance().read( getClusterName(), rep.getMetaStore() );
       }
       if ( nc != null ) {
         setZookeeperHosts( nc.getZooKeeperHost() );
         setZookeeperPort( nc.getZooKeeperPort() );
-        configLoaded = true;        
+        configLoaded = true;
       }
     } catch ( Throwable t ) {
       logDebug( t.getMessage(), t );
-    }    
+    }
 
     if ( !configLoaded ) {
       if ( entrynode != null ) {
@@ -465,19 +465,19 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
           setZookeeperPort( rep.getJobEntryAttributeString( id_jobentry, "zookeeper_port" ) ); //$NON-NLS-1$
         } catch ( KettleException ke ) {
           logError( ke.getMessage(), ke );
-        } 
+        }
       }
     }
-  }    
-  
+  }
+
   @Override
   public String getXML() {
     StringBuffer retval = new StringBuffer();
 
     retval.append( "\n    " ).append( XMLHandler.addTagValue( "cluster_name", clusterName ) ); //$NON-NLS-1$ //$NON-NLS-2$
     try {
-      if ( repository != null && !StringUtils.isEmpty( getClusterName() ) && 
-          NamedClusterManager.getInstance().contains( getClusterName(), repository.getMetaStore() ) ) {
+      if ( repository != null && !StringUtils.isEmpty( getClusterName() )
+          && NamedClusterManager.getInstance().contains( getClusterName(), repository.getMetaStore() ) ) {
         // pull config from NamedCluster
         NamedCluster nc = NamedClusterManager.getInstance().read( getClusterName(), repository.getMetaStore() );
         setZookeeperHosts( nc.getZooKeeperHost() );
@@ -485,8 +485,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
       }
     } catch ( MetaStoreException e ) {
       logDebug( e.getMessage(), e );
-    }  
-    
+    }
+
     if ( !Const.isEmpty( m_zookeeperHosts ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "zookeeper_hosts", m_zookeeperHosts ) );
     }
@@ -561,7 +561,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     throws KettleXMLException {
 
     loadClusterConfig( null, repository, stepnode );
-    
+
     m_coreConfigURL = XMLHandler.getTagValue( stepnode, "core_config_url" );
     m_defaultConfigURL = XMLHandler.getTagValue( stepnode, "default_config_url" );
     m_sourceTableName = XMLHandler.getTagValue( stepnode, "source_table_name" );
@@ -649,8 +649,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
     rep.saveStepAttribute( id_transformation, getObjectId(), "cluster_name", clusterName ); //$NON-NLS-1$
     try {
-      if ( !StringUtils.isEmpty( getClusterName() ) && 
-          NamedClusterManager.getInstance().contains( getClusterName(), rep.getMetaStore() ) ) {
+      if ( !StringUtils.isEmpty( getClusterName() )
+          && NamedClusterManager.getInstance().contains( getClusterName(), rep.getMetaStore() ) ) {
         // pull config from NamedCluster
         NamedCluster nc = NamedClusterManager.getInstance().read( getClusterName(), rep.getMetaStore() );
         setZookeeperHosts( nc.getZooKeeperHost() );
@@ -658,8 +658,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
       }
     } catch ( MetaStoreException e ) {
       logDebug( e.getMessage(), e );
-    }        
-    
+    }
+
     if ( !Const.isEmpty( m_zookeeperHosts ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "zookeeper_hosts", m_zookeeperHosts );
     }
@@ -726,7 +726,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     throws KettleException {
 
     loadClusterConfig( id_step, rep, null );
-    
+
     m_coreConfigURL = rep.getStepAttributeString( id_step, 0, "core_config_url" );
     m_defaultConfigURL = rep.getStepAttributeString( id_step, 0, "default_config_url" );
     m_sourceTableName = rep.getStepAttributeString( id_step, 0, "source_table_name" );
@@ -866,27 +866,32 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
             zookeeperPort = space.environmentSubstitute( zookeeperPort );
           }
 
-          List<String> forLogging = new ArrayList<String>();
-          conf = HBaseInputData.getHBaseConnection( zookeeperHosts, zookeeperPort, coreConf, defaultConf, forLogging );
-
-          for ( String m : forLogging ) {
-            logBasic( m );
-          }
         } catch ( Exception ex ) {
           throw new KettleStepException( ex.getMessage(), ex );
         }
 
         MappingAdmin mappingAdmin = null;
         try {
-          mappingAdmin = new MappingAdmin( conf );
-        } catch ( Exception ex ) {
-          throw new KettleStepException( ex.getMessage(), ex );
-        }
+          List<String> forLogging = new ArrayList<String>();
+          conf = HBaseInputData.getHBaseConnection( zookeeperHosts, zookeeperPort, coreConf, defaultConf, forLogging );
 
-        try {
+          for ( String m : forLogging ) {
+            logBasic( m );
+          }
+
+          mappingAdmin = new MappingAdmin( conf );
+
           m_cachedMapping = mappingAdmin.getMapping( m_sourceTableName, m_sourceMappingName );
         } catch ( Exception ex ) {
           throw new KettleStepException( ex.getMessage(), ex );
+        } finally {
+          if ( mappingAdmin != null && mappingAdmin.getConnection() != null ) {
+            try {
+              mappingAdmin.getConnection().close();
+            } catch ( Exception ex ) {
+              throw new KettleStepException( ex.getMessage(), ex );
+            }
+          }
         }
       }
     }

--- a/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseoutput/HBaseOutput.java
+++ b/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseoutput/HBaseOutput.java
@@ -107,6 +107,7 @@ public class HBaseOutput extends BaseStep implements StepInterface {
 
         try {
           logBasic( BaseMessages.getString( HBaseOutputMeta.PKG, "HBaseOutput.ClosingConnectionToTable" ) );
+          m_hbAdmin.close();
           m_hbAdmin.closeTargetTable();
           m_targetTableActive = false;
         } catch ( Exception ex ) {
@@ -326,6 +327,7 @@ public class HBaseOutput extends BaseStep implements StepInterface {
 
         try {
           logBasic( BaseMessages.getString( HBaseOutputMeta.PKG, "HBaseOutput.ClosingConnectionToTable" ) );
+          m_hbAdmin.close();
           m_hbAdmin.closeTargetTable();
           m_targetTableActive = false;
         } catch ( Exception ex ) {

--- a/legacy/src/main/java/org/pentaho/hbase/mapping/MappingAdmin.java
+++ b/legacy/src/main/java/org/pentaho/hbase/mapping/MappingAdmin.java
@@ -80,17 +80,17 @@ public class MappingAdmin {
   /**
    * Constructor. No conneciton information configured.
    */
-  public MappingAdmin() {
-    try {
-      HadoopConfiguration active =
-          HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration();
-      HBaseShim hbaseShim = active.getHBaseShim();
-      m_bytesUtil = hbaseShim.getHBaseConnection().getBytesUtil();
-    } catch ( Exception ex ) {
-      // catastrophic failure if we can't obtain a concrete implementation
-      throw new RuntimeException( ex );
-    }
-  }
+//  public MappingAdmin() {
+//    try {
+//      HadoopConfiguration active =
+//          HadoopConfigurationBootstrap.getHadoopConfigurationProvider().getActiveConfiguration();
+//      HBaseShim hbaseShim = active.getHBaseShim();
+//      m_bytesUtil = hbaseShim.getHBaseConnection().getBytesUtil();
+//    } catch ( Exception ex ) {
+//      // catastrophic failure if we can't obtain a concrete implementation
+//      throw new RuntimeException( ex );
+//    }
+//  }
 
   /**
    * Constructor
@@ -100,14 +100,13 @@ public class MappingAdmin {
    * @throws Exception
    *           if a problem occurs
    */
-  public MappingAdmin( HBaseConnection conn ) {
-    this();
-    setConnection( conn );
+  public MappingAdmin( HBaseConnection conn ) throws Exception {
+      this( conn, conn.getBytesUtil() );
   }
 
-  public MappingAdmin( HBaseConnection conn, HBaseBytesUtilShim bytesUtil ) {
-    m_bytesUtil = bytesUtil;
-    setConnection( conn );
+  public MappingAdmin( HBaseConnection conn, HBaseBytesUtilShim bytesUtil ) throws Exception {
+    this.m_admin = conn;
+    this.m_bytesUtil = bytesUtil;
   }
 
   /**
@@ -993,8 +992,7 @@ public class MappingAdmin {
       connProps.setProperty( HBaseConnection.ZOOKEEPER_QUORUM_KEY, "localhost" );
       conn.configureConnection( connProps, null );
 
-      MappingAdmin admin = new MappingAdmin();
-      admin.setConnection( conn );
+      MappingAdmin admin = new MappingAdmin( conn );
 
       if ( args.length == 0 || args[0].equalsIgnoreCase( "-h" ) || args[0].endsWith( "help" ) ) {
         System.err.println( "Commands:\n" );

--- a/legacy/src/main/resources/org/pentaho/di/trans/steps/hbaseinput/messages/messages_en_US.properties
+++ b/legacy/src/main/resources/org/pentaho/di/trans/steps/hbaseinput/messages/messages_en_US.properties
@@ -42,6 +42,7 @@ HBaseInputDialog.IncludeKey.Label=Include the key as a column
 
 HBaseInputDialog.ErrorMessage.UnableToConnect=Problem connecting to HBase
 HBaseInputDialog.ErrorMessage.UnableToGetMapping=Unable to retrieve mapping information
+HBaseInputDialog.ErrorMessage.FailedClosingHBaseConnection=Unable to close HBase connection
 
 HBaseInputDialog.Fields.FIELD_ALIAS=Alias
 HBaseInputDialog.Fields.FIELD_KEY=Key

--- a/legacy/src/main/resources/org/pentaho/di/trans/steps/hbaseoutput/messages/messages_en_US.properties
+++ b/legacy/src/main/resources/org/pentaho/di/trans/steps/hbaseoutput/messages/messages_en_US.properties
@@ -39,11 +39,13 @@ HBaseOutputDialog.WriteBufferSize.TipText=Larger buffer = faster/greater memory 
 
 HBaseOutputDialog.ErrorMessage.UnableToConnect=Problem connecting to HBase
 HBaseOutputDialog.ErrorMessage.UnableToGetMapping=Unable to retrieve mapping information
+HBaseOutputDialog.ErrorMessage.FailedClosingHBaseConnection=Unable to close HBase connection
 
 HBaseOutputDialog.Error.IssuesWithMapping.Title=Problems with mapping
 HBaseOutputDialog.Error.IssuesWithMapping=There are some problems with the mapping that need rectification
 HBaseOutputDialog.Error.IssuesWithMapping.ButtonOK=OK and close
 HBaseOutputDialog.Error.IssuesWithMapping.ButtonCancel=Cancel and rectify
+
 
 MappingDialog.TableName.Label=HBase table name
 MappingDialog.TableName.GetTableNames=Get table names


### PR DESCRIPTION
The way how HBase 1.0 API has been implemented requires explicitly close HBaseConnection.
In order to do this the HBase shim API is changed and new close() method is exposed.
This commit contains changes done on UI and step layers to accomplish closing connections.

@mattyb149 @brosander do you mind to review?