### PR TITLE
[BACKLOG-5026] Final fixes and UX adjustments for cluster test dialogs

### DIFF
--- a/impl/shim/shimTests/src/main/java/org/pentaho/big/data/impl/shim/tests/TestShimLoad.java
+++ b/impl/shim/shimTests/src/main/java/org/pentaho/big/data/impl/shim/tests/TestShimLoad.java
@@ -67,8 +67,8 @@ public class TestShimLoad extends BaseRuntimeTest {
 
   @Override public RuntimeTestResultSummary runTest( Object objectUnderTest ) {
     try {
-      String activeConfigurationId = hadoopConfigurationBootstrap.getActiveConfigurationId();
       hadoopConfigurationBootstrap.getProvider();
+      String activeConfigurationId = hadoopConfigurationBootstrap.getActiveConfigurationId();
       return new RuntimeTestResultSummaryImpl(
         new ClusterRuntimeTestEntry( messageGetterFactory, RuntimeTestEntrySeverity.INFO,
           messageGetter.getMessage( TEST_SHIM_LOAD_SHIM_LOADED_DESC, activeConfigurationId ),

--- a/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/ClusterTestDialog.java
+++ b/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/ClusterTestDialog.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
@@ -43,6 +45,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.core.gui.WindowProperty;
+import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.runtime.test.RuntimeTest;
 import org.pentaho.runtime.test.RuntimeTestProgressCallback;
@@ -104,8 +107,8 @@ public class ClusterTestDialog extends Dialog {
     formLayout.marginWidth = margin;
     formLayout.marginHeight = margin;
 
-    final int shellWidth = 285;
-    final int shellHeight = 160; // Golden ratio * width
+    final int shellWidth = 385;
+    final int shellHeight = 160;
     shell.setSize( shellWidth, shellHeight );
     shell.setMinimumSize( shellWidth, shellHeight );
     shell.setText( BaseMessages.getString( PKG, "ClusterTestDialog.Title" ) );
@@ -113,10 +116,7 @@ public class ClusterTestDialog extends Dialog {
 
     Label testingClusterLabel = new Label( shell, SWT.NONE );
     testingClusterLabel.setText( BaseMessages.getString( PKG, "ClusterTestDialog.ClusterTest.Label" ) );
-    FontData[] fontData = testingClusterLabel.getFont().getFontData();
-    fontData[0].setHeight( 16 );
     testingClusterLabel.setForeground( GUIResource.getInstance().getColorCrystalTextPentaho() );
-    testingClusterLabel.setFont( new Font( display, fontData[0] ) );
     FormData fd = new FormData();
     fd.left = new FormAttachment( 0, margin );
     fd.top = new FormAttachment( 0, margin );
@@ -132,6 +132,7 @@ public class ClusterTestDialog extends Dialog {
 
     final ProgressBar progressBar = new ProgressBar( shell, SWT.SMOOTH );
     progressBar.setMinimum( 0 ); // Max tests will be set upon first return
+    progressBar.computeSize( SWT.DEFAULT, 22, true );
 
     fd = new FormData();
     fd.top = new FormAttachment( testLabel, 10 );
@@ -150,7 +151,15 @@ public class ClusterTestDialog extends Dialog {
     Button[] buttons = new Button[]{ wCancel };
     BaseStepDialog.positionBottomRightButtons( shell, buttons, margin, null );
     shell.setBackgroundMode( SWT.INHERIT_FORCE );
+
+    Rectangle shellBounds = Spoon.getInstance().getShell().getBounds();
+
+    shell.pack();
     shell.open();
+
+    shell.setLocation(
+      shellBounds.x + ( shellBounds.width - shellWidth ) / 2,
+      shellBounds.y + ( shellBounds.height - shellHeight ) / 2 );
 
     // Start the cluster tests
     runtimeTester.runtimeTest( namedCluster, new RuntimeTestProgressCallback() {

--- a/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/ClusterTestResultsDialog.java
+++ b/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/ClusterTestResultsDialog.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
@@ -44,6 +45,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.gui.GUIResource;
 import org.pentaho.di.ui.core.gui.WindowProperty;
+import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.di.ui.util.HelpUtils;
 import org.pentaho.runtime.test.RuntimeTestStatus;
@@ -145,19 +147,19 @@ public class ClusterTestResultsDialog extends Dialog {
           case INFO:
             // The above are "Test(s) passed"
             image.setImage(
-              GUIResource.getInstance().getImage( "ui/images/success_green.svg", myClassLoader, 24, 24 ) );
+              GUIResource.getInstance().getImage( "ui/images/success_green.svg", myClassLoader, 22, 22 ) );
             break;
           case WARNING:
           case SKIPPED:
             // The above are "Test(s) finished with warnings"
             image.setImage(
-              GUIResource.getInstance().getImage( "ui/images/warning_yellow.svg", myClassLoader, 24, 24 ) );
+              GUIResource.getInstance().getImage( "ui/images/warning_yellow.svg", myClassLoader, 22, 22 ) );
             break;
           case ERROR:
           case FATAL:
             // The above are "Test(s) failed"
             image.setImage(
-              GUIResource.getInstance().getImage( "ui/images/error_red.svg", myClassLoader, 24, 24 ) );
+              GUIResource.getInstance().getImage( "ui/images/error_red.svg", myClassLoader, 22, 22 ) );
             break;
         }
         FormData imageLayoutData = new FormData();
@@ -224,7 +226,7 @@ public class ClusterTestResultsDialog extends Dialog {
     mainComposite.setSize( mainComposite.computeSize( SWT.DEFAULT, SWT.DEFAULT ) );
 
     Button wOk = new Button( shell, SWT.PUSH );
-    wOk.setText( BaseMessages.getString( PKG, "System.Button.OK" ) );
+    wOk.setText( BaseMessages.getString( PKG, "System.Button.Close" ) );
 
     wOk.addListener( SWT.Selection, new Listener() {
       public void handleEvent( Event e ) {
@@ -235,7 +237,15 @@ public class ClusterTestResultsDialog extends Dialog {
     Button[] buttons = new Button[]{ wOk };
     BaseStepDialog.positionBottomRightButtons( shell, buttons, margin, null );
 
+    Rectangle shellBounds = Spoon.getInstance().getShell().getBounds();
+
+    shell.pack();
     shell.open();
+
+    shell.setLocation(
+      shellBounds.x + ( shellBounds.width - shellWidth ) / 2,
+      shellBounds.y + ( shellBounds.height - shellHeight ) / 2 );
+
     while ( !shell.isDisposed() ) {
       if ( !display.readAndDispatch() ) {
         display.sleep();

--- a/kettle-plugins/common/ui/src/main/resources/org/pentaho/big/data/plugins/common/ui/messages/messages_en_US.properties
+++ b/kettle-plugins/common/ui/src/main/resources/org/pentaho/big/data/plugins/common/ui/messages/messages_en_US.properties
@@ -34,7 +34,6 @@ NamedClusterDialog.DialogError=Error opening dialog
 
 ClusterTestDialog.Title=Hadoop Cluster Test
 ClusterTestDialog.ClusterTest.Label=Testing Hadoop Cluster
-ClusterTestDialog.Shell.Doc=https://help.pentaho.com/Documentation/6.0/0P0/180/035
 ClusterTestDialog.ModuleTest=Cluster Test: {0}
 ClusterTestDialog.TestResult=\t{0}: {1} {2}
 ClusterTestDialog.TestsFinished=Tests Finished!


### PR DESCRIPTION
The change in TestShimLoad is needed as the shim type is not displayed when you test a cluster without having loaded a shim (which is the immediate use case for users). The rest correspond to the UX findings in the case/mockups.