### PR TITLE
[BACKLOG-8389] - Upgrade antlr to version 3.4 across Pentaho product suite - changes for pentaho big-data-plugin repository

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -15,9 +15,15 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>antlr</groupId>
+      <groupId>org.antlr</groupId>
       <artifactId>antlr</artifactId>
-      <version>2.7.7</version>
+      <version>3.4-complete</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ascsapjco3wrp</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -27,7 +27,6 @@
       <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}
       </outputFileNameMapping>
       <includes>
-        <include>antlr:antlr</include>
         <include>ascsapjco3wrp:ascsapjco3wrp</include>
         <include>asm:asm</include>
         <include>bouncycastle:bcmail-jdk14</include>


### PR DESCRIPTION
Replace antlr-2.7.7 with antlr-3.4-complete which contains antlr-2.7.7.
Exclude antlr-runtime  in the pentaho-big-data-assemblies-pmr-libraries pom because of build failure.

To build pentaho-big-data-assemblies-pmr-libraries it previously needs to build:

 - pentaho-reporting-engine-classic-core as it was changed to use antlr-3.4-complete (pentaho/pentaho-reporting#790);
 - pentaho-kettle-engine as it uses pentaho-reporting-engine-classic-core;
 - pentaho-platform as it has dependency on antlr-3.4-complete, pentaho-kettle-engine, pentaho-reporting-engine-classic-core (pentaho/pentaho-platform#2946).