### PR TITLE
[BACKLOG-4928] - additional fix

### DIFF
--- a/legacy/src/main/java/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
+++ b/legacy/src/main/java/org/pentaho/di/job/entries/sqoop/SqoopUtils.java
@@ -395,7 +395,7 @@ public class SqoopUtils {
 
     // Add custom arguments as they must appear before tool specific arguments
     for ( PropertyEntry entry : config.getCustomArguments() ) {
-      appendCustomArgument( customBuffer, entry, variableSpace );
+      appendCustomArgument( customBuffer, entry, variableSpace, true );
     }
 
     for ( Iterator<String> iterator = customBuffer.iterator(); iterator.hasNext(); ) {
@@ -505,11 +505,11 @@ public class SqoopUtils {
 
   private static void appendCustomArguments( List<String> args , SqoopConfig config, VariableSpace variableSpace ) {
     for ( PropertyEntry entry : config.getCustomArguments() ) {
-      appendCustomArgument( args, entry, variableSpace );
+      appendCustomArgument( args, entry, variableSpace, false );
     }
   }
 
-  private static void appendCustomArgument( List<String> args, PropertyEntry arg, VariableSpace variableSpace ) {
+  private static void appendCustomArgument( List<String> args, PropertyEntry arg, VariableSpace variableSpace, boolean quote ) {
     String key = arg.getKey();
     String value = arg.getValue();
 
@@ -526,8 +526,12 @@ public class SqoopUtils {
       value = variableSpace.environmentSubstitute( value );
     }
 
+    if ( quote ) {
+      value = quote( escapeBackslash( value ) );
+    }
+
     args.add( ARG_D );
-    args.add( key + EQUALS + quote( escapeBackslash( value ) ) );
+    args.add( key + EQUALS + value );
   }
 
   private static String escapeBackslash( String s ) {

--- a/legacy/src/test/java/org/pentaho/di/job/entries/sqoop/SqoopUtilsTest.java
+++ b/legacy/src/test/java/org/pentaho/di/job/entries/sqoop/SqoopUtilsTest.java
@@ -636,4 +636,17 @@ public class SqoopUtilsTest {
     assertEquals( "param", entry.getKey() );
     assertEquals( "value \\t", entry.getValue() );
   }
+
+  @Test
+  public void getCommandLineArguments_custom_backslash_in_value() throws Exception {
+    MockConfig config = new MockConfig();
+    AbstractModelList<PropertyEntry> customArguments = new AbstractModelList<>();
+    customArguments.add( new PropertyEntry( "mapreduce.job.name", "some/test\\Name" ) );
+    config.setCustomArguments( customArguments );
+
+    List<String> commandLineArgs = SqoopUtils.getCommandLineArgs( config, null );
+    assertEquals( 2, commandLineArgs.size() );
+    assertEquals( "-D", commandLineArgs.get( 0 ) );
+    assertEquals( "mapreduce.job.name=some/test\\Name", commandLineArgs.get( 1 ) );
+  }
 }


### PR DESCRIPTION
Remove value quoting and escaping for the case when sqoop is run from grid mode.