### PR TITLE
[BACKLOG-4688] - PMR installation HDFS directory path contains @VERSION@ string instead of actual value

### DIFF
--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -295,6 +295,15 @@
         </excludes>
       </resource>
     </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/*.properties</include>
+        </includes>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/legacy/src/main/java/org/pentaho/hadoop/PluginPropertiesUtil.java
+++ b/legacy/src/main/java/org/pentaho/hadoop/PluginPropertiesUtil.java
@@ -39,16 +39,22 @@ import java.util.Properties;
  */
 public class PluginPropertiesUtil {
   public static final String PLUGIN_PROPERTIES_FILE = "plugin.properties";
+  public static final String VERSION_PROPERTIES_FILE = "META-INF/version.properties";
   private static final String VERSION_REPLACE_STR = "@VERSION@";
-  /**
-   * Placeholder for the version string that is replaced during the ant build process. This is mangled here so we have
-   * something to compare against to determine if the replacement has occured.
-   */
-  private static final String VERSION_PLACEHOLDER = getVersionPlaceholder();
 
-  private static String getVersionPlaceholder() {
+  private final String VERSION_PLACEHOLDER;
+
+  public PluginPropertiesUtil() {
+    this( VERSION_PROPERTIES_FILE );
+  }
+
+  public PluginPropertiesUtil( String versionPropertiesFile ) {
+    VERSION_PLACEHOLDER = getVersionPlaceholder( versionPropertiesFile );
+  }
+
+  private static String getVersionPlaceholder( String versionPropertiesFile ) {
     try ( InputStream propertiesStream = PluginPropertiesUtil.class.getClassLoader().getResourceAsStream(
-      "META-INF/version.properties" ) ) {
+        versionPropertiesFile ) ) {
       Properties properties = new Properties();
       properties.load( propertiesStream );
       return properties.getProperty( "version", VERSION_REPLACE_STR );
@@ -95,11 +101,10 @@ public class PluginPropertiesUtil {
   }
 
   /**
-   * @return the version of this plugin or {@code null} if not set during the ant build process
+   * @return the version of this plugin
    */
   public String getVersion() {
     // This value is replaced during the ant build process (task: compile.pre)
-    String version = VERSION_REPLACE_STR;
-    return VERSION_PLACEHOLDER.equals( version ) ? null : version;
+    return VERSION_PLACEHOLDER;
   }
 }

--- a/legacy/src/test/java/org/pentaho/hadoop/PluginPropertiesUtilTest.java
+++ b/legacy/src/test/java/org/pentaho/hadoop/PluginPropertiesUtilTest.java
@@ -33,8 +33,22 @@ public class PluginPropertiesUtilTest {
     // This test will only success if using classes produced by the ant build
     PluginPropertiesUtil util = new PluginPropertiesUtil();
     assertNotNull(
-        "Version was not swapped out during build process. This will ALWAYS fail unless classes were built with ant script.",
-        util.getVersion() );
+      "Should never be null",
+      util.getVersion() );
+  }
+
+  @Test
+  public void testGetVersionFromNonDefaultLocation() {
+    PluginPropertiesUtil ppu = new PluginPropertiesUtil( "test-version.properties" );
+    String version = ppu.getVersion();
+    assertEquals( "X.Y.Z-TEST", version );
+  }
+
+  @Test
+  public void testGetVersionFromNonExistingLocation() {
+    PluginPropertiesUtil ppu = new PluginPropertiesUtil( "non-existing-version.properties" );
+    String version = ppu.getVersion();
+    assertEquals( "@VERSION@", version );
   }
 
 }


### PR DESCRIPTION
The @VERSION@ placeholder used to be filled in on build time with real release version.
After mavinization the substtution has gone. It's very hard to implement the same build step with maven.
Looking through sources it was figured out that the build time replacement is not needed at all.
The version is read from version.properties file what is quite reliable.

The PluginPropertiesUtils class was modified to return the version read from the properties file.
Additional constructor was added to allow reading from another location (primaraly for testing purpose)
remove comments about ant-replacements
check style