### PR TITLE
[BACKLOG-7927]: Spoon: Transformation doesn't become "modified" state when user close "Hadoop File Output" step's dialog using "OK" button.

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -1309,7 +1309,6 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     getData();
     activeFileNameField();
     enableParentFolder();
-    input.setChanged( changed );
 
     shell.open();
     while ( !shell.isDisposed() ) {


### PR DESCRIPTION
Fixed like in HadoopFileInputDialog. No unit test has been added because the change is on UI component.