### PR TITLE
[ENGOPS-1367] updated ce parent pom for site phase nullifcation of parents

### DIFF
--- a/api/cluster/pom.xml
+++ b/api/cluster/pom.xml
@@ -16,6 +16,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/api/hdfs/pom.xml
+++ b/api/hdfs/pom.xml
@@ -16,6 +16,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/api/initializer/pom.xml
+++ b/api/initializer/pom.xml
@@ -16,6 +16,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/api/pig/pom.xml
+++ b/api/pig/pom.xml
@@ -16,6 +16,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/api/runtimeTest/pom.xml
+++ b/api/runtimeTest/pom.xml
@@ -16,6 +16,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/assemblies/features/pom.xml
+++ b/assemblies/features/pom.xml
@@ -30,6 +30,10 @@
   <groupId>pentaho-karaf-features</groupId>
   <artifactId>pentaho-big-data-plugin-osgi</artifactId>
   <version>6.0-SNAPSHOT</version>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <build>
     <plugins>

--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -27,6 +27,10 @@
     <developerConnection>scm:git:git@github.com:${github.user}/${project.artifactId}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -13,6 +13,10 @@
 
   <artifactId>pentaho-big-data-assemblies-pmr-libraries</artifactId>
   <packaging>pom</packaging>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -27,6 +27,10 @@
     <developerConnection>scm:git:git@github.com:${github.user}/${project.artifactId}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <build>
     <plugins>

--- a/assemblies/standalone/pom.xml
+++ b/assemblies/standalone/pom.xml
@@ -15,6 +15,8 @@
 
   <packaging>pom</packaging>
   <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+    
     <package.features>true</package.features>
     <pentaho-karaf-ee-assembly.version>${project.version}</pentaho-karaf-ee-assembly.version>
     <dependency.karaf.revision>2.3.5</dependency.karaf.revision>

--- a/impl/cluster/pom.xml
+++ b/impl/cluster/pom.xml
@@ -15,6 +15,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/impl/clusterTests/pom.xml
+++ b/impl/clusterTests/pom.xml
@@ -15,6 +15,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/impl/shim/common/pom.xml
+++ b/impl/shim/common/pom.xml
@@ -17,6 +17,10 @@
     <description>a Pentaho open source project</description>
     <url>http://www.pentaho.com</url>
 
+    <properties>
+      <publish-sonar-phase>site</publish-sonar-phase>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>pentaho-kettle</groupId>

--- a/impl/shim/hdfs/pom.xml
+++ b/impl/shim/hdfs/pom.xml
@@ -17,6 +17,9 @@
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
 
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <!-- OSGi dependencies -->

--- a/impl/shim/initializer/pom.xml
+++ b/impl/shim/initializer/pom.xml
@@ -17,6 +17,9 @@
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
 
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <!-- OSGi dependencies -->

--- a/impl/shim/pig/pom.xml
+++ b/impl/shim/pig/pom.xml
@@ -17,6 +17,9 @@
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
 
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/impl/shim/shimTests/pom.xml
+++ b/impl/shim/shimTests/pom.xml
@@ -17,6 +17,9 @@
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
 
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <!-- OSGi dependencies -->

--- a/impl/vfs/hdfs/pom.xml
+++ b/impl/vfs/hdfs/pom.xml
@@ -15,6 +15,7 @@
     <name>Pentaho Community Edition Project: ${project.artifactId}</name>
 
     <properties>
+        <publish-sonar-phase>site</publish-sonar-phase>
         <dependency.kettle.revision>6.0-SNAPSHOT</dependency.kettle.revision>
     </properties>
 

--- a/kettle-plugins/common/namedClusterBridge/pom.xml
+++ b/kettle-plugins/common/namedClusterBridge/pom.xml
@@ -15,6 +15,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/kettle-plugins/common/ui/pom.xml
+++ b/kettle-plugins/common/ui/pom.xml
@@ -15,6 +15,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/kettle-plugins/pig/pom.xml
+++ b/kettle-plugins/pig/pom.xml
@@ -16,6 +16,10 @@
   <name>Pentaho Community Edition Project: ${project.artifactId}</name>
   <description>a Pentaho open source project</description>
   <url>http://www.pentaho.com</url>
+  
+  <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -21,6 +21,8 @@
   </licenses>
 
   <properties>
+    <publish-sonar-phase>site</publish-sonar-phase>
+    
     <xstream.version>1.4.2</xstream.version>
     <oozie.version>3.1.3-incubating</oozie.version>
     <avro.version>1.6.2</avro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
     <parent>
         <groupId>org.pentaho</groupId>
         <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-        <version>1.0.13</version>
-        <!-- https://github.com/pentaho/maven-parent-poms/blob/pentaho-ce-jar-parent-pom-1.0.10/pentaho-ce-jar-parent-pom/pom.xml -->
+        <version>1.0.14</version>
     </parent>
 
     <name>Pentaho Community Edition Project: ${project.artifactId}</name>
@@ -36,6 +35,8 @@
     </modules>
 
     <properties>
+        <publish-sonar-phase/>
+    
         <dependency.avro.revision>1.6.2</dependency.avro.revision>
         <dependency.aws-java-sdk.revision>1.0.008</dependency.aws-java-sdk.revision>
         <dependency.bean-matchers.revision>0.9</dependency.bean-matchers.revision>


### PR DESCRIPTION
knocks about 40 mins off the unit test and sonar publishing  ... tested here http://cerberus.pentaho.com/job/6.0-engops-testing/job/big-data-plugin-features/4/
@lgrill-pentaho 