### PR TITLE
[BACKLOG-5265] - Boot delegation workaround

### DIFF
--- a/impl/shim/common/src/main/java/com/pentaho/big/data/bundles/impl/shim/common/ShimBridgingClassloader.java
+++ b/impl/shim/common/src/main/java/com/pentaho/big/data/bundles/impl/shim/common/ShimBridgingClassloader.java
@@ -174,7 +174,17 @@ public class ShimBridgingClassloader extends ClassLoader {
     }
     if ( result == null ) {
       try {
-        return bundleWiringClassloader.loadClass( name, resolve );
+        Class<?> osgiProvidedClass = bundleWiringClassloader.loadClass( name, resolve );
+        if ( osgiProvidedClass.getClassLoader() == PluginRegistry.class.getClassLoader() ) {
+          // Give parent a chance to supercede the system classloader (workaround for boot delegation of packages we
+          // should have loaded from the parent)
+          try {
+            return super.loadClass( name, resolve );
+          } catch ( Exception e ) {
+            // Ignore
+          }
+        }
+        return osgiProvidedClass;
       } catch ( Exception e ) {
         // Ignore
       }


### PR DESCRIPTION
In the case that the returned class was loaded from the system classloader, give parent classloader a chance to load a different one