### PR TITLE
[BAD-341]: Hadoop File Input: NPE appears after click on "Browse" button

### DIFF
--- a/legacy/src/main/java/org/pentaho/di/ui/job/entries/hadoopcopyfiles/JobEntryHadoopCopyFilesDialog.java
+++ b/legacy/src/main/java/org/pentaho/di/ui/job/entries/hadoopcopyfiles/JobEntryHadoopCopyFilesDialog.java
@@ -271,6 +271,9 @@ public class JobEntryHadoopCopyFilesDialog extends JobEntryCopyFilesDialog {
       }
 
       if ( rootFile == null ) {
+        if ( defaultInitialFile == null ) {
+          return null;
+        }
         rootFile = defaultInitialFile.getFileSystem().getRoot();
         initialFile = defaultInitialFile;
       }

--- a/legacy/src/main/java/org/pentaho/di/ui/trans/steps/hadoopfileinput/HadoopFileInputDialog.java
+++ b/legacy/src/main/java/org/pentaho/di/ui/trans/steps/hadoopfileinput/HadoopFileInputDialog.java
@@ -2955,6 +2955,9 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
           }
 
           if ( rootFile == null ) {
+            if ( defaultInitialFile == null ) {
+              return;
+            }
             rootFile = defaultInitialFile.getFileSystem().getRoot();
             initialFile = defaultInitialFile;
           }

--- a/legacy/src/main/java/org/pentaho/di/ui/trans/steps/hadoopfileoutput/HadoopFileOutputDialog.java
+++ b/legacy/src/main/java/org/pentaho/di/ui/trans/steps/hadoopfileoutput/HadoopFileOutputDialog.java
@@ -1219,6 +1219,9 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
           }
 
           if ( rootFile == null ) {
+            if ( defaultInitialFile == null ) {
+              return;
+            }
             rootFile = defaultInitialFile.getFileSystem().getRoot();
             initialFile = defaultInitialFile;
           }
@@ -1672,7 +1675,7 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
 
   /**
    * Sets the output width to minimal width...
-   * 
+   *
    */
   public void setMinimalWidth() {
     int nrNonEmptyFields = wFields.nrNonEmpty();


### PR DESCRIPTION
The problem was caused with the case when the user types any nonsensical sequence of symbols in Path filed.
In such case defaultInitialFile=null and we have NPE.
Just Fixed NPEs without any changes in the logic of working on widgetSelected.
No unit tests have been added because these changes  are in UI components.