### PR TITLE
[BAD-347] - Variable fix in HadoopFileOutputStep

### DIFF
--- a/legacy/src/main/java/org/pentaho/di/ui/trans/steps/hadoopfileoutput/HadoopFileOutputDialog.java
+++ b/legacy/src/main/java/org/pentaho/di/ui/trans/steps/hadoopfileoutput/HadoopFileOutputDialog.java
@@ -1716,14 +1716,16 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     wCreateParentFolder.setEnabled( true );
   }
 
-  public String getUrlPath( String incomingURL ) {
-    String path = null;
+  public static String getUrlPath( String incomingURL ) {
+    String path = incomingURL;
     try {
       String noVariablesURL = incomingURL.replaceAll( "[${}]", "/" );
       UrlFileNameParser parser = new UrlFileNameParser();
       FileName fileName = parser.parseUri( null, null, noVariablesURL );
       String root = fileName.getRootURI();
-      path = incomingURL.substring( root.length() - 1 );
+      if ( noVariablesURL.startsWith( root ) ) {
+        path = incomingURL.substring( root.length() - 1 );
+      }
     } catch ( FileSystemException e ) {
       path = null;
     }

--- a/legacy/src/test/java/org/pentaho/di/ui/trans/steps/hadoopfileoutput/HadoopFileOutputDialogTest.java
+++ b/legacy/src/test/java/org/pentaho/di/ui/trans/steps/hadoopfileoutput/HadoopFileOutputDialogTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.ui.trans.steps.hadoopfileoutput;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by bryan on 9/22/15.
+ */
+public class HadoopFileOutputDialogTest {
+  @Test
+  public void testGetUrlPathHdfsPrefix() {
+    String prefixToBeRemoved = "hdfs://myhost:8020";
+    String expected = "/path/to/file";
+    assertEquals( expected, HadoopFileOutputDialog.getUrlPath( prefixToBeRemoved + expected ) );
+  }
+
+  @Test
+  public void testGetUrlPathMapRPRefix() {
+    String prefixToBeRemoved = "maprfs://";
+    String expected = "/path/to/file";
+    assertEquals( expected, HadoopFileOutputDialog.getUrlPath( prefixToBeRemoved + expected ) );
+  }
+
+  @Test
+  public void testGetUrlPathSpecialPrefix() {
+    String prefixToBeRemoved = "mySpecialPrefix://host";
+    String expected = "/path/to/file";
+    assertEquals( expected, HadoopFileOutputDialog.getUrlPath( prefixToBeRemoved + expected ) );
+  }
+
+  @Test
+  public void testGetUrlPathNoPrefix() {
+    String expected = "/path/to/file";
+    assertEquals( expected, HadoopFileOutputDialog.getUrlPath( expected ) );
+  }
+
+  @Test
+  public void testGetUrlPathVariablePrefix() {
+    String expected = "${myTestVar}";
+    assertEquals( expected, HadoopFileOutputDialog.getUrlPath( expected ) );
+  }
+}


### PR DESCRIPTION
Only removing root prefix if there is one