### PR TITLE
6.0 test fixes

### DIFF
--- a/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/hdfs/PingFileSystemEntryPointTestTest.java
+++ b/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/hdfs/PingFileSystemEntryPointTestTest.java
@@ -74,12 +74,14 @@ public class PingFileSystemEntryPointTestTest {
   @Test
   public void testSuccess() {
     RuntimeTestResultEntry results = mock( RuntimeTestResultEntry.class );
+    String testDescription = "test-description";
+    when( results.getDescription() ).thenReturn( testDescription );
     ConnectivityTest connectivityTest = mock( ConnectivityTest.class );
     when( connectivityTestFactory.create( messageGetterFactory, hdfsHost, hdfsPort, true ) )
       .thenReturn( connectivityTest );
     when( connectivityTest.runTest() ).thenReturn( results );
     RuntimeTestResultSummary runtimeTestResultSummary = fileSystemEntryPointTest.runTest( namedCluster );
-    assertEquals( results, runtimeTestResultSummary.getOverallStatusEntry() );
+    assertEquals( testDescription, runtimeTestResultSummary.getOverallStatusEntry().getDescription() );
     assertEquals( 0, runtimeTestResultSummary.getRuntimeTestResultEntries().size() );
   }
 

--- a/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/mr/PingJobTrackerTestTest.java
+++ b/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/mr/PingJobTrackerTestTest.java
@@ -72,12 +72,14 @@ public class PingJobTrackerTestTest {
   @Test
   public void testSuccess() {
     RuntimeTestResultEntry results = mock( RuntimeTestResultEntry.class );
+    String testDescription = "test-description";
+    when( results.getDescription() ).thenReturn( testDescription );
     ConnectivityTest connectivityTest = mock( ConnectivityTest.class );
     when( connectivityTestFactory.create( messageGetterFactory, jobTrackerHost, jobTrackerPort, true ) )
       .thenReturn( connectivityTest );
     when( connectivityTest.runTest() ).thenReturn( results );
     RuntimeTestResultSummary runtimeTestResultSummary = pingJobTrackerTest.runTest( namedCluster );
-    assertEquals( results, runtimeTestResultSummary.getOverallStatusEntry() );
+    assertEquals( testDescription, runtimeTestResultSummary.getOverallStatusEntry().getDescription() );
     assertEquals( 0, runtimeTestResultSummary.getRuntimeTestResultEntries().size() );
   }
 

--- a/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/oozie/PingOozieHostTestTest.java
+++ b/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/oozie/PingOozieHostTestTest.java
@@ -90,12 +90,14 @@ public class PingOozieHostTestTest {
   @Test
   public void testSuccess() {
     RuntimeTestResultEntry results = mock( RuntimeTestResultEntry.class );
+    String testDescription = "test-description";
+    when( results.getDescription() ).thenReturn( testDescription );
     ConnectivityTest connectivityTest = mock( ConnectivityTest.class );
     when( connectivityTestFactory.create( messageGetterFactory, oozieHost, ooziePort, false ) )
       .thenReturn( connectivityTest );
     when( connectivityTest.runTest() ).thenReturn( results );
     RuntimeTestResultSummary runtimeTestResultSummary = pingOozieHostTest.runTest( namedCluster );
-    assertEquals( results, runtimeTestResultSummary.getOverallStatusEntry() );
+    assertEquals( testDescription, runtimeTestResultSummary.getOverallStatusEntry().getDescription() );
     assertEquals( 0, runtimeTestResultSummary.getRuntimeTestResultEntries().size() );
   }
 }

--- a/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/zookeeper/PingZookeeperEnsembleTestTest.java
+++ b/impl/clusterTests/src/test/java/org/pentaho/big/data/impl/cluster/tests/zookeeper/PingZookeeperEnsembleTestTest.java
@@ -104,12 +104,14 @@ public class PingZookeeperEnsembleTestTest {
     RuntimeTestResultEntry clusterTestResultEntry = mock( RuntimeTestResultEntry.class );
     when( clusterTestResultEntry.getSeverity() ).thenReturn( RuntimeTestEntrySeverity.INFO );
     when( connectivityTest.runTest() ).thenReturn( clusterTestResultEntry );
+    String testDescription = "test-description";
+    when( clusterTestResultEntry.getDescription() ).thenReturn( testDescription );
     RuntimeTestResultSummary runtimeTestResultSummary = pingZookeeperEnsembleTest.runTest( namedCluster );
     List<RuntimeTestResultEntry> clusterTestResultEntries = runtimeTestResultSummary
       .getRuntimeTestResultEntries();
     assertEquals( 2, clusterTestResultEntries.size() );
-    assertEquals( clusterTestResultEntry, clusterTestResultEntries.get( 0 ) );
-    assertEquals( clusterTestResultEntry, clusterTestResultEntries.get( 1 ) );
+    assertEquals( testDescription, clusterTestResultEntries.get( 0 ).getDescription() );
+    assertEquals( testDescription, clusterTestResultEntries.get( 1 ).getDescription() );
   }
 
   @Test
@@ -128,6 +130,10 @@ public class PingZookeeperEnsembleTestTest {
     RuntimeTestResultEntry clusterTestResultEntry2 = mock( RuntimeTestResultEntry.class );
     when( clusterTestResultEntry2.getSeverity() ).thenReturn( RuntimeTestEntrySeverity.WARNING );
     when( connectivityTest2.runTest() ).thenReturn( clusterTestResultEntry2 );
+    String testDescription = "test-description";
+    when( clusterTestResultEntry.getDescription() ).thenReturn( testDescription );
+    String testDescription2 = "test-description2";
+    when( clusterTestResultEntry2.getDescription() ).thenReturn( testDescription2 );
     RuntimeTestResultSummary runtimeTestResultSummary = pingZookeeperEnsembleTest.runTest( namedCluster );
     List<RuntimeTestResultEntry> clusterTestResultEntries = runtimeTestResultSummary
       .getRuntimeTestResultEntries();
@@ -136,8 +142,8 @@ public class PingZookeeperEnsembleTestTest {
       messageGetter.getMessage( PingZookeeperEnsembleTest.PING_ZOOKEEPER_ENSEMBLE_TEST_SOME_NODES_FAILED_DESC ),
       messageGetter.getMessage( PingZookeeperEnsembleTest.PING_ZOOKEEPER_ENSEMBLE_TEST_SOME_NODES_FAILED_MESSAGE,
         host2 ) );
-    assertEquals( clusterTestResultEntry, clusterTestResultEntries.get( 0 ) );
-    assertEquals( clusterTestResultEntry2, clusterTestResultEntries.get( 1 ) );
+    assertEquals( testDescription, clusterTestResultEntries.get( 0 ).getDescription() );
+    assertEquals( testDescription2, clusterTestResultEntries.get( 1 ).getDescription() );
   }
 
   @Test
@@ -156,6 +162,10 @@ public class PingZookeeperEnsembleTestTest {
     RuntimeTestResultEntry clusterTestResultEntry2 = mock( RuntimeTestResultEntry.class );
     when( clusterTestResultEntry2.getSeverity() ).thenReturn( RuntimeTestEntrySeverity.WARNING );
     when( connectivityTest2.runTest() ).thenReturn( clusterTestResultEntry2 );
+    String testDescription = "test-description";
+    when( clusterTestResultEntry.getDescription() ).thenReturn( testDescription );
+    String testDescription2 = "test-description2";
+    when( clusterTestResultEntry2.getDescription() ).thenReturn( testDescription2 );
     RuntimeTestResultSummary runtimeTestResultSummary = pingZookeeperEnsembleTest.runTest( namedCluster );
     List<RuntimeTestResultEntry> clusterTestResultEntries = runtimeTestResultSummary
       .getRuntimeTestResultEntries();
@@ -164,7 +174,7 @@ public class PingZookeeperEnsembleTestTest {
       messageGetter.getMessage( PingZookeeperEnsembleTest.PING_ZOOKEEPER_ENSEMBLE_TEST_NO_NODES_SUCCEEDED_DESC ),
       messageGetter.getMessage( PingZookeeperEnsembleTest.PING_ZOOKEEPER_ENSEMBLE_TEST_NO_NODES_SUCCEEDED_MESSAGE,
         host1 + ", " + host2 ) );
-    assertEquals( clusterTestResultEntry, clusterTestResultEntries.get( 0 ) );
-    assertEquals( clusterTestResultEntry2, clusterTestResultEntries.get( 1 ) );
+    assertEquals( testDescription, clusterTestResultEntries.get( 0 ).getDescription() );
+    assertEquals( testDescription2, clusterTestResultEntries.get( 1 ).getDescription() );
   }
 }

--- a/impl/shim/shimTests/src/main/java/org/pentaho/big/data/impl/shim/tests/TestShimConfig.java
+++ b/impl/shim/shimTests/src/main/java/org/pentaho/big/data/impl/shim/tests/TestShimConfig.java
@@ -78,6 +78,7 @@ public class TestShimConfig extends BaseRuntimeTest {
   @Override public RuntimeTestResultSummary runTest( Object objectUnderTest ) {
     String activeConfigurationId = "";
     try {
+      activeConfigurationId = hadoopConfigurationBootstrap.getWillBeActiveConfigurationId();
       // Get the active shim
       HadoopConfigurationProvider hadoopConfigurationProvider = hadoopConfigurationBootstrap.getProvider();
 

--- a/impl/shim/shimTests/src/test/java/org/pentaho/big/data/impl/shim/tests/TestShimConfigTest.java
+++ b/impl/shim/shimTests/src/test/java/org/pentaho/big/data/impl/shim/tests/TestShimConfigTest.java
@@ -70,10 +70,13 @@ public class TestShimConfigTest {
   @Test
   public void testConfigurationException() throws ConfigurationException {
     String testMessage = "testMessage";
+    String testId = "testId";
+    when( hadoopConfigurationBootstrap.getWillBeActiveConfigurationId() ).thenReturn( testId );
     when( hadoopConfigurationBootstrap.getProvider() ).thenThrow( new ConfigurationException( testMessage ) );
     RuntimeTestResultSummary runtimeTestResultSummary = testShimConfig.runTest( namedCluster );
     verifyRuntimeTestResultEntry( runtimeTestResultSummary.getOverallStatusEntry(),
-      RuntimeTestEntrySeverity.ERROR, messageGetter.getMessage( TestShimLoad.TEST_SHIM_LOAD_UNABLE_TO_LOAD_SHIM_DESC ),
+      RuntimeTestEntrySeverity.ERROR,
+      messageGetter.getMessage( TestShimLoad.TEST_SHIM_LOAD_UNABLE_TO_LOAD_SHIM_DESC, testId ),
       testMessage, ConfigurationException.class );
     assertEquals( 0, runtimeTestResultSummary.getRuntimeTestResultEntries().size() );
   }
@@ -130,8 +133,9 @@ public class TestShimConfigTest {
 
     RuntimeTestResultSummary runtimeTestResultSummary = testShimConfig.runTest( namedCluster );
     verifyRuntimeTestResultEntry( runtimeTestResultSummary.getOverallStatusEntry(),
-      RuntimeTestEntrySeverity.WARNING, messageGetter.getMessage( TestShimConfig.TEST_SHIM_CONFIG_FS_NOMATCH_DESC ),
-      messageGetter.getMessage( TestShimConfig.TEST_SHIM_CONFIG_FS_NOMATCH_MESSAGE ) );
+      RuntimeTestEntrySeverity.WARNING,
+      messageGetter.getMessage( TestShimConfig.TEST_SHIM_CONFIG_FS_NOMATCH_DESC ),
+      messageGetter.getMessage( TestShimConfig.TEST_SHIM_CONFIG_FS_NOMATCH_MESSAGE, "maprfs://success:8020" ) );
     assertEquals( 0, runtimeTestResultSummary.getRuntimeTestResultEntries().size() );
   }
 

--- a/legacy/src/test/java/org/pentaho/di/job/entries/hadooptransjobexecutor/JobEntryHadoopTransJobExecutorTest.java
+++ b/legacy/src/test/java/org/pentaho/di/job/entries/hadooptransjobexecutor/JobEntryHadoopTransJobExecutorTest.java
@@ -27,7 +27,6 @@ import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.VFS;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.Result;
 import org.pentaho.di.core.exception.KettleException;
@@ -69,12 +68,12 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 // TODO Refactor JobEntryHadoopTransJobExecutor so it can be tested better than this pseudo-integration test
@@ -389,7 +388,7 @@ public class JobEntryHadoopTransJobExecutorTest {
     when( distributedCacheUtil.isKettleEnvironmentInstalledAt( fileSystem, kettleEnvInstallDir ) ).thenReturn( true );
     jobEntryHadoopTransJobExecutor.configureWithKettleEnvironment( hadoopShim, configuration, fileSystem,
       kettleEnvInstallDir );
-    verify( configuration ).set( JobEntryHadoopTransJobExecutor.MAPREDUCE_APPLICATION_CLASSPATH,
+    org.mockito.Mockito.verify( configuration ).set( JobEntryHadoopTransJobExecutor.MAPREDUCE_APPLICATION_CLASSPATH,
       "classes/," + testClasspath );
   }
 
@@ -406,7 +405,7 @@ public class JobEntryHadoopTransJobExecutorTest {
     File transFile = File.createTempFile( transName, ".ktr" );
     transFile.deleteOnExit();
     IOUtils.write( "<transformation/>", new FileOutputStream( transFile ) );
-    Mockito.when(
+    when(
       naming.nameResource( transFile.getName(),
         KettleVFS.getFileObject( transFile.getAbsolutePath() ).getParent().getURL().toString(),
         "ktr", ResourceNamingInterface.FileNamingType.TRANSFORMATION ) ).thenReturn( transFile.getName() );


### PR DESCRIPTION
@dkincade 

These are the cherry-picked commits from master that get the tests back to blue.  

All are test changes except for TestShimConfig's change which enhances the error message in the case that a shim cannot load.  It must have gotten mixed into the test commit but is good to have (if the new call fails, the next line would have had the same failure when trying to load the shim and then you at least know what shim it was trying to load)

/cc @mattyb149 