### PR TITLE
[BACKLOG-5230] - REGRESSION: HBase Input fails with "null key value" error message

### DIFF
--- a/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseinput/HBaseInputData.java
+++ b/legacy/src/main/java/org/pentaho/di/trans/steps/hbaseinput/HBaseInputData.java
@@ -519,6 +519,11 @@ public class HBaseInputData extends BaseStepData implements StepDataInterface {
         HBaseValueMeta currentCol = columnsMappedByAlias.get( name );
         String colFamilyName = currentCol.getColumnFamily();
         String qualifier = currentCol.getColumnName();
+        if ( currentCol.isKey() ) {
+          // skip key as it has already been processed 
+          // and is not in the scan's columns 
+          continue;
+        }
 
         boolean binaryColName = false;
         if ( qualifier.startsWith( "@@@binary@@@" ) ) {


### PR DESCRIPTION
the issue was caused by changes for new HBase filters.
in order to implement key filtering the corresponding column was added to the alias-map
however, as soon as the "key" is a synthetic column it was not available by the alias.

Solution is to skip the "key" alias resolution when looping through columns' map.

@mattyb149 @brosander @dkincade 