### PR TITLE
[BACKLOG-5026] Windows does not honor pack() for progress bar

### DIFF
--- a/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/ClusterTestDialog.java
+++ b/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/ClusterTestDialog.java
@@ -132,8 +132,7 @@ public class ClusterTestDialog extends Dialog {
 
     final ProgressBar progressBar = new ProgressBar( shell, SWT.SMOOTH );
     progressBar.setMinimum( 0 ); // Max tests will be set upon first return
-    progressBar.computeSize( SWT.DEFAULT, 22, true );
-
+    
     fd = new FormData();
     fd.top = new FormAttachment( testLabel, 10 );
     fd.left = new FormAttachment( 0, margin );
@@ -154,7 +153,6 @@ public class ClusterTestDialog extends Dialog {
 
     Rectangle shellBounds = Spoon.getInstance().getShell().getBounds();
 
-    shell.pack();
     shell.open();
 
     shell.setLocation(


### PR DESCRIPTION
Removed computeSize() and pack(), which caused the progress bar not to show up on Windows