### PR TITLE
[BACKLOG-6873]: Regression: NPE appears after clicking OK button if Hadoop Cluster is not chosen in "HBase Row Decoder" step

### DIFF
--- a/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseServiceImpl.java
+++ b/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseServiceImpl.java
@@ -63,8 +63,12 @@ public class HBaseServiceImpl implements HBaseService {
   public HBaseConnectionImpl getHBaseConnection( VariableSpace variableSpace, String siteConfig, String defaultConfig,
                                              LogChannelInterface logChannelInterface ) throws IOException {
     Properties connProps = new Properties();
-    String zooKeeperHost = variableSpace.environmentSubstitute( namedCluster.getZooKeeperHost() );
-    String zooKeeperPort = variableSpace.environmentSubstitute( namedCluster.getZooKeeperPort() );
+    String zooKeeperHost = null;
+    String zooKeeperPort  = null;
+    if ( namedCluster != null ) {
+      zooKeeperHost = variableSpace.environmentSubstitute( namedCluster.getZooKeeperHost() );
+      zooKeeperPort = variableSpace.environmentSubstitute( namedCluster.getZooKeeperPort() );
+    }
     if ( !Const.isEmpty( zooKeeperHost ) ) {
       connProps.setProperty( org.pentaho.hbase.shim.spi.HBaseConnection.ZOOKEEPER_QUORUM_KEY, zooKeeperHost );
     }

--- a/impl/shim/hbase/src/test/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseServiceImplTest.java
+++ b/impl/shim/hbase/src/test/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseServiceImplTest.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -137,5 +138,21 @@ public class HBaseServiceImplTest {
   @Test
   public void testGetResultFactory() {
     assertNotNull( hBaseService.getResultFactory() );
+  }
+
+  @Test
+  public void testGetHBaseConnectionWithNullNamedCluster() throws Exception {
+    String siteConfig = "site";
+    String defaultConfig = "default";
+    VariableSpace variableSpace = mock( VariableSpace.class );
+    LogChannelInterface logChannelInterface = mock( LogChannelInterface.class );
+    hBaseService = new HBaseServiceImpl( null, hadoopConfiguration );
+    try {
+      HBaseConnectionImpl hhBaseConnection =
+          hBaseService.getHBaseConnection( variableSpace, siteConfig, defaultConfig, logChannelInterface );
+      assertNotNull( hhBaseConnection );
+    } catch ( NullPointerException e ) {
+      fail( "No NPE is expected but it occurs" );
+    }
   }
 }

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingEditor.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingEditor.java
@@ -69,6 +69,7 @@ import org.pentaho.bigdata.api.hbase.table.HBaseTable;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.core.PropsUI;
 import org.pentaho.di.ui.core.dialog.ErrorDialog;
@@ -92,6 +93,8 @@ import org.pentaho.runtime.test.action.RuntimeTestActionService;
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
 public class MappingEditor extends Composite implements ConfigurationProducer {
+
+  private static final Class<?> PKG = MappingEditor.class;
 
   private final NamedClusterServiceLocator namedClusterServiceLocator;
   protected Shell m_shell;
@@ -584,6 +587,12 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
   }
 
   private void populateTableCombo( boolean force ) {
+    if ( namedClusterWidget != null && namedClusterWidget.getSelectedNamedCluster() == null ) {
+      MessageDialog.openError( m_shell, BaseMessages.getString( PKG,
+          "MappingDialog.Error.Title.NamedClusterNotSelected" ), BaseMessages.getString( PKG,
+              "MappingDialog.Error.Message.NamedClusterNotSelected.Msg" ) );
+      return;
+    }
 
     if ( m_configProducer == null ) {
       return;
@@ -639,6 +648,12 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
   }
 
   private void deleteMapping() {
+    if ( namedClusterWidget != null && namedClusterWidget.getSelectedNamedCluster() == null ) {
+      MessageDialog.openError( m_shell, BaseMessages.getString( PKG,
+          "MappingDialog.Error.Title.NamedClusterNotSelected" ), BaseMessages.getString( PKG,
+              "MappingDialog.Error.Message.NamedClusterNotSelected.Msg" ) );
+      return;
+    }
     String tableName = "";
     if ( !Const.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
       tableName = m_existingTableNamesCombo.getText().trim();
@@ -958,6 +973,12 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
   }
 
   private void saveMapping() {
+    if ( namedClusterWidget != null && namedClusterWidget.getSelectedNamedCluster() == null ) {
+      MessageDialog.openError( m_shell, BaseMessages.getString( PKG,
+          "MappingDialog.Error.Title.NamedClusterNotSelected" ), BaseMessages.getString( PKG,
+              "MappingDialog.Error.Message.NamedClusterNotSelected.Msg" ) );
+      return;
+    }
 
     Mapping theMapping = getMapping( true, null, false );
     if ( theMapping == null ) {
@@ -1208,9 +1229,6 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
   @Override public HBaseService getHBaseService() throws ClusterInitializationException {
     NamedCluster nc = namedClusterWidget.getSelectedNamedCluster();
-    if ( nc == null ) {
-      return null;
-    }
     return namedClusterServiceLocator.getService( nc, HBaseService.class );
   }
 

--- a/kettle-plugins/hbase/src/main/resources/org/pentaho/big/data/kettle/plugins/hbase/mapping/messages/messages_en_US.properties
+++ b/kettle-plugins/hbase/src/main/resources/org/pentaho/big/data/kettle/plugins/hbase/mapping/messages/messages_en_US.properties
@@ -1,0 +1,2 @@
+MappingDialog.Error.Message.NamedClusterNotSelected.Msg=You must select a named cluster to continue
+MappingDialog.Error.Title.NamedClusterNotSelected=No named cluster selected


### PR DESCRIPTION
There are a fix of NPE and unit test on it.
Also added checks for the cases when user is trying to save/delete Mapping into HBase but there is no any selected named cluster on MappingEditor. Changes are only on UI so no unit tests for it.
