### PR TITLE
[BACKLOG-5885]: REG: Hadoop Job Executor: Error in case "Jar" field contains spaces in path

### DIFF
--- a/api/mapreduce/src/main/java/org/pentaho/bigdata/api/mapreduce/MapReduceJobBuilder.java
+++ b/api/mapreduce/src/main/java/org/pentaho/bigdata/api/mapreduce/MapReduceJobBuilder.java
@@ -36,6 +36,13 @@ public interface MapReduceJobBuilder {
   void setResolvedJarUrl( URL resolvedJarUrl );
 
   /**
+   * Sets the jar to run
+   *
+   * @param jarUrl the jar to run
+   */
+  void setJarUrl( String jarUrl );
+
+  /**
    * Sets the job name
    *
    * @param hadoopJobName the job name

--- a/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/MapReduceJobBuilderImpl.java
+++ b/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/MapReduceJobBuilderImpl.java
@@ -49,6 +49,7 @@ public class MapReduceJobBuilderImpl implements MapReduceJobBuilder {
   private final VariableSpace variableSpace;
   private final Map<String, String> userDefined;
   private URL resolvedJarUrl;
+  private String jarUrl;
   private String hadoopJobName;
   private String outputKeyClass;
   private String outputValueClass;
@@ -73,6 +74,11 @@ public class MapReduceJobBuilderImpl implements MapReduceJobBuilder {
 
   @Override public void setResolvedJarUrl( URL resolvedJarUrl ) {
     this.resolvedJarUrl = resolvedJarUrl;
+  }
+
+  @Override
+  public void setJarUrl( String jarUrl ) {
+    this.jarUrl = jarUrl;
   }
 
   @Override public void setHadoopJobName( String hadoopJobName ) {
@@ -190,7 +196,7 @@ public class MapReduceJobBuilderImpl implements MapReduceJobBuilder {
       }
     }
 
-    conf.setJar( resolvedJarUrl.toString() );
+    conf.setJar( jarUrl );
 
     conf.setNumMapTasks( numMapTasks );
     conf.setNumReduceTasks( numReduceTasks );

--- a/impl/shim/mapreduce/src/test/java/org/pentaho/big/data/impl/shim/mapreduce/MapReduceJobBuilderImplTest.java
+++ b/impl/shim/mapreduce/src/test/java/org/pentaho/big/data/impl/shim/mapreduce/MapReduceJobBuilderImplTest.java
@@ -66,6 +66,7 @@ public class MapReduceJobBuilderImplTest {
   private String testJobName;
   private String inputPath;
   private URL resolvedJarUrl;
+  private String jarUrl;
   private int numMapTasks;
   private int numReduceTasks;
   private String userPath;
@@ -122,6 +123,7 @@ public class MapReduceJobBuilderImplTest {
     userPath2Path = mock( Path.class );
     when( fileSystem.asPath( fsUrl, userPath2 ) ).thenReturn( userPath2Path );
     inputPath = userPath + "," + userPath2;
+    jarUrl = "http://jar.com/myjar";
     resolvedJarUrl = new URL( "http://jar.com/myjar" );
     numMapTasks = 3;
     numReduceTasks = 1;
@@ -134,6 +136,7 @@ public class MapReduceJobBuilderImplTest {
     mapReduceJobBuilder.setOutputKeyClass( String.class.getCanonicalName() );
     mapReduceJobBuilder.setOutputValueClass( String.class.getCanonicalName() );
     mapReduceJobBuilder.setInputPath( inputPath );
+    mapReduceJobBuilder.setJarUrl( jarUrl );
     mapReduceJobBuilder.setResolvedJarUrl( resolvedJarUrl );
     mapReduceJobBuilder.setNumMapTasks( numMapTasks );
     mapReduceJobBuilder.setNumReduceTasks( numReduceTasks );
@@ -144,7 +147,7 @@ public class MapReduceJobBuilderImplTest {
     verify( configuration ).setOutputKeyClass( String.class );
     verify( configuration ).setOutputValueClass( String.class );
     verify( configuration ).setInputPaths( userPath1Path, userPath2Path );
-    verify( configuration ).setJar( resolvedJarUrl.toString() );
+    verify( configuration ).setJar( jarUrl );
     verify( configuration ).setNumMapTasks( numMapTasks );
     verify( configuration ).setNumReduceTasks( numReduceTasks );
   }
@@ -161,6 +164,7 @@ public class MapReduceJobBuilderImplTest {
     mapReduceJobBuilder.setOutputFormatClass( Float.class.getCanonicalName() );
     mapReduceJobBuilder.setInputPath( inputPath );
     mapReduceJobBuilder.setOutputPath( userPath2 );
+    mapReduceJobBuilder.setJarUrl( jarUrl );
     mapReduceJobBuilder.setResolvedJarUrl( resolvedJarUrl );
     mapReduceJobBuilder.setNumMapTasks( numMapTasks );
     mapReduceJobBuilder.setNumReduceTasks( numReduceTasks );
@@ -192,7 +196,7 @@ public class MapReduceJobBuilderImplTest {
     verify( configuration ).setOutputFormat( Float.class );
     verify( configuration ).setInputPaths( userPath1Path, userPath2Path );
     verify( configuration ).setOutputPath( userPath2Path );
-    verify( configuration ).setJar( resolvedJarUrl.toString() );
+    verify( configuration ).setJar( jarUrl );
     verify( configuration ).setNumMapTasks( numMapTasks );
     verify( configuration ).setNumReduceTasks( numReduceTasks );
     verify( logChannelInterface ).logBasic( logMeBasic );

--- a/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutor.java
+++ b/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutor.java
@@ -366,6 +366,7 @@ public class JobEntryHadoopJobExecutor extends JobEntryBase implements Cloneable
         MapReduceJobBuilder jobBuilder = mapReduceService.createJobBuilder( log, variables );
 
         jobBuilder.setResolvedJarUrl( resolvedJarUrl );
+        jobBuilder.setJarUrl( environmentSubstitute( jarUrl ) );
         jobBuilder.setHadoopJobName( environmentSubstitute( hadoopJobName ) );
 
         jobBuilder.setOutputKeyClass( environmentSubstitute( outputKeyClass ) );


### PR DESCRIPTION
The issue was introduced with the commit: https://github.com/pentaho/big-data-plugin/commit/ceb855aa6b215b43a82f9b5c353527a29b83d3d7
On the line: https://github.com/pentaho/big-data-plugin/blob/ceb855aa6b215b43a82f9b5c353527a29b83d3d7/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/MapReduceJobBuilderImpl.java#L193
we set into hadoop config.jar the path string after processing in resolveJarUrl method.

For the case when jarUrl has a space character (e.g. D:\PENT\ISSUES\6.1\BACKLOG-5885\Folder Test\pentaho-mapreduce-sample_MR2.jar),
we will set config.jar=file:/D:/PENT/ISSUES/6.1/BACKLOG-5885/Folder%20Test/pentaho-mapreduce-sample_MR2.jar with already encoded space.
Hadoop during processing jars (org.apache.hadoop.mapreduce.JobSubmitter.copyAndConfigureFiles(Job job, Path submitJobDir, short replication)) constructs its own path to jar (org.apache.hadoop.fs.Path jobJarPath = new org.apache.hadoop.fs.Path(jobJar))
And it seems that hadoop escapes %20 one more time (it looks like Folder%2520Test). In any case according to the doc (https://hadoop.apache.org/docs/r2.6.2/api/org/apache/hadoop/fs/Path.html#Path%28java.lang.String%29)
we should use path strings that are URIs, but with unescaped elements.

So the fix is just to use exactly that path that was entered by the user in config.jar  without any additional processing as it was implemented before.
Unit tests have been corrected.