### PR TITLE
[BACKLOG-5260] - Adding the RuntimeTest to the main testless big-data

### DIFF
--- a/assemblies/features/src/main/resources/features.xml
+++ b/assemblies/features/src/main/resources/features.xml
@@ -1,7 +1,6 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
   <feature name="pentaho-big-data-plugin-osgi" version="1.0">
   	<feature>pentaho-big-data-plugin-testless-osgi</feature>
-    <bundle>mvn:pentaho/pentaho-big-data-api-runtimeTest/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-clusterTests/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-shim-shimTests/${project.version}</bundle>
   </feature>
@@ -12,6 +11,7 @@
     <bundle>mvn:pentaho/pentaho-big-data-api-initializer/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-api-hdfs/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-api-pig/${project.version}</bundle>
+    <bundle>mvn:pentaho/pentaho-big-data-api-runtimeTest/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-cluster/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-shim-common/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-shim-initializer/${project.version}</bundle>


### PR DESCRIPTION
                 feature.big-data commons-ui depends on runtime test
                 feature