### PR TITLE
[BAD-475]: Need to update Big Data Plugin for Pentaho 6.1 with proper Shim List

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -140,15 +140,8 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-cdh54-package</artifactId>
-      <version>${dependency.hadoop-shims-cdh54.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-hdp22-package</artifactId>
-      <version>${dependency.hadoop-shims-hdp22.revision}</version>
+      <artifactId>pentaho-hadoop-shims-cdh55-package</artifactId>
+      <version>${dependency.hadoop-shims-cdh55.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -168,15 +161,8 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-emr34-package</artifactId>
-      <version>${dependency.hadoop-shims-emr34.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-emr41-package</artifactId>
-      <version>${dependency.hadoop-shims-emr41.revision}</version>
+      <artifactId>pentaho-hadoop-shims-emr310-package</artifactId>
+      <version>${dependency.hadoop-shims-emr310.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -219,7 +205,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-cdh54-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-cdh55-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
@@ -231,25 +217,13 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-hdp22-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-mapr410-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-emr34-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-emr41-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-emr310-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -43,28 +43,28 @@
     <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
     <plugin.org.codehaus.mojo.build-helper-maven-plugin.version>1.5</plugin.org.codehaus.mojo.build-helper-maven-plugin.version>
     <dependency.pentaho-registry.revision>6.1-SNAPSHOT</dependency.pentaho-registry.revision>
-    <dependency.hadoop-shims-cdh54.revision>6.1-SNAPSHOT</dependency.hadoop-shims-cdh54.revision>
+    <dependency.hadoop-shims-api.revision>6.1-SNAPSHOT</dependency.hadoop-shims-api.revision>
+    <dependency.hadoop-shims-cdh55.revision>6.1-SNAPSHOT</dependency.hadoop-shims-cdh55.revision>
+    <dependency.hadoop-shims-emr310.revision>6.1-SNAPSHOT</dependency.hadoop-shims-emr310.revision>
+    <dependency.hadoop-shims-mapr410.revision>6.1-SNAPSHOT</dependency.hadoop-shims-mapr410.revision>
+    <dependency.hadoop-shims-hdp23.revision>6.1-SNAPSHOT</dependency.hadoop-shims-hdp23.revision>
+    <dependency.hadoop-shims-hadoop-20.revision>6.1-SNAPSHOT</dependency.hadoop-shims-hadoop-20.revision>
     <dependency.guava.revision>17.0</dependency.guava.revision>
     <dependency.maven-resources-plugin.revision>2.7</dependency.maven-resources-plugin.revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <dependency.common.revision>3.3.0-v20070426</dependency.common.revision>
     <dependency.metastore.revision>6.1-SNAPSHOT</dependency.metastore.revision>
-    <dependency.hadoop-shims-emr41.revision>6.1-SNAPSHOT</dependency.hadoop-shims-emr41.revision>
     <dependency.commons-configuration.revision>1.9</dependency.commons-configuration.revision>
     <dependency.high-scale-lib.revision>1.1.2</dependency.high-scale-lib.revision>
     <dependency.mondrian.revision>3.12-SNAPSHOT</dependency.mondrian.revision>
     <dependency.kettle.revision>6.1-SNAPSHOT</dependency.kettle.revision>
-    <dependency.hadoop-shims-hadoop-20.revision>6.1-SNAPSHOT</dependency.hadoop-shims-hadoop-20.revision>
     <dependency.pentaho-reporting.revision>6.1-SNAPSHOT</dependency.pentaho-reporting.revision>
     <dependency.slf4j.revision>1.7.3</dependency.slf4j.revision>
     <dependency.jets3t.revision>0.9.3</dependency.jets3t.revision>
     <dependency.xstream.revision>1.4.2</dependency.xstream.revision>
-    <dependency.hadoop-shims-hdp22.revision>6.1-SNAPSHOT</dependency.hadoop-shims-hdp22.revision>
-    <dependency.hadoop-shims-mapr410.revision>6.1-SNAPSHOT</dependency.hadoop-shims-mapr410.revision>
     <dependency.oozie.revision>3.1.3-incubating</dependency.oozie.revision>
     <dependency.pentaho-metadata.revision>6.1-SNAPSHOT</dependency.pentaho-metadata.revision>
     <dependency.maven-clean-plugin.revision>2.5</dependency.maven-clean-plugin.revision>
-    <dependency.hadoop-shims-emr34.revision>6.1-SNAPSHOT</dependency.hadoop-shims-emr34.revision>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <dependency.libthrift.revision>0.6</dependency.libthrift.revision>
     <dependency.pentaho-database-model.revision>6.1-SNAPSHOT</dependency.pentaho-database-model.revision>
@@ -73,14 +73,12 @@
     <dependency.commands.revision>3.3.0-I20070605-0010</dependency.commands.revision>
     <publish-sonar-phase></publish-sonar-phase>
     <plugin.org.apache.maven.plugins.maven-failsafe-plugin.version>2.17</plugin.org.apache.maven.plugins.maven-failsafe-plugin.version>
-    <dependency.hadoop-shims-hdp23.revision>6.1-SNAPSHOT</dependency.hadoop-shims-hdp23.revision>
     <dependency.junit.revision>4.11</dependency.junit.revision>
     <dependency.pdi-osgi-bridge-core.revision>${project.version}</dependency.pdi-osgi-bridge-core.revision>
     <dependency.jline.revision>0.9.94</dependency.jline.revision>
     <dependency.pentaho-s3-vfs.revision>6.1-SNAPSHOT</dependency.pentaho-s3-vfs.revision>
     <dependency.commons-vfs-revision>2.1-20150824</dependency.commons-vfs-revision>
     <dependency.bean-matchers.revision>0.9</dependency.bean-matchers.revision>
-    <dependency.hadoop-shims-api.revision>6.1-SNAPSHOT</dependency.hadoop-shims-api.revision>
     <dependency.avro.revision>1.6.2</dependency.avro.revision>
     <dependency.pentaho-hadoop-hive-jdbc-shim.revision>6.1-SNAPSHOT</dependency.pentaho-hadoop-hive-jdbc-shim.revision>
     <dependency.cxf.revision>2.6.15</dependency.cxf.revision>


### PR DESCRIPTION
Updated poms with the proper shim list:
CDH 5.5
HDP 2.3
EMR 3.10
MapR 4.1