### PR TITLE
[SP-2202] - Backport of PDI-14192 - PDI, "Oozie Job Executor" step: new properties can't be added manually (6.0 Suite)

### DIFF
--- a/legacy/src/main/resources/org/pentaho/di/ui/job/entries/oozie/xul/OozieJobExecutor.xul
+++ b/legacy/src/main/resources/org/pentaho/di/ui/job/entries/oozie/xul/OozieJobExecutor.xul
@@ -103,8 +103,8 @@
                         <label value="${Oozie.JobExecutor.Workflow.Properties.Label}" />
                         <spacer flex="1"/>
                         <hbox padding="2">
-                            <button image="../../../../../../../../../ui/images/Add.png" onclick="controller.addNewProperty()" />
-                            <button image="../../../../../../../../../ui/images/generic-delete.png" onclick="controller.removeProperty()" />
+                            <button image="ui/images/Add.png" onclick="controller.addNewProperty()" />
+                            <button image="ui/images/generic-delete.png" onclick="controller.removeProperty()" />
                         </hbox>
                     </hbox>
                     <vbox padding="0" spacing="0" flex="1">


### PR DESCRIPTION
- in 5.4, UI images were moved to kettle-ui.jar; fix the paths of buttons to make the visible
(cherry picked from commit a8f1d43)

@mattyb149, @brosander, review it please. This is a backport of https://github.com/pentaho/big-data-plugin/pull/547