### PR TITLE
[BACKLOG-7925]: Spoon: Transformation becomes "modified" state when user close "Hadoop File Input" step's dialog using "Close" button.

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,6 +38,8 @@ import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.ShellAdapter;
+import org.eclipse.swt.events.ShellEvent;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
@@ -563,6 +565,14 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
     wWraps.addSelectionListener( lsFlags );
     wLayoutPaged.addSelectionListener( lsFlags );
     wAccFilenames.addSelectionListener( lsFlags );
+
+    // Detect X or ALT-F4 or something that kills this window...
+    shell.addShellListener( new ShellAdapter() {
+      public void shellClosed( ShellEvent e ) {
+        cancel();
+      }
+    } );
+
     wTabFolder.setSelection( 0 );
 
     // Set the shell size, based upon previous time...


### PR DESCRIPTION
Fixed like in HadoopFileOutputDialog. No unit test has been added because the change is only on UI component.