### PR TITLE
[BACKLOG-5908]: REG: Hadoop Job Executer doesn't use correct informat…

### DIFF
--- a/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutorDialog.java
+++ b/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutorDialog.java
@@ -223,11 +223,13 @@ public class JobEntryHadoopJobExecutorDialog extends JobEntryDialog implements J
   private void selectNamedCluster() {
     @SuppressWarnings( "unchecked" )
     XulMenuList<NamedCluster> namedClusterMenu =
-      (XulMenuList<NamedCluster>) container.getDocumentRoot().getElementById( "named-clusters" ); //$NON-NLS-1$
+        (XulMenuList<NamedCluster>) container.getDocumentRoot().getElementById( "named-clusters" ); //$NON-NLS-1$
 
     NamedCluster namedCluster = jobEntry.getNamedCluster();
-    namedClusterMenu.setSelectedItem( namedCluster );
-    controller.getAdvancedConfiguration().setSelectedNamedCluster( namedCluster );
+    if ( isKnownNamedCluster( namedCluster, controller ) ) {
+      namedClusterMenu.setSelectedItem( namedCluster );
+      controller.getAdvancedConfiguration().setSelectedNamedCluster( namedCluster );
+    }
   }
 
   public JobEntryInterface open() {
@@ -235,6 +237,26 @@ public class JobEntryHadoopJobExecutorDialog extends JobEntryDialog implements J
     dialog.show();
 
     return jobEntry;
+  }
+
+  private boolean isKnownNamedCluster( NamedCluster jobNameCluster, JobEntryHadoopJobExecutorController controller ) {
+    boolean result = false;
+    String jncName = jobNameCluster.getName();
+    List<NamedCluster> nClusters = null;
+    try {
+      nClusters = controller.getNamedClusters();
+    } catch ( MetaStoreException e ) {
+      logger.error( e.getMessage(), e );
+    }
+    if ( jncName != null && nClusters != null ) {
+      for ( NamedCluster nc : nClusters ) {
+        if ( jncName != null && jncName.equals( nc.getName() ) ) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
   }
 
 }


### PR DESCRIPTION
…ion from named cluster.

This issue was introduced with changes in the commit: https://github.com/pentaho/big-data-plugin/commit/ceb855aa6b215b43a82f9b5c353527a29b83d3d7
(exactly starting from the line:
https://github.com/pentaho/big-data-plugin/blob/ceb855aa6b215b43a82f9b5c353527a29b83d3d7/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutorDialog.java#L228)

So the fix is just to return the behavior that was before.
No unit test because the change is on UI (in Dialog).