### PR TITLE
[PDI-14443] - Hadoop Kerberos security ticket not renewed after expire

### DIFF
--- a/impl/shim/hdfs/src/main/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemCallable.java
+++ b/impl/shim/hdfs/src/main/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemCallable.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.pentaho.big.data.bundles.impl.shim.hdfs;
+
+import org.apache.hadoop.fs.FileSystem;
+
+public interface HadoopFileSystemCallable {
+  FileSystem getFileSystem();
+}

--- a/impl/shim/hdfs/src/main/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemFactoryImpl.java
+++ b/impl/shim/hdfs/src/main/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemFactoryImpl.java
@@ -59,8 +59,8 @@ public class HadoopFileSystemFactoryImpl implements HadoopFileSystemFactory {
   }
 
   @Override public HadoopFileSystem create( NamedCluster namedCluster ) throws IOException {
-    HadoopShim hadoopShim = hadoopConfiguration.getHadoopShim();
-    Configuration configuration = hadoopShim.createConfiguration();
+    final HadoopShim hadoopShim = hadoopConfiguration.getHadoopShim();
+    final Configuration configuration = hadoopShim.createConfiguration();
     String fsDefault;
     //TODO: AUTH
     if ( namedCluster.isMapr() ) {
@@ -83,6 +83,16 @@ public class HadoopFileSystemFactoryImpl implements HadoopFileSystemFactory {
     if ( fileSystem instanceof LocalFileSystem ) {
       throw new IOException( "Got a local filesystem, was expecting an hdfs connection" );
     }
-    return new HadoopFileSystemImpl( fileSystem );
+
+    return new HadoopFileSystemImpl( new HadoopFileSystemCallable() {
+      @Override
+      public FileSystem getFileSystem() {
+        try {
+          return (FileSystem) hadoopShim.getFileSystem( configuration ).getDelegate();
+        } catch ( IOException e ) {
+          return null;
+        }
+      }
+    } );
   }
 }

--- a/impl/shim/hdfs/src/main/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemImpl.java
+++ b/impl/shim/hdfs/src/main/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemImpl.java
@@ -40,17 +40,17 @@ import java.io.OutputStream;
  * Created by bryan on 5/28/15.
  */
 public class HadoopFileSystemImpl implements HadoopFileSystem {
-  private final FileSystem fileSystem;
+  private HadoopFileSystemCallable hadoopFileSystemCallable;
 
-  public HadoopFileSystemImpl( FileSystem fileSystem ) {
-    this.fileSystem = fileSystem;
+  public HadoopFileSystemImpl( HadoopFileSystemCallable hadoopFileSystemCallable ) {
+    this.hadoopFileSystemCallable = hadoopFileSystemCallable;
   }
 
   @Override
   public OutputStream append( final HadoopFileSystemPath path ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<OutputStream>() {
       @Override public OutputStream call() throws IOException {
-        return fileSystem.append( new Path( path.getPath() ) );
+        return getFileSystem().append( new Path( path.getPath() ) );
       }
     } );
   }
@@ -59,7 +59,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public OutputStream create( final HadoopFileSystemPath path ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<OutputStream>() {
       @Override public OutputStream call() throws IOException {
-        return fileSystem.create( new Path( path.getPath() ) );
+        return getFileSystem().create( new Path( path.getPath() ) );
       }
     } );
   }
@@ -68,7 +68,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public boolean delete( final HadoopFileSystemPath path, final boolean arg1 ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<Boolean>() {
       @Override public Boolean call() throws IOException {
-        return fileSystem.delete( new Path( path.getPath() ), arg1 );
+        return getFileSystem().delete( new Path( path.getPath() ), arg1 );
       }
     } );
   }
@@ -77,7 +77,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public HadoopFileStatus getFileStatus( final HadoopFileSystemPath path ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<HadoopFileStatus>() {
       @Override public HadoopFileStatus call() throws IOException {
-        return new HadoopFileStatusImpl( fileSystem.getFileStatus( new Path( path.getPath() ) ) );
+        return new HadoopFileStatusImpl( getFileSystem().getFileStatus( new Path( path.getPath() ) ) );
       }
     } );
   }
@@ -86,7 +86,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public boolean mkdirs( final HadoopFileSystemPath path ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<Boolean>() {
       @Override public Boolean call() throws IOException {
-        return fileSystem.mkdirs( new Path( path.getPath() ) );
+        return getFileSystem().mkdirs( new Path( path.getPath() ) );
       }
     } );
   }
@@ -95,7 +95,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public InputStream open( final HadoopFileSystemPath path ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<InputStream>() {
       @Override public InputStream call() throws IOException {
-        return fileSystem.open( new Path( path.getPath() ) );
+        return getFileSystem().open( new Path( path.getPath() ) );
       }
     } );
   }
@@ -104,7 +104,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public boolean rename( final HadoopFileSystemPath path, final HadoopFileSystemPath path2 ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<Boolean>() {
       @Override public Boolean call() throws IOException {
-        return fileSystem.rename( new Path( path.getPath() ), new Path( path2.getPath() ) );
+        return getFileSystem().rename( new Path( path.getPath() ), new Path( path2.getPath() ) );
       }
     } );
   }
@@ -113,7 +113,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public void setTimes( final HadoopFileSystemPath path, final long mtime, final long atime ) throws IOException {
     callAndWrapExceptions( new IOExceptionCallable<Void>() {
       @Override public Void call() throws IOException {
-        fileSystem.setTimes( new Path( path.getPath() ), mtime, atime );
+        getFileSystem().setTimes( new Path( path.getPath() ), mtime, atime );
         return null;
       }
     } );
@@ -123,7 +123,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   public HadoopFileStatus[] listStatus( final HadoopFileSystemPath path ) throws IOException {
     FileStatus[] fileStatuses = callAndWrapExceptions( new IOExceptionCallable<FileStatus[]>() {
       @Override public FileStatus[] call() throws IOException {
-        return fileSystem.listStatus( new Path( path.getPath() ) );
+        return getFileSystem().listStatus( new Path( path.getPath() ) );
       }
     } );
     if ( fileStatuses == null ) {
@@ -142,11 +142,11 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   }
 
   @Override public HadoopFileSystemPath getHomeDirectory() {
-    return new HadoopFileSystemPathImpl( fileSystem.getHomeDirectory() );
+    return new HadoopFileSystemPathImpl( getFileSystem().getHomeDirectory() );
   }
 
   @Override public HadoopFileSystemPath makeQualified( HadoopFileSystemPath hadoopFileSystemPath ) {
-    return new HadoopFileSystemPathImpl( fileSystem
+    return new HadoopFileSystemPathImpl( getFileSystem()
       .makeQualified( HadoopFileSystemPathImpl.toHadoopFileSystemPathImpl( hadoopFileSystemPath ).getRawPath() ) );
   }
 
@@ -165,7 +165,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
     }
     callAndWrapExceptions( new IOExceptionCallable<Void>() {
       @Override public Void call() throws IOException {
-        fileSystem.setPermission(
+        getFileSystem().setPermission(
           HadoopFileSystemPathImpl.toHadoopFileSystemPathImpl( hadoopFileSystemPath ).getRawPath(),
           new FsPermission( FsAction.values()[ owner ], FsAction.values()[ group ], FsAction.values()[ other ] ) );
         return null;
@@ -176,7 +176,7 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
   @Override public boolean exists( final HadoopFileSystemPath path ) throws IOException {
     return callAndWrapExceptions( new IOExceptionCallable<Boolean>() {
       @Override public Boolean call() throws IOException {
-        return fileSystem.exists( HadoopFileSystemPathImpl.toHadoopFileSystemPathImpl( path ).getRawPath() );
+        return getFileSystem().exists( HadoopFileSystemPathImpl.toHadoopFileSystemPathImpl( path ).getRawPath() );
       }
     } );
   }
@@ -185,22 +185,22 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
     return callAndWrapExceptions( new IOExceptionCallable<HadoopFileSystemPath>() {
       @Override public HadoopFileSystemPath call() throws IOException {
         return new HadoopFileSystemPathImpl(
-          fileSystem.getFileStatus( HadoopFileSystemPathImpl.toHadoopFileSystemPathImpl( path ).getRawPath() )
+          getFileSystem().getFileStatus( HadoopFileSystemPathImpl.toHadoopFileSystemPathImpl( path ).getRawPath() )
             .getPath() );
       }
     } );
   }
 
   @Override public String getFsDefaultName() {
-    return fileSystem.getConf().get( "fs.defaultFS", fileSystem.getConf().get( "fs.default.name" ) );
+    return getFileSystem().getConf().get( "fs.defaultFS", getFileSystem().getConf().get( "fs.default.name" ) );
   }
 
   @Override public void setProperty( String name, String value ) {
-    fileSystem.getConf().set( name, value );
+    getFileSystem().getConf().set( name, value );
   }
 
   @Override public String getProperty( String name, String defaultValue ) {
-    return fileSystem.getConf().get( name, defaultValue );
+    return getFileSystem().getConf().get( name, defaultValue );
   }
 
   private <T> T callAndWrapExceptions( IOExceptionCallable<T> ioExceptionCallable ) throws IOException {
@@ -213,5 +213,9 @@ public class HadoopFileSystemImpl implements HadoopFileSystem {
 
   private interface IOExceptionCallable<T> {
     T call() throws IOException;
+  }
+
+  private FileSystem getFileSystem() {
+    return hadoopFileSystemCallable.getFileSystem();
   }
 }

--- a/impl/shim/hdfs/src/test/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemImplTest.java
+++ b/impl/shim/hdfs/src/test/java/com/pentaho/big/data/bundles/impl/shim/hdfs/HadoopFileSystemImplTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
  */
 public class HadoopFileSystemImplTest {
   private FileSystem fileSystem;
+  private HadoopFileSystemCallable hadoopFileSystemCallable;
   private HadoopFileSystemImpl hadoopFileSystem;
   private HadoopFileSystemPath hadoopFileSystemPath;
   private FSDataOutputStream outputStream;
@@ -65,7 +66,8 @@ public class HadoopFileSystemImplTest {
     fileSystem = mock( FileSystem.class );
     configuration = mock( Configuration.class );
     when( fileSystem.getConf() ).thenReturn( configuration );
-    hadoopFileSystem = new HadoopFileSystemImpl( fileSystem );
+    hadoopFileSystemCallable = mock( HadoopFileSystemCallable.class );
+    hadoopFileSystem = new HadoopFileSystemImpl( hadoopFileSystemCallable );
     outputStream = mock( FSDataOutputStream.class );
     inputStream = mock( FSDataInputStream.class );
     hadoopFileSystemPath = mock( HadoopFileSystemPath.class );
@@ -74,6 +76,7 @@ public class HadoopFileSystemImplTest {
     pathString2 = "test/path2";
     when( hadoopFileSystemPath.getPath() ).thenReturn( pathString );
     when( hadoopFileSystemPath2.getPath() ).thenReturn( pathString2 );
+    when( hadoopFileSystemCallable.getFileSystem() ).thenReturn( fileSystem );
   }
 
   @Test


### PR DESCRIPTION
Change to access FileSystem via shim in order to have up-to-date kerberos ticket.