### PR TITLE
[BACKLOG-6065]: PDI: "Hadoop Job Executor" step can't be changed in a new job.

### DIFF
--- a/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutorDialog.java
+++ b/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/JobEntryHadoopJobExecutorDialog.java
@@ -241,18 +241,20 @@ public class JobEntryHadoopJobExecutorDialog extends JobEntryDialog implements J
 
   private boolean isKnownNamedCluster( NamedCluster jobNameCluster, JobEntryHadoopJobExecutorController controller ) {
     boolean result = false;
-    String jncName = jobNameCluster.getName();
-    List<NamedCluster> nClusters = null;
-    try {
-      nClusters = controller.getNamedClusters();
-    } catch ( MetaStoreException e ) {
-      logger.error( e.getMessage(), e );
-    }
-    if ( jncName != null && nClusters != null ) {
-      for ( NamedCluster nc : nClusters ) {
-        if ( jncName != null && jncName.equals( nc.getName() ) ) {
-          result = true;
-          break;
+    if ( jobNameCluster != null ) {
+      String jncName = jobNameCluster.getName();
+      List<NamedCluster> nClusters = null;
+      try {
+        nClusters = controller.getNamedClusters();
+      } catch ( MetaStoreException e ) {
+        logger.error( e.getMessage(), e );
+      }
+      if ( jncName != null && nClusters != null ) {
+        for ( NamedCluster nc : nClusters ) {
+          if ( jncName != null && jncName.equals( nc.getName() ) ) {
+            result = true;
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
This issue has happened just because of missed Null check for NamedCluster in the fix https://github.com/pentaho/big-data-plugin/pull/588
So the fix is just to add null check.
No unit test because the change is on UI (in Dialog).