### PR TITLE
[PDI-15176] Named Clusters dropdown doesn't preserve selected cluster a…

### DIFF
--- a/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/ui/entry/pmr/JobEntryHadoopTransJobExecutorController.java
+++ b/kettle-plugins/mapreduce/src/main/java/org/pentaho/big/data/kettle/plugins/mapreduce/ui/entry/pmr/JobEntryHadoopTransJobExecutorController.java
@@ -1481,15 +1481,21 @@ public class JobEntryHadoopTransJobExecutorController extends AbstractXulEventHa
   public void editNamedCluster() throws MetaStoreException {
     if ( isSelectedNamedCluster() ) {
       String newNcName = ncDelegate.editNamedCluster( null, getSelectedNamedCluster(), getJobEntryDialog() );
-      namedClustersChanged();
-      selectedNamedClusterChanged( getNamedClusterName( getSelectedNamedCluster() ), newNcName );
+      if ( newNcName != null ) {
+        //cancel button on editing pressed, clusters not changed
+        namedClustersChanged();
+        selectedNamedClusterChanged( getNamedClusterName( getSelectedNamedCluster() ), newNcName );
+      }
     }
   }
 
   public void newNamedCluster() throws MetaStoreException {
     String newNcName = ncDelegate.newNamedCluster( jobMeta, null, getJobEntryDialog() );
-    namedClustersChanged();
-    selectedNamedClusterChanged( getNamedClusterName( getSelectedNamedCluster() ), newNcName );
+    if ( newNcName != null ) {
+      //cancel button on editing pressed, clusters not changed
+      namedClustersChanged();
+      selectedNamedClusterChanged( getNamedClusterName( getSelectedNamedCluster() ), newNcName );
+    }
   }
 
   private Shell getJobEntryDialog() {

--- a/kettle-plugins/oozie/src/main/java/org/pentaho/big/data/kettle/plugins/oozie/OozieJobExecutorConfig.java
+++ b/kettle-plugins/oozie/src/main/java/org/pentaho/big/data/kettle/plugins/oozie/OozieJobExecutorConfig.java
@@ -28,6 +28,7 @@ import org.pentaho.big.data.kettle.plugins.job.JobEntryMode;
 import org.pentaho.big.data.kettle.plugins.job.PropertyEntry;
 import org.pentaho.ui.xul.XulEventSource;
 import org.pentaho.ui.xul.stereotype.Bindable;
+import org.pentaho.ui.xul.util.AbstractModelList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +46,7 @@ public class OozieJobExecutorConfig extends BlockableJobConfig implements XulEve
   public static final String OOZIE_WORKFLOW_PROPERTIES = "oozieWorkflowProperties";
   public static final String MODE = "mode";
 
-  private transient List<NamedCluster> namedClusters;
+  private transient AbstractModelList<NamedCluster> namedClusters;
   private transient NamedCluster namedCluster = null; // selected
   private String clusterName; // saved (String)
   private String oozieUrl = null;
@@ -57,6 +58,7 @@ public class OozieJobExecutorConfig extends BlockableJobConfig implements XulEve
   private String mode = null;
 
   public OozieJobExecutorConfig() {
+    namedClusters = new AbstractModelList<>(  );
   }
 
   @Bindable
@@ -101,7 +103,7 @@ public class OozieJobExecutorConfig extends BlockableJobConfig implements XulEve
   }
 
   @Bindable
-  public void setNamedClusters( List<NamedCluster> namedClusters ) {
+  public void setNamedClusters( AbstractModelList<NamedCluster> namedClusters ) {
     this.namedClusters = namedClusters;
   }
 

--- a/kettle-plugins/oozie/src/main/java/org/pentaho/big/data/kettle/plugins/oozie/OozieJobExecutorJobEntryDialog.java
+++ b/kettle-plugins/oozie/src/main/java/org/pentaho/big/data/kettle/plugins/oozie/OozieJobExecutorJobEntryDialog.java
@@ -23,7 +23,6 @@
 package org.pentaho.big.data.kettle.plugins.oozie;
 
 import org.eclipse.swt.widgets.Shell;
-import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.plugins.common.ui.HadoopClusterDelegateImpl;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
@@ -31,11 +30,9 @@ import org.pentaho.di.job.entry.JobEntryDialogInterface;
 import org.pentaho.di.job.entry.JobEntryInterface;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.ui.core.database.dialog.tags.ExtTextbox;
-import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.job.entry.JobEntryDialog;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.spoon.XulSpoonSettingsManager;
-import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.XulException;
 import org.pentaho.ui.xul.XulRunner;
@@ -44,9 +41,7 @@ import org.pentaho.ui.xul.binding.DefaultBindingFactory;
 import org.pentaho.ui.xul.swt.SwtXulLoader;
 import org.pentaho.ui.xul.swt.SwtXulRunner;
 
-import java.util.Collections;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.ResourceBundle;
 
 /**
@@ -100,20 +95,7 @@ public class OozieJobExecutorJobEntryDialog extends JobEntryDialog implements Jo
       XulDomContainer container, BindingFactory bindingFactory ) {
     return new OozieJobExecutorJobEntryController( jobMeta, container, jobEntry, bindingFactory,
       new HadoopClusterDelegateImpl( Spoon.getInstance(), jobEntry.getNamedClusterService(),
-        jobEntry.getRuntimeTestActionService(), jobEntry.getRuntimeTester() ),
-      getNamedClusters( jobEntry ) );
-  }
-
-  private List<NamedCluster> getNamedClusters( OozieJobExecutorJobEntry jobEntry ) {
-    try {
-      return jobEntry.getNamedClusterService().list( Spoon.getInstance().getMetaStore() );
-    } catch ( MetaStoreException e ) {
-      new ErrorDialog( parent,
-        getMessage( "ErrorLoadingClusters.Title" ),
-        getMessage( "ErrorLoadingClusters.Message" ),
-        e );
-      return Collections.emptyList();
-    }
+        jobEntry.getRuntimeTestActionService(), jobEntry.getRuntimeTester() ) );
   }
 
   private String getMessage( String key ) {

--- a/kettle-plugins/sqoop/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/ui/AbstractSqoopJobEntryController.java
+++ b/kettle-plugins/sqoop/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/ui/AbstractSqoopJobEntryController.java
@@ -25,6 +25,7 @@ package org.pentaho.big.data.kettle.plugins.sqoop.ui;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Shell;
 import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.kettle.plugins.hdfs.vfs.HadoopVfsFileChooserDialog;
@@ -60,6 +61,7 @@ import org.pentaho.ui.xul.binding.BindingFactory;
 import org.pentaho.ui.xul.components.XulButton;
 import org.pentaho.ui.xul.components.XulMenuList;
 import org.pentaho.ui.xul.containers.XulDeck;
+import org.pentaho.ui.xul.containers.XulDialog;
 import org.pentaho.ui.xul.containers.XulTree;
 import org.pentaho.ui.xul.util.AbstractModelList;
 import org.pentaho.vfs.ui.CustomVfsUiPanel;
@@ -67,8 +69,6 @@ import org.pentaho.vfs.ui.VfsFileChooserDialog;
 
 import java.util.Collection;
 import java.util.List;
-
-import static org.pentaho.big.data.kettle.plugins.sqoop.SqoopConfig.TABLE;
 
 /**
  * Base functionality to support a Sqoop job entry controller that provides most of the common functionality to back a
@@ -201,7 +201,7 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
     // TODO Determine if separate schema field is required, this has to be provided as part of the --table argument
     // anyway.
     // bindings.add(bindingFactory.createBinding(config, SCHEMA, SCHEMA, VALUE));
-    bindings.add( bindingFactory.createBinding( config, TABLE, TABLE, VALUE ) );
+    bindings.add( bindingFactory.createBinding( config, SqoopConfig.TABLE, SqoopConfig.TABLE, VALUE ) );
 
     bindings.add( bindingFactory.createBinding( config, SqoopConfig.COMMAND_LINE, SqoopConfig.COMMAND_LINE, VALUE ) );
 
@@ -1001,4 +1001,40 @@ public abstract class AbstractSqoopJobEntryController<S extends SqoopConfig, E e
     }
     updateDeleteButton();
   }
+
+  public void newNamedCluster( String stepName ) {
+    XulDialog xulDialog = (XulDialog) getXulDomContainer().getDocumentRoot().getElementById( stepName );
+    Shell shell = (Shell) xulDialog.getRootObject();
+    String newNamedCluster = ncDelegate.newNamedCluster( jobMeta, null, shell );
+    if ( newNamedCluster != null ) {
+      //cancel button on editing pressed, clusters not changed
+      populateNamedClusters();
+      selectNamedCluster( newNamedCluster );
+    }
+  }
+
+  public void editNamedCluster( String stepName ) {
+    if ( isSelectedNamedCluster() ) {
+      XulDialog xulDialog = (XulDialog) getXulDomContainer().getDocumentRoot().getElementById( stepName );
+      Shell shell = (Shell) xulDialog.getRootObject();
+      String clusterName = ncDelegate.editNamedCluster( null, selectedNamedCluster, shell );
+      if ( clusterName != null ) {
+        //cancel button on editing pressed, clusters not changed
+        populateNamedClusters();
+        selectNamedCluster( clusterName );
+      }
+    }
+  }
+
+  public void selectNamedCluster( String configName ) {
+    @SuppressWarnings( "unchecked" )
+    XulMenuList<NamedCluster> namedConfigMenu =
+      (XulMenuList<NamedCluster>) container.getDocumentRoot().getElementById( "named-clusters" );
+    for ( NamedCluster nc : getNamedClusters() ) {
+      if ( configName != null && configName.equals( nc.getName() ) ) {
+        namedConfigMenu.setSelectedItem( nc );
+      }
+    }
+  }
+
 }

--- a/kettle-plugins/sqoop/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/ui/SqoopExportJobEntryController.java
+++ b/kettle-plugins/sqoop/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/ui/SqoopExportJobEntryController.java
@@ -25,7 +25,6 @@ package org.pentaho.big.data.kettle.plugins.sqoop.ui;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
-import org.eclipse.swt.widgets.Shell;
 import org.pentaho.big.data.kettle.plugins.hdfs.vfs.Schemes;
 import org.pentaho.big.data.kettle.plugins.sqoop.AbstractSqoopJobEntry;
 import org.pentaho.big.data.kettle.plugins.sqoop.SqoopExportConfig;
@@ -37,18 +36,17 @@ import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.binding.Binding;
 import org.pentaho.ui.xul.binding.BindingFactory;
-import org.pentaho.ui.xul.containers.XulDialog;
 import org.pentaho.vfs.ui.VfsFileChooserDialog;
 
 import java.util.Collection;
-
-import static org.pentaho.big.data.kettle.plugins.sqoop.SqoopExportConfig.EXPORT_DIR;
 
 /**
  * Controller for the Sqoop Export Dialog.
  */
 public class SqoopExportJobEntryController extends
     AbstractSqoopJobEntryController<SqoopExportConfig, SqoopExportJobEntry> {
+
+  public static final String SQOOP_EXPORT_STEP_NAME = "sqoop-export";
 
   public SqoopExportJobEntryController( JobMeta jobMeta, XulDomContainer container, SqoopExportJobEntry sqoopJobEntry,
       BindingFactory bindingFactory ) {
@@ -57,7 +55,7 @@ public class SqoopExportJobEntryController extends
 
   @Override
   public String getDialogElementId() {
-    return "sqoop-export";
+    return SQOOP_EXPORT_STEP_NAME;
   }
 
   @Override
@@ -65,7 +63,7 @@ public class SqoopExportJobEntryController extends
       Collection<Binding> bindings ) {
     super.createBindings( config, container, bindingFactory, bindings );
 
-    bindings.add( bindingFactory.createBinding( config, EXPORT_DIR, EXPORT_DIR, "value" ) );
+    bindings.add( bindingFactory.createBinding( config, SqoopExportConfig.EXPORT_DIR, SqoopExportConfig.EXPORT_DIR, "value" ) );
   }
 
   public void browseForExportDirectory() {
@@ -109,18 +107,10 @@ public class SqoopExportJobEntryController extends
   }
 
   public void editNamedCluster() {
-    if ( isSelectedNamedCluster() ) {
-      XulDialog xulDialog = (XulDialog) getXulDomContainer().getDocumentRoot().getElementById( "sqoop-export" );
-      Shell shell = (Shell) xulDialog.getRootObject();
-      ncDelegate.editNamedCluster( null, selectedNamedCluster, shell );
-      populateNamedClusters();
-    }
+    editNamedCluster( SQOOP_EXPORT_STEP_NAME );
   }
 
   public void newNamedCluster() {
-    XulDialog xulDialog = (XulDialog) getXulDomContainer().getDocumentRoot().getElementById( "sqoop-export" );
-    Shell shell = (Shell) xulDialog.getRootObject();
-    ncDelegate.newNamedCluster( jobMeta, null, shell );
-    populateNamedClusters();
+    newNamedCluster( SQOOP_EXPORT_STEP_NAME );
   }
 }

--- a/kettle-plugins/sqoop/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/ui/SqoopImportJobEntryController.java
+++ b/kettle-plugins/sqoop/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/ui/SqoopImportJobEntryController.java
@@ -24,7 +24,6 @@ package org.pentaho.big.data.kettle.plugins.sqoop.ui;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
-import org.eclipse.swt.widgets.Shell;
 import org.pentaho.big.data.kettle.plugins.hdfs.vfs.Schemes;
 import org.pentaho.big.data.kettle.plugins.sqoop.AbstractSqoopJobEntry;
 import org.pentaho.big.data.kettle.plugins.sqoop.SqoopImportConfig;
@@ -36,18 +35,17 @@ import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.binding.Binding;
 import org.pentaho.ui.xul.binding.BindingFactory;
-import org.pentaho.ui.xul.containers.XulDialog;
 import org.pentaho.vfs.ui.VfsFileChooserDialog;
 
 import java.util.Collection;
-
-import static org.pentaho.big.data.kettle.plugins.sqoop.SqoopImportConfig.TARGET_DIR;
 
 /**
  * Controller for the Sqoop Import Dialog.
  */
 public class SqoopImportJobEntryController extends
     AbstractSqoopJobEntryController<SqoopImportConfig, SqoopImportJobEntry> {
+
+  public static final String SQOOP_IMPORT_STEP_NAME = "sqoop-import";
 
   public SqoopImportJobEntryController( JobMeta jobMeta, XulDomContainer container, SqoopImportJobEntry sqoopJobEntry,
       BindingFactory bindingFactory ) {
@@ -64,7 +62,7 @@ public class SqoopImportJobEntryController extends
       Collection<Binding> bindings ) {
     super.createBindings( config, container, bindingFactory, bindings );
 
-    bindings.add( bindingFactory.createBinding( config, TARGET_DIR, TARGET_DIR, "value" ) );
+    bindings.add( bindingFactory.createBinding( config, SqoopImportConfig.TARGET_DIR, SqoopImportConfig.TARGET_DIR, "value" ) );
   }
 
   public void browseForTargetDirectory() {
@@ -101,18 +99,10 @@ public class SqoopImportJobEntryController extends
   }
 
   public void editNamedCluster() {
-    if ( isSelectedNamedCluster() ) {
-      XulDialog xulDialog = (XulDialog) getXulDomContainer().getDocumentRoot().getElementById( "sqoop-import" );
-      Shell shell = (Shell) xulDialog.getRootObject();
-      ncDelegate.editNamedCluster( null, selectedNamedCluster, shell );
-      populateNamedClusters();
-    }
+    editNamedCluster( SQOOP_IMPORT_STEP_NAME );
   }
 
   public void newNamedCluster() {
-    XulDialog xulDialog = (XulDialog) getXulDomContainer().getDocumentRoot().getElementById( "sqoop-import" );
-    Shell shell = (Shell) xulDialog.getRootObject();
-    ncDelegate.newNamedCluster( jobMeta, null, shell );
-    populateNamedClusters();
+    newNamedCluster( SQOOP_IMPORT_STEP_NAME );
   }
 }


### PR DESCRIPTION
fixed also BACKLOG-8083 and losing selected cluster on cancel in dialog "cluster details", 
For future as written in comment to BACKLOG-8082 the logic will be much better to be the same for all cluster selection

Actually in code we have different ways of selecting named cluster and dublication of logic. In some places NamedClusterWidgetImpl used while in others HadoopClusterDelegateImpl which is incapsulated in NamedClusterWidgetImpl. Also some logic which is in NamedClusterWidgetImpl is dublicated in Sqoop Import, Sqoop Export, Oozie controllers (i.e. editNamedCluster, newNamedCluster, initiate - which is populateNamedClusters). This dublication comes to several bugs such as this, http://jira.pentaho.com/browse/PDI-15176 and http://jira.pentaho.com/browse/BACKLOG-7972 and spending time to support different implementations, test them separately and fix.

But for now it's a fix with partial uniting of logic for sqoop steps
