### PR TITLE
[BAD-297] - Hadoop file output fails append to file

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
@@ -1323,8 +1323,6 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
   private void activeFileNameField() {
     wlFileNameField.setEnabled( wFileNameInField.getSelection() );
     wFileNameField.setEnabled( wFileNameInField.getSelection() );
-    wlExtension.setEnabled( !wFileNameInField.getSelection() );
-    wExtension.setEnabled( !wFileNameInField.getSelection() );
     wlFilename.setEnabled( !wFileNameInField.getSelection() );
     wFilename.setEnabled( !wFileNameInField.getSelection() );
 


### PR DESCRIPTION
It's according the first point of the http://jira.pentaho.com/browse/BAD-297 :
1. In tab File, when the "Accept filename from field" is selected, the "Extension" field is greyed out indicating it is not used. However it still gets used.
So it was decided to enable for editing extension field (as it was and still is being used) to not break somebody`s existing ktrs.