### PR TITLE
[BAD-451]: Second newly added Hadoop Copy job entry shares the same m…

### DIFF
--- a/kettle-plugins/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/kettle-plugins/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,13 +12,13 @@
     <argument ref="runtimeTester"/>
     <pen:di-plugin type="org.pentaho.di.core.plugins.JobEntryPluginType"/>
   </bean>
-  <bean id="hadoopFileInputMeta" class="org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileInputMeta">
+  <bean id="hadoopFileInputMeta" class="org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileInputMeta" scope="prototype">
     <argument ref="namedClusterService"/>
     <argument ref="runtimeTestActionService"/>
     <argument ref="runtimeTester"/>
     <pen:di-plugin type="org.pentaho.di.core.plugins.StepPluginType"/>
   </bean>
-  <bean id="hadoopFileOutputMeta" class="org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileOutputMeta">
+  <bean id="hadoopFileOutputMeta" class="org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileOutputMeta" scope="prototype">
     <argument ref="namedClusterService"/>
     <argument ref="runtimeTestActionService"/>
     <argument ref="runtimeTester"/>


### PR DESCRIPTION
…etadata of already added and configured first Hadoop Copy.

This issue also takes place for Hadoop File Input and Hadoop File Output steps. So this is the additional fix for these steps. 