### PR TITLE
[BAD-482]: HBase Row Decoder: selected Hadoop cluster drop-down value is not saving

### DIFF
--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseConnectionException.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseConnectionException.java
@@ -1,0 +1,36 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+/**
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class HBaseConnectionException extends Exception {
+
+  private static final long serialVersionUID = -6215675067801506240L;
+
+  public HBaseConnectionException( String message, Throwable cause ) {
+    super( message, cause );
+  }
+
+}

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingUtils.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingUtils.java
@@ -1,0 +1,44 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase.mapping;
+
+import java.io.IOException;
+
+import org.pentaho.big.data.api.initializer.ClusterInitializationException;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseConnectionException;
+import org.pentaho.big.data.kettle.plugins.hbase.input.Messages;
+import org.pentaho.bigdata.api.hbase.HBaseConnection;
+
+public class MappingUtils {
+
+  public static MappingAdmin getMappingAdmin( ConfigurationProducer cProducer ) throws HBaseConnectionException {
+    HBaseConnection hbConnection = null;
+    try {
+      hbConnection = cProducer.getHBaseConnection();
+      hbConnection.checkHBaseAvailable();
+      return new MappingAdmin( hbConnection );
+    } catch ( ClusterInitializationException | IOException e ) {
+      throw new HBaseConnectionException( Messages.getString( "MappingDialog.Error.Message.UnableToConnect" ), e );
+    }
+  }
+
+}

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderDialog.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderDialog.java
@@ -44,6 +44,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.kettle.plugins.hbase.mapping.MappingEditor;
@@ -68,7 +69,7 @@ import java.util.List;
 
 /**
  * UI dialog for the HBase row decoder step
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
 public class HBaseRowDecoderDialog extends BaseStepDialog implements StepDialogInterface {
@@ -356,6 +357,10 @@ public class HBaseRowDecoderDialog extends BaseStepDialog implements StepDialogI
     if ( mapping != null ) {
       m_currentMeta.setMapping( mapping );
     }
+    NamedCluster selectedNamedCluster = m_mappingEditor.getSelectedNamedCluster();
+    if ( selectedNamedCluster != null ) {
+      m_currentMeta.setNamedCluster( selectedNamedCluster );
+    }
 
     if ( !m_originalMeta.equals( m_currentMeta ) ) {
       m_currentMeta.setChanged();
@@ -374,6 +379,7 @@ public class HBaseRowDecoderDialog extends BaseStepDialog implements StepDialogI
       m_incomingResultCombo.setText( m_currentMeta.getIncomingResultField() );
     }
 
+    m_mappingEditor.setSelectedNamedCluster( m_currentMeta.getNamedCluster().getName() );
     if ( m_currentMeta.getMapping() != null ) {
       m_mappingEditor.setMapping( m_currentMeta.getMapping() );
     }

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMeta.java
@@ -23,16 +23,17 @@
 package org.pentaho.big.data.kettle.plugins.hbase.rowdecoder;
 
 import org.eclipse.swt.widgets.Shell;
+import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
+import org.pentaho.big.data.kettle.plugins.hbase.NamedClusterLoadSaveUtil;
 import org.pentaho.bigdata.api.hbase.HBaseService;
 import org.pentaho.bigdata.api.hbase.mapping.Mapping;
 import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
-import org.pentaho.di.core.Counter;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -53,6 +54,7 @@ import org.pentaho.di.trans.step.StepDialogInterface;
 import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 import org.pentaho.di.trans.step.StepMetaInterface;
+import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.runtime.test.RuntimeTester;
 import org.pentaho.runtime.test.action.RuntimeTestActionService;
 import org.w3c.dom.Node;
@@ -63,15 +65,17 @@ import java.util.Set;
 
 /**
  * Meta class for the HBase row decoder.
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
- * 
+ *
  */
 @Step( id = "HBaseRowDecoder", image = "HBRD.svg", name = "HBaseRowDecoder.Name",
     description = "HBaseRowDecoder.Description",
     categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.BigData",
     i18nPackageName = "org.pentaho.di.trans.steps.hbaserowdecoder" )
 public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterface {
+
+  protected NamedCluster namedCluster;
 
   /** The incoming field that contains the HBase row key */
   protected String m_incomingKeyField = "";
@@ -86,6 +90,8 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
   private final RuntimeTestActionService runtimeTestActionService;
   private final RuntimeTester runtimeTester;
 
+  private final NamedClusterLoadSaveUtil namedClusterLoadSaveUtil;
+
   public HBaseRowDecoderMeta( NamedClusterServiceLocator namedClusterServiceLocator,
                               NamedClusterService namedClusterService,
                               RuntimeTestActionService runtimeTestActionService, RuntimeTester runtimeTester ) {
@@ -93,11 +99,29 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
     this.namedClusterService = namedClusterService;
     this.runtimeTestActionService = runtimeTestActionService;
     this.runtimeTester = runtimeTester;
+    this.namedClusterLoadSaveUtil = new NamedClusterLoadSaveUtil();
+  }
+
+
+
+  /**
+   * @param namedCluster the namedCluster to set
+   */
+  public void setNamedCluster( NamedCluster namedCluster ) {
+    this.namedCluster = namedCluster;
   }
 
   /**
+   * @return the namedCluster
+   */
+  public NamedCluster getNamedCluster() {
+    return namedCluster;
+  }
+
+
+  /**
    * Set the incoming field that holds the HBase row key
-   * 
+   *
    * @param inKey
    *          the name of the field that holds the key
    */
@@ -107,7 +131,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   /**
    * Get the incoming field that holds the HBase row key
-   * 
+   *
    * @return the name of the field that holds the key
    */
   public String getIncomingKeyField() {
@@ -116,7 +140,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   /**
    * Set the incoming field that holds the HBase row Result object
-   * 
+   *
    * @param inResult
    *          the name of the field that holds the HBase row Result object
    */
@@ -126,7 +150,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   /**
    * Get the incoming field that holds the HBase row Result object
-   * 
+   *
    * @return the name of the field that holds the HBase row Result object
    */
   public String getIncomingResultField() {
@@ -135,7 +159,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   /**
    * Set the mapping to use for decoding the row
-   * 
+   *
    * @param m
    *          the mapping to use
    */
@@ -145,7 +169,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   /**
    * Get the mapping to use for decoding the row
-   * 
+   *
    * @return the mapping to use
    */
   public Mapping getMapping() {
@@ -155,6 +179,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
   public void setDefault() {
     m_incomingKeyField = "";
     m_incomingResultField = "";
+    namedCluster = namedClusterService.getClusterTemplate();
   }
 
   @Override
@@ -231,7 +256,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   @Override
   public String getXML() {
-    StringBuffer retval = new StringBuffer();
+    StringBuilder retval = new StringBuilder();
 
     if ( !Const.isEmpty( m_incomingKeyField ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "incoming_key_field", m_incomingKeyField ) );
@@ -240,6 +265,8 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "incoming_result_field", m_incomingResultField ) );
     }
 
+    namedClusterLoadSaveUtil.getXml( retval, namedClusterService, namedCluster, repository == null ? null : repository
+        .getMetaStore(), log );
     if ( m_mapping != null ) {
       retval.append( m_mapping.getXML() );
     }
@@ -247,36 +274,39 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
     return retval.toString();
   }
 
-  public void loadXML( Node stepnode, List<DatabaseMeta> databases, Map<String, Counter> counters )
-    throws KettleXMLException {
-
+  public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
     m_incomingKeyField = XMLHandler.getTagValue( stepnode, "incoming_key_field" );
     m_incomingResultField = XMLHandler.getTagValue( stepnode, "incoming_result_field" );
-
+    this.namedCluster =
+        namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, null, repository, metaStore, stepnode, log );
     try {
-      m_mapping = namedClusterServiceLocator.getService( null, HBaseService.class ).getMappingFactory().createMapping();
+      m_mapping =
+          namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class ).getMappingFactory()
+              .createMapping();
     } catch ( ClusterInitializationException e ) {
       throw new KettleXMLException( e );
     }
     m_mapping.loadXML( stepnode );
-
   }
 
-  public void readRep( Repository rep, ObjectId id_step, List<DatabaseMeta> databases, Map<String, Counter> counters )
+  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
     throws KettleException {
 
     m_incomingKeyField = rep.getStepAttributeString( id_step, 0, "incoming_key_field" );
     m_incomingResultField = rep.getStepAttributeString( id_step, 0, "incoming_result_field" );
-
+    this.namedCluster =
+        namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, id_step, rep, metaStore, null, log );
     try {
-      m_mapping = namedClusterServiceLocator.getService( null, HBaseService.class ).getMappingFactory().createMapping();
+      m_mapping =
+          namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class ).getMappingFactory()
+              .createMapping();
     } catch ( ClusterInitializationException e ) {
       throw new KettleXMLException( e );
     }
     m_mapping.readRep( rep, id_step );
   }
 
-  public void saveRep( Repository rep, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
+  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
 
     if ( !Const.isEmpty( m_incomingKeyField ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "incoming_key_field", m_incomingKeyField );
@@ -285,6 +315,8 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
       rep.saveStepAttribute( id_transformation, id_step, 0, "incoming_result_field", m_incomingResultField );
     }
 
+    namedClusterLoadSaveUtil.saveRep( rep, metaStore, id_transformation, id_step, namedClusterService, namedCluster, log );
+
     if ( m_mapping != null ) {
       m_mapping.saveRep( rep, id_transformation, id_step );
     }
@@ -292,7 +324,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   /**
    * Get the UI for this step.
-   * 
+   *
    * @param shell
    *          a <code>Shell</code> value
    * @param meta
@@ -307,4 +339,5 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
     return new HBaseRowDecoderDialog( shell, meta, transMeta, name, namedClusterService, runtimeTestActionService,
       runtimeTester, namedClusterServiceLocator );
   }
+
 }

--- a/kettle-plugins/hbase/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/kettle-plugins/hbase/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,7 +19,7 @@
     <argument ref="runtimeTester"/>
     <pen:di-plugin type="org.pentaho.di.core.plugins.StepPluginType"/>
   </bean>
-  <bean id="hBaseRowDecoderMeta" class="org.pentaho.big.data.kettle.plugins.hbase.rowdecoder.HBaseRowDecoderMeta">
+  <bean id="hBaseRowDecoderMeta" class="org.pentaho.big.data.kettle.plugins.hbase.rowdecoder.HBaseRowDecoderMeta" scope="prototype">
     <argument ref="namedClusterServiceLocator"/>
     <argument ref="namedClusterService"/>
     <argument ref="runtimeTestActionService"/>

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingUtilsTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingUtilsTest.java
@@ -1,0 +1,93 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase.mapping;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.pentaho.big.data.api.initializer.ClusterInitializationException;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseConnectionException;
+import org.pentaho.bigdata.api.hbase.HBaseConnection;
+
+/**
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class MappingUtilsTest {
+
+  /**
+   *
+   */
+  private static final String UNABLE_TO_CONNECT_TO_H_BASE = "Unable to connect to HBase";
+  private ConfigurationProducer cProducerMock = mock( ConfigurationProducer.class );
+  private HBaseConnection hbConnectionMock = mock( HBaseConnection.class );
+
+  @Test
+  public void testGetMappingAdmin_NoException() {
+    try {
+      when( cProducerMock.getHBaseConnection() ).thenReturn( hbConnectionMock );
+      MappingAdmin mappingAdmin = MappingUtils.getMappingAdmin( cProducerMock );
+      assertNotNull( mappingAdmin );
+      assertSame( hbConnectionMock, mappingAdmin.getConnection() );
+      verify( hbConnectionMock ).checkHBaseAvailable();
+    } catch ( Exception e ) {
+      fail( "No exception expected but it occurs!" );
+    }
+  }
+
+  @Test
+  public void testGetMappingAdmin_ClusterInitializationExceptionToHBaseConnectionException() throws Exception {
+    ClusterInitializationException clusterInitializationException =
+        new ClusterInitializationException( new Exception( "ClusterInitializationException" ) );
+    try {
+      when( cProducerMock.getHBaseConnection() ).thenThrow( clusterInitializationException );
+      MappingUtils.getMappingAdmin( cProducerMock );
+      fail( "Expected HBaseConnectionException but it doen not occur!" );
+    } catch ( HBaseConnectionException e ) {
+      assertEquals( UNABLE_TO_CONNECT_TO_H_BASE, e.getMessage() );
+      assertSame( clusterInitializationException, e.getCause() );
+    }
+  }
+
+  @Test
+  public void testGetMappingAdmin_IOExceptionToHBaseConnectionException() throws Exception {
+    IOException ioException = new IOException( "IOException" );
+    try {
+      when( cProducerMock.getHBaseConnection() ).thenThrow( ioException );
+      MappingUtils.getMappingAdmin( cProducerMock );
+      fail( "Expected HBaseConnectionException but it doen not occur!" );
+    } catch ( HBaseConnectionException e ) {
+      assertEquals( UNABLE_TO_CONNECT_TO_H_BASE, e.getMessage() );
+      assertSame( ioException, e.getCause() );
+    }
+  }
+
+}


### PR DESCRIPTION
Added saving selected NamedCluster, loading already saved values;
Added unit tests.

Also fixed the incorrect scope for HBaseRowDecoderMeta (please see /pentaho-big-data-kettle-plugins-hbase/src/main/resources/OSGI-INF/blueprint/blueprint.xml)
It should be: scope="prototype".