### PR TITLE
[BAD-261] - PentahoTableInputFormat does not work on secured Hadoop cluster

### DIFF
--- a/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseConnectionWrapper.java
+++ b/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseConnectionWrapper.java
@@ -216,6 +216,11 @@ public class HBaseConnectionWrapper extends HBaseConnection {
     delegate.close();
   }
 
+  @Override
+  public void obtainAuthTokenForJob( org.pentaho.hadoop.shim.api.Configuration conf ) throws Exception {
+    delegate.obtainAuthTokenForJob( conf );
+  }
+
   public Result getCurrentResult() {
     try {
       return (Result) resultSetRowField.get( realImpl );

--- a/impl/shim/hbase/src/test/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseConnectionWrapperTest.java
+++ b/impl/shim/hbase/src/test/java/com/pentaho/big/data/bundles/impl/shim/hbase/HBaseConnectionWrapperTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pentaho.bigdata.api.hbase.HBaseConnection;
 import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.hadoop.shim.api.Configuration;
 import org.pentaho.hbase.shim.api.ColumnFilter;
 import org.pentaho.hbase.shim.api.HBaseValueMeta;
 import org.pentaho.hbase.shim.spi.HBaseBytesUtilShim;
@@ -347,6 +348,13 @@ public class HBaseConnectionWrapperTest {
   public void testClose() throws Exception {
     hBaseConnectionWrapper.close();
     verify( delegate ).close();
+  }
+
+  @Test
+  public void testObtainAuthTokenForJob() throws Exception {
+    Configuration configuration = mock( Configuration.class );
+    hBaseConnectionWrapper.obtainAuthTokenForJob( configuration );
+    verify( delegate ).obtainAuthTokenForJob( configuration );
   }
 
   @Test


### PR DESCRIPTION
* Added ObtainAuthTokenForJob method delegation