### PR TITLE
[BACKLOG-8748] Support for SparkSQL

### DIFF
--- a/impl/shim/hive/src/main/java/com/pentaho/big/data/bundles/impl/shim/hive/ShimDriverLoader.java
+++ b/impl/shim/hive/src/main/java/com/pentaho/big/data/bundles/impl/shim/hive/ShimDriverLoader.java
@@ -51,6 +51,7 @@ public class ShimDriverLoader implements HadoopConfigurationListener {
   public static final String HIVE_2_SIMBA = "hive2Simba";
   public static final String IMPALA = "Impala";
   public static final String IMPALA_SIMBA = "ImpalaSimba";
+  public static final String SPARK_SIMBA = "SparkSqlSimba";
 
   private final Logger LOGGER = LoggerFactory.getLogger( ShimDriverLoader.class );
 
@@ -89,6 +90,7 @@ public class ShimDriverLoader implements HadoopConfigurationListener {
     hiveDriverFactoryMap.put( HIVE_2_SIMBA, HiveSimbaDriver::new );
     hiveDriverFactoryMap.put( IMPALA, ImpalaDriver::new );
     hiveDriverFactoryMap.put( IMPALA_SIMBA, ImpalaSimbaDriver::new );
+    hiveDriverFactoryMap.put( SPARK_SIMBA, SparkSimbaDriver::new );
     return hiveDriverFactoryMap;
   }
 

--- a/impl/shim/hive/src/main/java/com/pentaho/big/data/bundles/impl/shim/hive/SparkSimbaDriver.java
+++ b/impl/shim/hive/src/main/java/com/pentaho/big/data/bundles/impl/shim/hive/SparkSimbaDriver.java
@@ -20,13 +20,25 @@
  *
  ******************************************************************************/
 
-package org.apache.hive.jdbc;
+package com.pentaho.big.data.bundles.impl.shim.hive;
 
-import org.pentaho.big.data.kettle.plugins.hive.DummyDriver;
+import org.pentaho.big.data.api.jdbc.JdbcUrlParser;
 
-/**
- * DummyDriver implementation to avoid CNF exception
- * when ImpalaDatabaseMeta is loaded.  See DummyDriver.
- */
-public class ImpalaDriver extends DummyDriver {
+import java.sql.Driver;
+import java.sql.SQLException;
+
+public class SparkSimbaDriver extends HiveSimbaDriver {
+  public SparkSimbaDriver( Driver delegate, String hadoopConfigurationId, boolean defaultConfiguration,
+                          JdbcUrlParser jdbcUrlParser ) {
+    super( delegate, hadoopConfigurationId, defaultConfiguration, jdbcUrlParser );
+  }
+
+  @Override
+  protected Driver checkBeforeCallActiveDriver( String url ) throws SQLException {
+    if ( !url.contains( SIMBA_SPECIFIC_URL_PARAMETER ) || !url.matches( ".+:spark:.*" ) ) {
+      // BAD-215 check required to distinguish Simba driver
+      return null;
+    }
+    return delegate;
+  }
 }

--- a/kettle-plugins/hive/pom.xml
+++ b/kettle-plugins/hive/pom.xml
@@ -58,6 +58,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>

--- a/kettle-plugins/hive/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/kettle-plugins/hive/src/main/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -25,27 +25,8 @@ package org.apache.hadoop.hive.jdbc;
 import org.pentaho.big.data.kettle.plugins.hive.DummyDriver;
 
 /**
- * <p>
- * This is proxy driver for the Hive JDBC Driver available through the current
- * active Hadoop configuration.
- * </p>
- * <p>
- * This driver is named exactly the same as the official Apache Hive driver
- * so no further modifications are required by calling code to swap in this
- * proxy.
- * </p>
- * <p>
- * This class uses reflection to attempt to find the Big Data Plugin and load
- * the HadoopConfigurationBootstrap so we have access to the Hive JDBC driver
- * that is compatible with the currently selected Hadoop configuration. All
- * operations are delegated to the current active Hadoop configuration's Hive
- * JDBC driver via HadoopConfiguration#getHiveJdbcDriver.
- * </p>
- * <p>
- * All calls to the loaded HiveDriver will have the current Thread's context
- * class loader set to the class that loaded the driver so subsequent resource
- * lookups are successful.
- * </p>
+ * DummyDriver implementation to avoid CNF exception
+ * when Hive2DatabaseMeta is loaded.  See DummyDriver.
  */
 public class HiveDriver extends DummyDriver {
 }

--- a/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/HiveDriver.java
+++ b/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/HiveDriver.java
@@ -25,27 +25,8 @@ package org.apache.hive.jdbc;
 import org.pentaho.big.data.kettle.plugins.hive.DummyDriver;
 
 /**
- * <p>
- * This is proxy driver for the Hive Server 2 JDBC Driver available through the current
- * active Hadoop configuration.
- * </p>
- * <p>
- * This driver is named exactly the same as the official Apache Hive driver
- * so no further modifications are required by calling code to swap in this
- * proxy.
- * </p>
- * <p>
- * This class uses reflection to attempt to find the Big Data Plugin and load
- * the HadoopConfigurationBootstrap so we have access to the Hive JDBC driver
- * that is compatible with the currently selected Hadoop configuration. All
- * operations are delegated to the current active Hadoop configuration's Hive
- * JDBC driver via HadoopConfiguration#getHiveJdbcDriver.
- * </p>
- * <p>
- * All calls to the loaded HiveDriver will have the current Thread's context
- * class loader set to the class that loaded the driver so subsequent resource
- * lookups are successful.
- * </p>
+ * DummyDriver implementation to avoid CNF exception
+ * when HiveDatabaseMeta is loaded.  See DummyDriver.
  */
 public class HiveDriver extends DummyDriver {
 }

--- a/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/HiveSimbaDriver.java
+++ b/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/HiveSimbaDriver.java
@@ -25,7 +25,8 @@ package org.apache.hive.jdbc;
 import org.pentaho.big.data.kettle.plugins.hive.DummyDriver;
 
 /**
- * User: Dzmitry Stsiapanau Date: 7/2/2015 Time: 03:42
+ * DummyDriver implementation to avoid CNF exception
+ * when HiveSimbaDatabaseMeta is loaded.  See DummyDriver.
  */
 public class HiveSimbaDriver extends DummyDriver {
 }

--- a/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/ImpalaSimbaDriver.java
+++ b/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/ImpalaSimbaDriver.java
@@ -25,7 +25,8 @@ package org.apache.hive.jdbc;
 import org.pentaho.big.data.kettle.plugins.hive.DummyDriver;
 
 /**
- * User: Dzmitry Stsiapanau Date: 7/2/2015 Time: 03:42
+ * DummyDriver implementation to avoid CNF exception
+ * when ImpalaSimbaDatabaseMeta is loaded.  See DummyDriver.
  */
 public class ImpalaSimbaDriver extends DummyDriver {
 }

--- a/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/SparkSqlSimbaDriver.java
+++ b/kettle-plugins/hive/src/main/java/org/apache/hive/jdbc/SparkSqlSimbaDriver.java
@@ -26,7 +26,7 @@ import org.pentaho.big.data.kettle.plugins.hive.DummyDriver;
 
 /**
  * DummyDriver implementation to avoid CNF exception
- * when ImpalaDatabaseMeta is loaded.  See DummyDriver.
+ * when SparkSqlSimbaDriver is loaded.  See DummyDriver.
  */
-public class ImpalaDriver extends DummyDriver {
+public class SparkSqlSimbaDriver extends DummyDriver {
 }

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/BaseSimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/BaseSimbaDatabaseMeta.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.pentaho.big.data.api.jdbc.DriverLocator;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public abstract class BaseSimbaDatabaseMeta extends Hive2DatabaseMeta {
+
+  @VisibleForTesting static final String ODBC_DRIVER_CLASS_NAME = "sun.jdbc.odbc.JdbcOdbcDriver";
+  @VisibleForTesting static final String KRB_HOST_FQDN = "KrbHostFQDN";
+  @VisibleForTesting static final String KRB_SERVICE_NAME = "KrbServiceName";
+  @VisibleForTesting static final String URL_IS_CONFIGURED_THROUGH_JNDI = "Url is configured through JNDI";
+  @VisibleForTesting static final String JDBC_ODBC_S = "jdbc:odbc:%s";
+
+  private final String jdbcUrlTemplate;
+  private static final String DEFAULT_DB = "default";
+
+  public BaseSimbaDatabaseMeta( DriverLocator driverLocator ) {
+    super( driverLocator );
+    jdbcUrlTemplate = getJdbcPrefix() + "%s:%d/%s;AuthMech=%d%s";
+  }
+
+  protected abstract String getJdbcPrefix();
+
+  @Override
+  public abstract String getDriverClass();
+
+  @Override public int[] getAccessTypeList() {
+    return new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI };
+  }
+
+  @Override public String getURL( String hostname, String port, String databaseName ) {
+    Integer portNumber;
+    if ( Const.isEmpty( port ) ) {
+      portNumber = getDefaultDatabasePort();
+    } else {
+      portNumber = Integer.valueOf( port );
+    }
+    if ( Const.isEmpty( databaseName ) ) {
+      databaseName = DEFAULT_DB;
+    }
+    switch ( getAccessType() ) {
+      case DatabaseMeta.TYPE_ACCESS_ODBC: {
+        return String.format( JDBC_ODBC_S, databaseName );
+      }
+      case DatabaseMeta.TYPE_ACCESS_JNDI: {
+        return URL_IS_CONFIGURED_THROUGH_JNDI;
+      }
+      case DatabaseMeta.TYPE_ACCESS_NATIVE:
+      default: {
+        Integer authMethod = 0;
+        StringBuilder additional = new StringBuilder();
+        String userName = getUsername();
+        String password = getPassword();
+        String krbFQDN = getProperty( KRB_HOST_FQDN );
+        String extraKrbFQDN = getExtraProperty( KRB_HOST_FQDN );
+        String krbPrincipal = getProperty( KRB_SERVICE_NAME );
+        String extraKrbPrincipal = getExtraProperty( KRB_SERVICE_NAME );
+        if ( ( !Const.isEmpty( krbPrincipal ) || !Const.isEmpty( extraKrbPrincipal ) ) && ( !Const.isEmpty( krbFQDN )
+          || !Const.isEmpty( extraKrbFQDN ) ) ) {
+          authMethod = 1;
+        } else if ( !Const.isEmpty( userName ) ) {
+          additional.append( ";UID=" );
+          additional.append( userName );
+          if ( !Const.isEmpty( password ) ) {
+            authMethod = 3;
+            additional.append( ";PWD=" );
+            additional.append( password );
+          } else {
+            authMethod = 2;
+          }
+        }
+        return String.format( jdbcUrlTemplate, hostname, portNumber, databaseName, authMethod, additional );
+      }
+    }
+  }
+
+  private String getExtraProperty( String key ) {
+    return getAttributes().getProperty( ATTRIBUTE_PREFIX_EXTRA_OPTION + getPluginId() + "." + key );
+  }
+
+  private String getProperty( String key ) {
+    return getAttributes().getProperty( key );
+  }
+
+  /**
+   * This method assumes that Hive has no concept of primary and technical keys and auto increment columns. We are
+   * ignoring the tk, pk and useAutoinc parameters.
+   */
+  @Override
+  public String getFieldDefinition( ValueMetaInterface v, String tk, String pk, boolean useAutoinc,
+                                    boolean addFieldname, boolean addCr ) {
+    StringBuilder retval = new StringBuilder();
+
+    String fieldname = v.getName();
+    int length = v.getLength();
+    int precision = v.getPrecision();
+
+    if ( addFieldname ) {
+      retval.append( fieldname ).append( ' ' );
+    }
+    int type = v.getType();
+    switch ( type ) {
+      case ValueMetaInterface.TYPE_BOOLEAN:
+        retval.append( "BOOLEAN" );
+        break;
+
+      case ValueMetaInterface.TYPE_DATE:
+        retval.append( "DATE" );
+        break;
+
+      case ValueMetaInterface.TYPE_TIMESTAMP:
+        retval.append( "TIMESTAMP" );
+        break;
+
+      case ValueMetaInterface.TYPE_STRING:
+        retval.append( "VARCHAR" );
+        break;
+
+      case ValueMetaInterface.TYPE_NUMBER:
+      case ValueMetaInterface.TYPE_INTEGER:
+      case ValueMetaInterface.TYPE_BIGNUMBER:
+        // Integer values...
+        if ( precision == 0 ) {
+          if ( length > 9 ) {
+            if ( length < 19 ) {
+              // can hold signed values between -9223372036854775808 and 9223372036854775807
+              // 18 significant digits
+              retval.append( "BIGINT" );
+            } else {
+              retval.append( "FLOAT" );
+            }
+          } else {
+            retval.append( "INT" );
+          }
+        } else {
+          // Floating point values...
+          if ( length > 15 ) {
+            retval.append( "FLOAT" );
+          } else {
+            // A double-precision floating-point number is accurate to approximately 15 decimal places.
+            // http://mysql.mirrors-r-us.net/doc/refman/5.1/en/numeric-type-overview.html
+            retval.append( "DOUBLE" );
+          }
+        }
+        break;
+    }
+    return retval.toString();
+  }
+}

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/DummyDriver.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/DummyDriver.java
@@ -31,6 +31,14 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 /**
+ * DummyDriver is a bare Driver implementation used as a way
+ * to avoid ClassNotFoundException when kettle attempts to load
+ * the class associated with each meta.
+ *
+ * The classes which extend DummyDriver have the same unique
+ * names as the name exposed by .getDriverClass() in the
+ * DatabaseMeta implementation.
+ *
  * Created by bryan on 3/30/16.
  */
 public class DummyDriver implements Driver {

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/Hive2SimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/Hive2SimbaDatabaseMeta.java
@@ -22,33 +22,26 @@
 
 package org.pentaho.big.data.kettle.plugins.hive;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.big.data.api.jdbc.DriverLocator;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
 
+// Intenionally disabled.  The Simba Hive driver is currently unsupported.
 //@DatabaseMetaPlugin( type = "HIVE2SIMBA", typeDescription = "Hadoop Hive 2 with Simba Driver" )
-public class Hive2SimbaDatabaseMeta extends Hive2DatabaseMeta {
+public class Hive2SimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
 
-  public static final String ODBC_DRIVER_CLASS_NAME = "sun.jdbc.odbc.JdbcOdbcDriver";
-  public static final String JDBC_ODBC_S = "jdbc:odbc:%s";
-  public static final String URL_IS_CONFIGURED_THROUGH_JNDI = "Url is configured through JNDI";
-  public static final String KRB_HOST_FQDN = "KrbHostFQDN";
-  public static final String KRB_SERVICE_NAME = "KrbServiceName";
-  protected static final String JAR_FILE = "HiveJDBC41.jar";
-  //protected static final String DRIVER_CLASS_NAME = "com.simba.hive.jdbc41.HS2Driver";
-  protected static final String DRIVER_CLASS_NAME = "org.apache.hive.jdbc.HiveSimbaDriver";
-  protected static final String JDBC_URL_PREFIX = "jdbc:hive2://";
-  protected static final String AUTH_MECH = "AuthMech";
-  protected static final String JDBC_URL_TEMPLATE = JDBC_URL_PREFIX + "%s:%d/%s;" + AUTH_MECH + "=%d%s";
+  @VisibleForTesting static final String JAR_FILE = "HiveJDBC41.jar";
+  @VisibleForTesting static final String DRIVER_CLASS_NAME = "org.apache.hive.jdbc.HiveSimbaDriver";
+  @VisibleForTesting static final String JDBC_URL_PREFIX = "jdbc:hive2://";
+  @VisibleForTesting static final int DEFAULT_PORT = 10000;
 
 
   public Hive2SimbaDatabaseMeta( DriverLocator driverLocator ) {
     super( driverLocator );
   }
 
-  @Override public int[] getAccessTypeList() {
-    return new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI };
+  @Override protected String getJdbcPrefix() {
+    return JDBC_URL_PREFIX;
   }
 
   @Override
@@ -60,142 +53,13 @@ public class Hive2SimbaDatabaseMeta extends Hive2DatabaseMeta {
     }
   }
 
-  @Override public String getURL( String hostname, String port, String databaseName ) {
-    Integer portNumber;
-    if ( Const.isEmpty( port ) ) {
-      portNumber = getDefaultDatabasePort();
-    } else {
-      portNumber = Integer.valueOf( port );
-    }
-    if ( Const.isEmpty( databaseName ) ) {
-      databaseName = "default";
-    }
-    switch ( getAccessType() ) {
-      case DatabaseMeta.TYPE_ACCESS_ODBC: {
-        return String.format( JDBC_ODBC_S, databaseName );
-      }
-      case DatabaseMeta.TYPE_ACCESS_JNDI: {
-        return URL_IS_CONFIGURED_THROUGH_JNDI;
-      }
-      case DatabaseMeta.TYPE_ACCESS_NATIVE:
-      default: {
-        Integer authMethod = 0;
-        StringBuilder additional = new StringBuilder();
-        String userName = getUsername();
-        String password = getPassword();
-        String krbFQDN = getProperty( KRB_HOST_FQDN );
-        String extraKrbFQDN = getExtraProperty( KRB_HOST_FQDN );
-        String krbPrincipal = getProperty( KRB_SERVICE_NAME );
-        String extraKrbPrincipal = getExtraProperty( KRB_SERVICE_NAME );
-        if ( ( !Const.isEmpty( krbPrincipal ) || !Const.isEmpty( extraKrbPrincipal ) ) && ( !Const.isEmpty( krbFQDN )
-          || !Const.isEmpty( extraKrbFQDN ) ) ) {
-          authMethod = 1;
-        } else if ( !Const.isEmpty( userName ) ) {
-          additional.append( ";UID=" );
-          additional.append( userName );
-          if ( !Const.isEmpty( password ) ) {
-            authMethod = 3;
-            additional.append( ";PWD=" );
-            additional.append( password );
-          } else {
-            authMethod = 2;
-          }
-        }
-        return String.format( JDBC_URL_TEMPLATE, hostname, portNumber, databaseName, authMethod, additional );
-      }
-    }
-  }
-
-  private String getExtraProperty( String key ) {
-    return getAttributes().getProperty( ATTRIBUTE_PREFIX_EXTRA_OPTION + getPluginId() + "." + key );
-  }
-
-  private String getProperty( String key ) {
-    return getAttributes().getProperty( key );
-  }
-
-  /**
-   * This method assumes that Hive has no concept of primary and technical keys and auto increment columns. We are
-   * ignoring the tk, pk and useAutoinc parameters.
-   */
   @Override
-  public String getFieldDefinition( ValueMetaInterface v, String tk, String pk, boolean useAutoinc,
-                                    boolean addFieldname, boolean addCr ) {
+  public String[] getUsedLibraries() {
+    return new String[] { JAR_FILE };
+  }
 
-    StringBuilder retval = new StringBuilder();
-
-    String fieldname = v.getName();
-    int length = v.getLength();
-    int precision = v.getPrecision();
-
-    if ( addFieldname ) {
-      retval.append( fieldname ).append( ' ' );
-    }
-
-    int type = v.getType();
-    switch ( type ) {
-
-      case ValueMetaInterface.TYPE_BOOLEAN:
-        retval.append( "BOOLEAN" );
-        break;
-
-      //  Hive does not support DATE until 0.12
-      case ValueMetaInterface.TYPE_DATE:
-        if ( isDriverVersion( 0, 12 ) ) {
-          retval.append( "DATE" );
-        } else {
-          throw new IllegalArgumentException( "Date types not supported in this version of Hive" );
-        }
-        break;
-
-      // Hive does not support DATE until 0.8
-      case ValueMetaInterface.TYPE_TIMESTAMP:
-        if ( isDriverVersion( 0, 8 ) ) {
-          retval.append( "TIMESTAMP" );
-        } else {
-          throw new IllegalArgumentException( "Timestamp types not supported in this version of Hive" );
-        }
-        break;
-
-      case ValueMetaInterface.TYPE_STRING:
-        if ( length == 1 && isDriverVersion( 0, 13 ) ) {
-          retval.append( "CHAR" );
-        } else if ( isDriverVersion( 0, 12 ) ) {
-          retval.append( "VARCHAR" );
-        } else {
-          retval.append( "STRING" );
-        }
-        break;
-
-      case ValueMetaInterface.TYPE_NUMBER:
-      case ValueMetaInterface.TYPE_INTEGER:
-      case ValueMetaInterface.TYPE_BIGNUMBER:
-        // Integer values...
-        if ( precision == 0 ) {
-          if ( length > 9 ) {
-            if ( length < 19 ) {
-              // can hold signed values between -9223372036854775808 and 9223372036854775807
-              // 18 significant digits
-              retval.append( "BIGINT" );
-            } else {
-              retval.append( "FLOAT" );
-            }
-          } else {
-            retval.append( "INT" );
-          }
-        } else {
-          // Floating point values...
-          if ( length > 15 ) {
-            retval.append( "FLOAT" );
-          } else {
-            // A double-precision floating-point number is accurate to approximately 15 decimal places.
-            // http://mysql.mirrors-r-us.net/doc/refman/5.1/en/numeric-type-overview.html
-            retval.append( "DOUBLE" );
-          }
-        }
-        break;
-    }
-
-    return retval.toString();
+  @Override
+  public int getDefaultDatabasePort() {
+    return DEFAULT_PORT;
   }
 }

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/ImpalaSimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/ImpalaSimbaDatabaseMeta.java
@@ -23,29 +23,23 @@
 package org.pentaho.big.data.kettle.plugins.hive;
 
 import org.pentaho.big.data.api.jdbc.DriverLocator;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.plugins.DatabaseMetaPlugin;
-import org.pentaho.di.core.row.ValueMetaInterface;
 
 @DatabaseMetaPlugin( type = "IMPALASIMBA", typeDescription = "Cloudera Impala" )
-public class ImpalaSimbaDatabaseMeta extends ImpalaDatabaseMeta {
+public class ImpalaSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
 
-  public static final String ODBC_DRIVER_CLASS_NAME = "sun.jdbc.odbc.JdbcOdbcDriver";
-  public static final String KRB_HOST_FQDN = "KrbHostFQDN";
-  public static final String KRB_SERVICE_NAME = "KrbServiceName";
   protected static final String JAR_FILE = "ImpalaJDBC41.jar";
-  //protected static final String DRIVER_CLASS_NAME = "com.simba.impala.jdbc41.Driver";
   protected static final String JDBC_URL_PREFIX = "jdbc:impala://";
   protected static final String DRIVER_CLASS_NAME = "org.apache.hive.jdbc.ImpalaSimbaDriver";
-  protected static final String JDBC_URL_TEMPLATE = JDBC_URL_PREFIX + "%s:%d/%s;AuthMech=%d%s";
+  protected static final int DEFAULT_PORT = 21050;
 
   public ImpalaSimbaDatabaseMeta( DriverLocator driverLocator ) {
     super( driverLocator );
   }
 
-  @Override public int[] getAccessTypeList() {
-    return new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI };
+  @Override protected String getJdbcPrefix() {
+    return JDBC_URL_PREFIX;
   }
 
   @Override
@@ -57,142 +51,14 @@ public class ImpalaSimbaDatabaseMeta extends ImpalaDatabaseMeta {
     }
   }
 
-  @Override public String getURL( String hostname, String port, String databaseName ) {
-    Integer portNumber;
-    if ( Const.isEmpty( port ) ) {
-      portNumber = getDefaultDatabasePort();
-    } else {
-      portNumber = Integer.valueOf( port );
-    }
-    if ( Const.isEmpty( databaseName ) ) {
-      databaseName = "default";
-    }
-    switch ( getAccessType() ) {
-      case DatabaseMeta.TYPE_ACCESS_ODBC: {
-        return String.format( "jdbc:odbc:%s", databaseName );
-      }
-      case DatabaseMeta.TYPE_ACCESS_JNDI: {
-        return "Url is configured through JNDI";
-      }
-      case DatabaseMeta.TYPE_ACCESS_NATIVE:
-      default: {
-        Integer authMethod = 0;
-        StringBuilder additional = new StringBuilder();
-        String userName = getUsername();
-        String password = getPassword();
-        String krbFQDN = getProperty( KRB_HOST_FQDN );
-        String extraKrbFQDN = getExtraProperty( KRB_HOST_FQDN );
-        String krbPrincipal = getProperty( KRB_SERVICE_NAME );
-        String extraKrbPrincipal = getExtraProperty( KRB_SERVICE_NAME );
-        if ( ( !Const.isEmpty( krbPrincipal ) || !Const.isEmpty( extraKrbPrincipal ) ) && ( !Const.isEmpty( krbFQDN )
-          || !Const.isEmpty( extraKrbFQDN ) ) ) {
-          authMethod = 1;
-        } else if ( !Const.isEmpty( userName ) ) {
-          additional.append( ";UID=" );
-          additional.append( userName );
-          if ( !Const.isEmpty( password ) ) {
-            authMethod = 3;
-            additional.append( ";PWD=" );
-            additional.append( password );
-          } else {
-            authMethod = 2;
-          }
-        }
-        return String.format( JDBC_URL_TEMPLATE, hostname, portNumber, databaseName, authMethod, additional );
-      }
-    }
-  }
-
-  private String getExtraProperty( String key ) {
-    return getAttributes().getProperty( ATTRIBUTE_PREFIX_EXTRA_OPTION + getPluginId() + "." + key );
-  }
-
-  private String getProperty( String key ) {
-    return getAttributes().getProperty( key );
-  }
-
-  /**
-   * This method assumes that Hive has no concept of primary and technical keys and auto increment columns. We are
-   * ignoring the tk, pk and useAutoinc parameters.
-   */
   @Override
-  public String getFieldDefinition( ValueMetaInterface v, String tk, String pk, boolean useAutoinc,
-                                    boolean addFieldname, boolean addCr ) {
-
-    StringBuilder retval = new StringBuilder();
-
-    String fieldname = v.getName();
-    int length = v.getLength();
-    int precision = v.getPrecision();
-
-    if ( addFieldname ) {
-      retval.append( fieldname ).append( ' ' );
-    }
-
-    int type = v.getType();
-    switch ( type ) {
-
-      case ValueMetaInterface.TYPE_BOOLEAN:
-        retval.append( "BOOLEAN" );
-        break;
-
-      //  Hive does not support DATE until 0.12
-      case ValueMetaInterface.TYPE_DATE:
-        if ( isDriverVersion( 0, 12 ) ) {
-          retval.append( "DATE" );
-        } else {
-          throw new IllegalArgumentException( "Date types not supported in this version of Hive" );
-        }
-        break;
-
-      // Hive does not support DATE until 0.8
-      case ValueMetaInterface.TYPE_TIMESTAMP:
-        if ( isDriverVersion( 0, 8 ) ) {
-          retval.append( "TIMESTAMP" );
-        } else {
-          throw new IllegalArgumentException( "Timestamp types not supported in this version of Hive" );
-        }
-        break;
-
-      case ValueMetaInterface.TYPE_STRING:
-        if ( length == 1 && isDriverVersion( 0, 13 ) ) {
-          retval.append( "CHAR" );
-        } else if ( isDriverVersion( 0, 12 ) ) {
-          retval.append( "VARCHAR" );
-        } else {
-          retval.append( "STRING" );
-        }
-        break;
-
-      case ValueMetaInterface.TYPE_NUMBER:
-      case ValueMetaInterface.TYPE_INTEGER:
-      case ValueMetaInterface.TYPE_BIGNUMBER:
-        // Integer values...
-        if ( precision == 0 ) {
-          if ( length > 9 ) {
-            if ( length < 19 ) {
-              // can hold signed values between -9223372036854775808 and 9223372036854775807
-              // 18 significant digits
-              retval.append( "BIGINT" );
-            } else {
-              retval.append( "FLOAT" );
-            }
-          } else {
-            retval.append( "INT" );
-          }
-        } else {
-          // Floating point values...
-          if ( length > 15 ) {
-            retval.append( "FLOAT" );
-          } else {
-            // A double-precision floating-point number is accurate to approximately 15 decimal places.
-            // http://mysql.mirrors-r-us.net/doc/refman/5.1/en/numeric-type-overview.html
-            retval.append( "DOUBLE" );
-          }
-        }
-        break;
-    }
-
-    return retval.toString();
+  public String[] getUsedLibraries() {
+    return new String[] { JAR_FILE };
   }
+
+  @Override
+  public int getDefaultDatabasePort() {
+    return DEFAULT_PORT;
+  }
+
 }

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.hive;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.pentaho.big.data.api.jdbc.DriverLocator;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.plugins.DatabaseMetaPlugin;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+@DatabaseMetaPlugin( type = "SPARKSIMBA", typeDescription = "SparkSQL" )
+public class SparkSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
+
+  @VisibleForTesting static final String JDBC_URL_PREFIX = "jdbc:spark://";
+  @VisibleForTesting static final String DRIVER_CLASS_NAME = "org.apache.hive.jdbc.SparkSqlSimbaDriver";
+  @VisibleForTesting static final String JAR_FILE = "SparkJDBC41.jar";
+  @VisibleForTesting static final int DEFAULT_PORT = 10015;
+
+  public SparkSimbaDatabaseMeta( DriverLocator driverLocator ) {
+    super( driverLocator );
+  }
+
+  @Override public int[] getAccessTypeList() {
+    return new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_JNDI };
+  }
+
+  @Override protected String getJdbcPrefix() {
+    return JDBC_URL_PREFIX;
+  }
+
+  @Override
+  public String getDriverClass() {
+    return DRIVER_CLASS_NAME;
+  }
+
+  @Override
+  public String getSQLQueryFields( String tableName ) {
+    return "SELECT * FROM " + getTableReference( tableName ) + " LIMIT 0";
+  }
+
+  @Override
+  public String getStartQuote() {
+    return "`";
+  }
+
+  @Override
+  public String getEndQuote() {
+    return "`";
+  }
+
+  private String getTableReference( String tableName ) {
+    if ( !isTableNameQualified( tableName ) ) {
+      return getSchemaTableCombination( getDatabaseName(), tableName );
+    } else {
+      return tableName;
+    }
+  }
+
+  private boolean isTableNameQualified( String tableName ) {
+    String quotedDbName = getStartQuote() + getDatabaseName() + getEndQuote();
+    return tableName.startsWith( getDatabaseName() ) || tableName.startsWith( quotedDbName );
+  }
+
+  @Override
+  public String getSQLTableExists( String tablename ) {
+    return "SELECT 1 FROM " + getTableReference( tablename );
+  }
+
+  @Override
+  public String getTruncateTableStatement( String tableName ) {
+    return "TRUNCATE TABLE " + getTableReference( tableName );
+  }
+
+  @Override
+  public String getSQLColumnExists( String columnname, String tablename ) {
+    return "SELECT " + columnname + " FROM " + getTableReference( tablename );
+  }
+
+  @Override
+  public String getSelectCountStatement( String tableName ) {
+    return SELECT_COUNT_STATEMENT + " " + getTableReference( tableName );
+  }
+
+  @Override
+  public String getDropColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean use_autoinc,
+                                        String pk, boolean semicolon ) {
+    throw new UnsupportedOperationException( "Cannot DROP columns with SparkSQL" );
+  }
+
+  @Override
+  public String getAddColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
+                                       String pk, boolean semicolon ) {
+    throw new UnsupportedOperationException( "Cannot ADD columns with SparkSQL" );
+  }
+
+  @Override
+  public String getModifyColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
+                                          String pk, boolean semicolon ) {
+    throw new UnsupportedOperationException( "Cannot MODIFY columns with SparkSQL" );
+  }
+
+  @Override
+  public String[] getUsedLibraries() {
+    return new String[] { JAR_FILE };
+  }
+
+  @Override
+  public int getDefaultDatabasePort() {
+    return DEFAULT_PORT;
+  }
+}

--- a/kettle-plugins/hive/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/kettle-plugins/hive/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,6 +29,11 @@
     <argument ref="driverLocator"/>
   </bean>
 
+  <bean id="sparkSimbaDatabaseMeta" class="org.pentaho.big.data.kettle.plugins.hive.SparkSimbaDatabaseMeta" scope="prototype">
+    <pen:di-plugin type="org.pentaho.di.core.plugins.DatabasePluginType"/>
+    <argument ref="driverLocator"/>
+  </bean>
+
   <reference id="driverLocator" interface="org.pentaho.big.data.api.jdbc.DriverLocator"/>
 
   <!--<bean id="hive2DatabaseDialect" class="org.pentaho.big.data.kettle.plugins.hive.Hive2DatabaseDialect"/>

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/BaseSimbaDatabaseMetaTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/BaseSimbaDatabaseMetaTest.java
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.hive;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.big.data.api.jdbc.DriverLocator;
+import org.pentaho.di.core.database.DatabaseMeta;
+import org.pentaho.di.core.exception.KettleDatabaseException;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaInternetAddress;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.Driver;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by bryan on 10/21/15.
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class BaseSimbaDatabaseMetaTest {
+  public static final String LOCALHOST = "localhost";
+  public static final String PORT = "10000";
+  public static final String DEFAULT = "default";
+  @Mock DriverLocator driverLocator;
+  @Mock Driver driver;
+  private BaseSimbaDatabaseMeta baseSimbaDatabaseMeta;
+  private String baseSimbaDatabaseMetaURL;
+
+  String driverClassname = "driverClassname";
+  String jdbcPrefix = "jdbc:prefix://";
+
+  @Before
+  public void setup() throws Throwable {
+    baseSimbaDatabaseMeta = new BaseSimbaDatabaseMeta( driverLocator ) {
+      @Override protected String getJdbcPrefix() {
+        return jdbcPrefix;
+      }
+
+      @Override public String getDriverClass() {
+        return driverClassname;
+      }
+    };
+    baseSimbaDatabaseMetaURL = baseSimbaDatabaseMeta.getURL( LOCALHOST, PORT, DEFAULT );
+    when( driverLocator.getDriver( baseSimbaDatabaseMetaURL ) ).thenReturn( driver );
+  }
+
+  @Test
+  public void testVersionConstructor() throws Throwable {
+    int majorVersion = 22;
+    int minorVersion = 33;
+    when( driver.getMajorVersion() ).thenReturn( majorVersion );
+    when( driver.getMinorVersion() ).thenReturn( minorVersion );
+    assertTrue( baseSimbaDatabaseMeta.isDriverVersion( majorVersion, minorVersion ) );
+    assertFalse( baseSimbaDatabaseMeta.isDriverVersion( majorVersion, minorVersion + 1 ) );
+    assertFalse( baseSimbaDatabaseMeta.isDriverVersion( majorVersion + 1, minorVersion ) );
+  }
+
+  @Test
+  public void testGetAccessTypeList() {
+    assertArrayEquals(
+      new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI },
+      baseSimbaDatabaseMeta.getAccessTypeList() );
+  }
+
+
+  @Test
+  public void testGetDriverClassOther() {
+    assertEquals( driverClassname, baseSimbaDatabaseMeta.getDriverClass() );
+  }
+
+  @Test
+  public void testGetUrlDefaults() throws KettleDatabaseException, MalformedURLException {
+    String testHost = "testHost";
+    String urlString = baseSimbaDatabaseMeta.getURL( testHost, "", "" );
+    assertTrue( urlString.startsWith( jdbcPrefix ) );
+    URL url = new URL( "http://" + urlString.substring( ImpalaSimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
+    assertEquals( testHost, url.getHost() );
+    assertEquals( baseSimbaDatabaseMeta.getDefaultDatabasePort(), url.getPort() );
+    assertEquals( "/default;AuthMech=0", url.getPath() );
+  }
+
+  @Test
+  public void testGetUrlOdbc() throws KettleDatabaseException {
+    String testDbName = "testDbName";
+    baseSimbaDatabaseMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_ODBC );
+    assertEquals( String.format( Hive2SimbaDatabaseMeta.JDBC_ODBC_S, testDbName ),
+      baseSimbaDatabaseMeta.getURL( "", "", testDbName ) );
+  }
+
+  @Test
+  public void testGetUrlJndi() throws KettleDatabaseException {
+    baseSimbaDatabaseMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_JNDI );
+    assertEquals( Hive2SimbaDatabaseMeta.URL_IS_CONFIGURED_THROUGH_JNDI, baseSimbaDatabaseMeta.getURL( "", "", "" ) );
+  }
+
+  @Test
+  public void testGetUrlKerb() throws Throwable {
+    String testHost = "testHost";
+    String testPort = "1111";
+    String testDb = "testDb";
+    // Regular properties
+    baseSimbaDatabaseMeta.getAttributes().put( ImpalaSimbaDatabaseMeta.KRB_HOST_FQDN, "fqdn" );
+    baseSimbaDatabaseMeta.getAttributes().put( Hive2SimbaDatabaseMeta.KRB_SERVICE_NAME, "service" );
+    String urlString = baseSimbaDatabaseMeta.getURL( testHost, testPort, testDb );
+    assertTrue( urlString.startsWith( jdbcPrefix ) );
+    URL url = new URL( "http://" + urlString.substring( ImpalaSimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
+    assertEquals( testHost, url.getHost() );
+    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
+    assertEquals( "/" + testDb + ";AuthMech=1", url.getPath() );
+
+    // Extra properties
+    baseSimbaDatabaseMeta = new ImpalaSimbaDatabaseMeta( driverLocator );
+    baseSimbaDatabaseMeta.getAttributes().put(
+      Hive2SimbaDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + baseSimbaDatabaseMeta.getPluginId() + "."
+        + Hive2SimbaDatabaseMeta.KRB_HOST_FQDN, "fqdn" );
+    baseSimbaDatabaseMeta.getAttributes()
+      .put( Hive2SimbaDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + baseSimbaDatabaseMeta.getPluginId() + "."
+        + Hive2SimbaDatabaseMeta.KRB_SERVICE_NAME, "service" );
+    urlString = baseSimbaDatabaseMeta.getURL( testHost, testPort, testDb );
+    assertTrue( urlString.startsWith( ImpalaSimbaDatabaseMeta.JDBC_URL_PREFIX ) );
+    url = new URL( "http://" + urlString.substring( ImpalaSimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
+    assertEquals( testHost, url.getHost() );
+    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
+    assertEquals( "/" + testDb + ";AuthMech=1", url.getPath() );
+  }
+
+  @Test
+  public void testGetUrlUsername() throws KettleDatabaseException, MalformedURLException {
+    String testUsername = "testUsername";
+    baseSimbaDatabaseMeta.setUsername( testUsername );
+
+    String testHost = "testHost";
+    String testPort = "1111";
+    String testDb = "testDb";
+    String urlString = baseSimbaDatabaseMeta.getURL( testHost, testPort, testDb );
+    assertTrue( urlString.startsWith( jdbcPrefix ) );
+    URL url = new URL( "http://" + urlString.substring( ImpalaSimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
+    assertEquals( testHost, url.getHost() );
+    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
+    assertEquals( "/" + testDb + ";AuthMech=2;UID=" + testUsername, url.getPath() );
+  }
+
+  @Test
+  public void testGetUrlPassword() throws KettleDatabaseException, MalformedURLException {
+    String testUsername = "testUsername";
+    String testPassword = "testPassword";
+    baseSimbaDatabaseMeta.setUsername( testUsername );
+    baseSimbaDatabaseMeta.setPassword( testPassword );
+
+    String testHost = "testHost";
+    String testPort = "1111";
+    String testDb = "testDb";
+    String urlString = baseSimbaDatabaseMeta.getURL( testHost, testPort, testDb );
+    assertTrue( urlString.startsWith( jdbcPrefix ) );
+    URL url = new URL( "http://" + urlString.substring( ImpalaSimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
+    assertEquals( testHost, url.getHost() );
+    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
+    assertEquals(
+      "/" + testDb + ";AuthMech=3;UID=" + testUsername + ";PWD=" + testPassword,
+      url.getPath() );
+  }
+
+  @Test
+  public void testGetFieldDefinitionBoolean() {
+    assertGetFieldDefinition( new ValueMetaBoolean(), "boolName", "BOOLEAN" );
+  }
+
+  @Test
+  public void testGetFieldDefinitionDate() {
+    when( driver.getMajorVersion() ).thenReturn( 0 );
+    when( driver.getMinorVersion() ).thenReturn( 12 );
+    assertGetFieldDefinition( new ValueMetaDate(), "dateName", "DATE" );
+  }
+
+  @Test
+  public void testGetFieldDefinitionTimestamp() {
+    when( driver.getMajorVersion() ).thenReturn( 0 );
+    when( driver.getMinorVersion() ).thenReturn( 8 );
+    assertGetFieldDefinition( new ValueMetaTimestamp(), "timestampName", "TIMESTAMP" );
+  }
+
+  @Test
+  public void testGetFieldDefinitionStringVarchar() {
+    when( driver.getMajorVersion() ).thenReturn( 0 );
+    when( driver.getMinorVersion() ).thenReturn( 12 );
+    assertGetFieldDefinition( new ValueMetaString(), "stringName", "VARCHAR" );
+  }
+
+  @Test
+  public void testGetFieldDefinitionNumber() {
+    String numberName = "numberName";
+    ValueMetaInterface valueMetaInterface = new ValueMetaNumber();
+    valueMetaInterface.setName( numberName );
+    valueMetaInterface.setPrecision( 0 );
+    valueMetaInterface.setLength( 9 );
+    assertGetFieldDefinition( valueMetaInterface, "INT" );
+
+    valueMetaInterface.setLength( 18 );
+    assertGetFieldDefinition( valueMetaInterface, "BIGINT" );
+
+    valueMetaInterface.setLength( 19 );
+    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
+
+    valueMetaInterface.setPrecision( 10 );
+    valueMetaInterface.setLength( 16 );
+    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
+
+    valueMetaInterface.setLength( 15 );
+    assertGetFieldDefinition( valueMetaInterface, "DOUBLE" );
+  }
+
+  @Test
+  public void testGetFieldDefinitionInteger() {
+    String integerName = "integerName";
+    ValueMetaInterface valueMetaInterface = new ValueMetaInteger();
+    valueMetaInterface.setName( integerName );
+    valueMetaInterface.setPrecision( 0 );
+    valueMetaInterface.setLength( 9 );
+    assertGetFieldDefinition( valueMetaInterface, "INT" );
+
+    valueMetaInterface.setLength( 18 );
+    assertGetFieldDefinition( valueMetaInterface, "BIGINT" );
+
+    valueMetaInterface.setLength( 19 );
+    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
+  }
+
+  @Test
+  public void testGetFieldDefinitionBigNumber() {
+    String bigNumberName = "bigNumberName";
+    ValueMetaInterface valueMetaInterface = new ValueMetaBigNumber();
+    valueMetaInterface.setName( bigNumberName );
+    valueMetaInterface.setPrecision( 0 );
+    valueMetaInterface.setLength( 9 );
+    assertGetFieldDefinition( valueMetaInterface, "INT" );
+
+    valueMetaInterface.setLength( 18 );
+    assertGetFieldDefinition( valueMetaInterface, "BIGINT" );
+
+    valueMetaInterface.setLength( 19 );
+    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
+
+    valueMetaInterface.setPrecision( 10 );
+    valueMetaInterface.setLength( 16 );
+    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
+
+    valueMetaInterface.setLength( 15 );
+    assertGetFieldDefinition( valueMetaInterface, "DOUBLE" );
+  }
+
+  @Test
+  public void testGetFieldDefinition() {
+    assertGetFieldDefinition( new ValueMetaInternetAddress(), "internetAddressName", "" );
+  }
+
+  private void assertGetFieldDefinition( ValueMetaInterface valueMetaInterface, String name, String expectedType ) {
+    valueMetaInterface = valueMetaInterface.clone();
+    valueMetaInterface.setName( name );
+    assertGetFieldDefinition( valueMetaInterface, expectedType );
+  }
+
+  private void assertGetFieldDefinition( ValueMetaInterface valueMetaInterface, String expectedType ) {
+    assertEquals( expectedType,
+      baseSimbaDatabaseMeta.getFieldDefinition( valueMetaInterface, null, null, false, false,
+        false ) );
+    assertEquals( valueMetaInterface.getName() + " " + expectedType,
+      baseSimbaDatabaseMeta.getFieldDefinition( valueMetaInterface, null, null, false, true, false ) );
+  }
+}

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/Hive2SimbaDatabaseDialectTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/Hive2SimbaDatabaseDialectTest.java
@@ -28,6 +28,8 @@ import org.pentaho.database.model.DatabaseAccessType;
 import org.pentaho.database.model.DatabaseConnection;
 import org.pentaho.database.model.IDatabaseType;
 
+import static org.junit.Assert.assertEquals;
+
 public class Hive2SimbaDatabaseDialectTest {
 
   private Hive2SimbaDatabaseDialect dialect;
@@ -51,7 +53,7 @@ public class Hive2SimbaDatabaseDialectTest {
 
   @Test
   public void testGetUsedLibraries() {
-    Assert.assertEquals( dialect.getUsedLibraries()[0], "HiveJDBC41.jar" );
+    assertEquals( dialect.getUsedLibraries()[0], "HiveJDBC41.jar" );
   }
 
   @Test
@@ -62,7 +64,7 @@ public class Hive2SimbaDatabaseDialectTest {
   @Test
   public void testGetDatabaseType() {
     IDatabaseType dbType = dialect.getDatabaseType();
-    Assert.assertEquals( dbType.getName(), "Hadoop Hive 2 (Simba)" );
+    assertEquals( dbType.getName(), "Hadoop Hive 2 (Simba)" );
   }
 
   @Test
@@ -78,6 +80,6 @@ public class Hive2SimbaDatabaseDialectTest {
   @Test
   public void testGetTruncateTableStatement() {
     String tableName = "table1";
-    Assert.assertEquals( dialect.getTruncateTableStatement( tableName ), "TRUNCATE TABLE " + tableName );
+    assertEquals( dialect.getTruncateTableStatement( tableName ), "TRUNCATE TABLE " + tableName );
   }
 }

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/Hive2SimbaDatabaseMetaTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/Hive2SimbaDatabaseMetaTest.java
@@ -25,34 +25,19 @@ package org.pentaho.big.data.kettle.plugins.hive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.pentaho.big.data.api.jdbc.DriverLocator;
 import org.pentaho.di.core.database.DatabaseMeta;
-import org.pentaho.di.core.exception.KettleDatabaseException;
-import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaBigNumber;
-import org.pentaho.di.core.row.value.ValueMetaBoolean;
-import org.pentaho.di.core.row.value.ValueMetaDate;
-import org.pentaho.di.core.row.value.ValueMetaInteger;
-import org.pentaho.di.core.row.value.ValueMetaInternetAddress;
-import org.pentaho.di.core.row.value.ValueMetaNumber;
-import org.pentaho.di.core.row.value.ValueMetaString;
-import org.pentaho.di.core.row.value.ValueMetaTimestamp;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.sql.Driver;
+import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by bryan on 10/20/15.
- */
 @RunWith( MockitoJUnitRunner.class )
 public class Hive2SimbaDatabaseMetaTest {
   public static final String LOCALHOST = "localhost";
@@ -60,33 +45,18 @@ public class Hive2SimbaDatabaseMetaTest {
   public static final String DEFAULT = "default";
   @Mock DriverLocator driverLocator;
   @Mock Driver driver;
-
-  private Hive2SimbaDatabaseMeta hive2SimbaDatabaseMeta;
+  @InjectMocks Hive2SimbaDatabaseMeta hive2SimbaDatabaseMeta;
   private String hive2SimbaDatabaseMetaURL;
 
   @Before
   public void setup() throws Throwable {
-    hive2SimbaDatabaseMeta = new Hive2SimbaDatabaseMeta( driverLocator );
     hive2SimbaDatabaseMetaURL = hive2SimbaDatabaseMeta.getURL( LOCALHOST, PORT, DEFAULT );
     when( driverLocator.getDriver( hive2SimbaDatabaseMetaURL ) ).thenReturn( driver );
   }
 
   @Test
-  public void testVersionConstructor() throws Throwable {
-    int majorVersion = 22;
-    int minorVersion = 33;
-    when( driver.getMajorVersion() ).thenReturn( 22 );
-    when( driver.getMinorVersion() ).thenReturn( 33 );
-    assertTrue( hive2SimbaDatabaseMeta.isDriverVersion( majorVersion, minorVersion ) );
-    assertFalse( hive2SimbaDatabaseMeta.isDriverVersion( majorVersion, minorVersion + 1 ) );
-    assertFalse( hive2SimbaDatabaseMeta.isDriverVersion( majorVersion + 1, minorVersion ) );
-  }
-
-  @Test
-  public void testGetAccessTypeList() {
-    assertArrayEquals(
-      new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI },
-      hive2SimbaDatabaseMeta.getAccessTypeList() );
+  public void testGetDriverClassOther() {
+    assertEquals( Hive2SimbaDatabaseMeta.DRIVER_CLASS_NAME, hive2SimbaDatabaseMeta.getDriverClass() );
   }
 
   @Test
@@ -96,236 +66,21 @@ public class Hive2SimbaDatabaseMetaTest {
   }
 
   @Test
-  public void testGetDriverClassOther() {
-    assertEquals( Hive2SimbaDatabaseMeta.DRIVER_CLASS_NAME, hive2SimbaDatabaseMeta.getDriverClass() );
+  public void testGetJdbcPrefix() {
+    assertEquals( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX,
+      hive2SimbaDatabaseMeta.getJdbcPrefix() );
   }
 
   @Test
-  public void testGetUrlDefaults() throws KettleDatabaseException, MalformedURLException {
-    String testHost = "testHost";
-    String urlString = hive2SimbaDatabaseMeta.getURL( testHost, "", "" );
-    assertTrue( urlString.startsWith( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX ) );
-    URL url = new URL( "http://" + urlString.substring( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
-    assertEquals( testHost, url.getHost() );
-    assertEquals( hive2SimbaDatabaseMeta.getDefaultDatabasePort(), url.getPort() );
-    assertEquals( "/default;" + Hive2SimbaDatabaseMeta.AUTH_MECH + "=0", url.getPath() );
+  public void testGetUsedLibraries() {
+    assertTrue( Arrays.equals(
+      hive2SimbaDatabaseMeta.getUsedLibraries(),
+      new String[] { hive2SimbaDatabaseMeta.JAR_FILE } ) );
   }
 
   @Test
-  public void testGetUrlOdbc() throws KettleDatabaseException {
-    String testDbName = "testDbName";
-    hive2SimbaDatabaseMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_ODBC );
-    assertEquals( String.format( Hive2SimbaDatabaseMeta.JDBC_ODBC_S, testDbName ),
-      hive2SimbaDatabaseMeta.getURL( "", "", testDbName ) );
-  }
-
-  @Test
-  public void testGetUrlJndi() throws KettleDatabaseException {
-    hive2SimbaDatabaseMeta.setAccessType( DatabaseMeta.TYPE_ACCESS_JNDI );
-    assertEquals( Hive2SimbaDatabaseMeta.URL_IS_CONFIGURED_THROUGH_JNDI, hive2SimbaDatabaseMeta.getURL( "", "", "" ) );
-  }
-
-  @Test
-  public void testGetUrlKerb() throws Throwable {
-    String testHost = "testHost";
-    String testPort = "1111";
-    String testDb = "testDb";
-    // Regular properties
-    hive2SimbaDatabaseMeta.getAttributes().put( Hive2SimbaDatabaseMeta.KRB_HOST_FQDN, "fqdn" );
-    hive2SimbaDatabaseMeta.getAttributes().put( Hive2SimbaDatabaseMeta.KRB_SERVICE_NAME, "service" );
-    String urlString = hive2SimbaDatabaseMeta.getURL( testHost, testPort, testDb );
-    assertTrue( urlString.startsWith( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX ) );
-    URL url = new URL( "http://" + urlString.substring( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
-    assertEquals( testHost, url.getHost() );
-    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
-    assertEquals( "/" + testDb + ";" + Hive2SimbaDatabaseMeta.AUTH_MECH + "=1", url.getPath() );
-
-    // Extra properties
-    hive2SimbaDatabaseMeta = new Hive2SimbaDatabaseMeta( driverLocator );
-    hive2SimbaDatabaseMeta.getAttributes().put(
-      Hive2SimbaDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + hive2SimbaDatabaseMeta.getPluginId() + "."
-        + Hive2SimbaDatabaseMeta.KRB_HOST_FQDN, "fqdn" );
-    hive2SimbaDatabaseMeta.getAttributes()
-      .put( Hive2SimbaDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION + hive2SimbaDatabaseMeta.getPluginId() + "."
-        + Hive2SimbaDatabaseMeta.KRB_SERVICE_NAME, "service" );
-    urlString = hive2SimbaDatabaseMeta.getURL( testHost, testPort, testDb );
-    assertTrue( urlString.startsWith( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX ) );
-    url = new URL( "http://" + urlString.substring( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
-    assertEquals( testHost, url.getHost() );
-    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
-    assertEquals( "/" + testDb + ";" + Hive2SimbaDatabaseMeta.AUTH_MECH + "=1", url.getPath() );
-  }
-
-  @Test
-  public void testGetUrlUsername() throws KettleDatabaseException, MalformedURLException {
-    String testUsername = "testUsername";
-    hive2SimbaDatabaseMeta.setUsername( testUsername );
-
-    String testHost = "testHost";
-    String testPort = "1111";
-    String testDb = "testDb";
-    String urlString = hive2SimbaDatabaseMeta.getURL( testHost, testPort, testDb );
-    assertTrue( urlString.startsWith( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX ) );
-    URL url = new URL( "http://" + urlString.substring( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
-    assertEquals( testHost, url.getHost() );
-    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
-    assertEquals( "/" + testDb + ";" + Hive2SimbaDatabaseMeta.AUTH_MECH + "=2;UID=" + testUsername, url.getPath() );
-  }
-
-  @Test
-  public void testGetUrlPassword() throws KettleDatabaseException, MalformedURLException {
-    String testUsername = "testUsername";
-    String testPassword = "testPassword";
-    hive2SimbaDatabaseMeta.setUsername( testUsername );
-    hive2SimbaDatabaseMeta.setPassword( testPassword );
-
-    String testHost = "testHost";
-    String testPort = "1111";
-    String testDb = "testDb";
-    String urlString = hive2SimbaDatabaseMeta.getURL( testHost, testPort, testDb );
-    assertTrue( urlString.startsWith( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX ) );
-    URL url = new URL( "http://" + urlString.substring( Hive2SimbaDatabaseMeta.JDBC_URL_PREFIX.length() ) );
-    assertEquals( testHost, url.getHost() );
-    assertEquals( Integer.valueOf( testPort ).intValue(), url.getPort() );
-    assertEquals(
-      "/" + testDb + ";" + Hive2SimbaDatabaseMeta.AUTH_MECH + "=3;UID=" + testUsername + ";PWD=" + testPassword,
-      url.getPath() );
-  }
-
-  @Test
-  public void testGetFieldDefinitionBoolean() {
-    assertGetFieldDefinition( new ValueMetaBoolean(), "boolName", "BOOLEAN" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionDate() {
-    when( driver.getMajorVersion() ).thenReturn( 0 );
-    when( driver.getMinorVersion() ).thenReturn( 12 );
-    assertGetFieldDefinition( new ValueMetaDate(), "dateName", "DATE" );
-  }
-
-  @Test( expected = IllegalArgumentException.class )
-  public void testGetFieldDefinitionDateUnsupported() {
-    when( driver.getMajorVersion() ).thenReturn( 0 );
-    when( driver.getMinorVersion() ).thenReturn( 11 );
-    assertGetFieldDefinition( new ValueMetaDate(), "dateName", "DATE" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionTimestamp() {
-    when( driver.getMajorVersion() ).thenReturn( 0 );
-    when( driver.getMinorVersion() ).thenReturn( 8 );
-    assertGetFieldDefinition( new ValueMetaTimestamp(), "timestampName", "TIMESTAMP" );
-  }
-
-  @Test( expected = IllegalArgumentException.class )
-  public void testGetFieldDefinitionUnsupported() {
-    when( driver.getMajorVersion() ).thenReturn( 0 );
-    when( driver.getMinorVersion() ).thenReturn( 7 );
-    assertGetFieldDefinition( new ValueMetaTimestamp(), "timestampName", "TIMESTAMP" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionString() {
-    assertGetFieldDefinition( new ValueMetaString(), "stringName", "STRING" );
-    ValueMetaString valueMetaInterface = new ValueMetaString();
-    valueMetaInterface.setLength( 1 );
-    assertGetFieldDefinition( valueMetaInterface, "stringName", "STRING" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionStringChar() {
-    when( driver.getMajorVersion() ).thenReturn( 0 );
-    when( driver.getMinorVersion() ).thenReturn( 13 );
-    ValueMetaString valueMetaInterface = new ValueMetaString();
-    valueMetaInterface.setLength( 1 );
-    assertGetFieldDefinition( valueMetaInterface, "stringName", "CHAR" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionStringVarchar() {
-    when( driver.getMajorVersion() ).thenReturn( 0 );
-    when( driver.getMinorVersion() ).thenReturn( 12 );
-    assertGetFieldDefinition( new ValueMetaString(), "stringName", "VARCHAR" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionNumber() {
-    String numberName = "numberName";
-    ValueMetaInterface valueMetaInterface = new ValueMetaNumber();
-    valueMetaInterface.setName( numberName );
-    valueMetaInterface.setPrecision( 0 );
-    valueMetaInterface.setLength( 9 );
-    assertGetFieldDefinition( valueMetaInterface, "INT" );
-
-    valueMetaInterface.setLength( 18 );
-    assertGetFieldDefinition( valueMetaInterface, "BIGINT" );
-
-    valueMetaInterface.setLength( 19 );
-    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
-
-    valueMetaInterface.setPrecision( 10 );
-    valueMetaInterface.setLength( 16 );
-    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
-
-    valueMetaInterface.setLength( 15 );
-    assertGetFieldDefinition( valueMetaInterface, "DOUBLE" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionInteger() {
-    String integerName = "integerName";
-    ValueMetaInterface valueMetaInterface = new ValueMetaInteger();
-    valueMetaInterface.setName( integerName );
-    valueMetaInterface.setPrecision( 0 );
-    valueMetaInterface.setLength( 9 );
-    assertGetFieldDefinition( valueMetaInterface, "INT" );
-
-    valueMetaInterface.setLength( 18 );
-    assertGetFieldDefinition( valueMetaInterface, "BIGINT" );
-
-    valueMetaInterface.setLength( 19 );
-    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
-  }
-
-  @Test
-  public void testGetFieldDefinitionBigNumber() {
-    String bigNumberName = "bigNumberName";
-    ValueMetaInterface valueMetaInterface = new ValueMetaBigNumber();
-    valueMetaInterface.setName( bigNumberName );
-    valueMetaInterface.setPrecision( 0 );
-    valueMetaInterface.setLength( 9 );
-    assertGetFieldDefinition( valueMetaInterface, "INT" );
-
-    valueMetaInterface.setLength( 18 );
-    assertGetFieldDefinition( valueMetaInterface, "BIGINT" );
-
-    valueMetaInterface.setLength( 19 );
-    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
-
-    valueMetaInterface.setPrecision( 10 );
-    valueMetaInterface.setLength( 16 );
-    assertGetFieldDefinition( valueMetaInterface, "FLOAT" );
-
-    valueMetaInterface.setLength( 15 );
-    assertGetFieldDefinition( valueMetaInterface, "DOUBLE" );
-  }
-
-  @Test
-  public void testGetFieldDefinition() {
-    assertGetFieldDefinition( new ValueMetaInternetAddress(), "internetAddressName", "" );
-  }
-
-  private void assertGetFieldDefinition( ValueMetaInterface valueMetaInterface, String name, String expectedType ) {
-    valueMetaInterface = valueMetaInterface.clone();
-    valueMetaInterface.setName( name );
-    assertGetFieldDefinition( valueMetaInterface, expectedType );
-  }
-
-  private void assertGetFieldDefinition( ValueMetaInterface valueMetaInterface, String expectedType ) {
-    assertEquals( expectedType, hive2SimbaDatabaseMeta.getFieldDefinition( valueMetaInterface, null, null, false, false,
-      false ) );
-    assertEquals( valueMetaInterface.getName() + " " + expectedType,
-      hive2SimbaDatabaseMeta.getFieldDefinition( valueMetaInterface, null, null, false, true, false ) );
+  public void testGetDefaultDatabasePort() {
+    assertEquals( Hive2SimbaDatabaseMeta.DEFAULT_PORT,
+      hive2SimbaDatabaseMeta.getDefaultDatabasePort() );
   }
 }

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.hive;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.big.data.api.jdbc.DriverLocator;
+import org.pentaho.di.core.database.DatabaseMeta;
+
+import java.sql.Driver;
+import java.util.Arrays;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith( MockitoJUnitRunner.class )
+public class SparkSimbaDatabaseMetaTest {
+  public static final String LOCALHOST = "localhost";
+  public static final String PORT = "10000";
+  public static final String DEFAULT = "default";
+  @Mock DriverLocator driverLocator;
+  @Mock Driver driver;
+  @InjectMocks private SparkSimbaDatabaseMeta sparkSimbaDatabaseMeta;
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
+  private String sparkSimbaDatabaseMetaURL;
+  private static final String DB_NAME = "dbName";
+
+  @Before
+  public void setup() throws Throwable {
+    sparkSimbaDatabaseMetaURL = sparkSimbaDatabaseMeta.getURL( LOCALHOST, PORT, DEFAULT );
+    when( driverLocator.getDriver( sparkSimbaDatabaseMetaURL ) ).thenReturn( driver );
+    sparkSimbaDatabaseMeta.setDatabaseName( DB_NAME );
+  }
+
+  @Test
+  public void testGetAccessTypeList() {
+    assertArrayEquals(
+      new int[] { DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_JNDI },
+      sparkSimbaDatabaseMeta.getAccessTypeList() );
+  }
+
+  @Test
+  public void testGetJdbcPrefix() {
+    assertEquals( SparkSimbaDatabaseMeta.JDBC_URL_PREFIX,
+      sparkSimbaDatabaseMeta.getJdbcPrefix() );
+  }
+
+  @Test
+  public void testGetUsedLibraries() {
+    assertTrue( Arrays.equals(
+      sparkSimbaDatabaseMeta.getUsedLibraries(),
+      new String[] { sparkSimbaDatabaseMeta.JAR_FILE } ) );
+  }
+
+  @Test
+  public void testGetDefaultDatabasePort() {
+    assertEquals( SparkSimbaDatabaseMeta.DEFAULT_PORT,
+      sparkSimbaDatabaseMeta.getDefaultDatabasePort() );
+  }
+
+  @Test
+  public void testQuoting() {
+    assertEquals( "`", sparkSimbaDatabaseMeta.getStartQuote() );
+    assertEquals( "`", sparkSimbaDatabaseMeta.getEndQuote() );
+  }
+
+  @Test
+  public void testGeneratedSQLContainsSchemaReferenceWhenTableUnqualified() {
+    verifySchemaQualifier( null, "foo" );
+  }
+
+  @Test
+  public void testGeneratedSQLContainsSchemaReferenceWhenTableQualified() {
+    verifySchemaQualifier( DB_NAME, "foo" );
+  }
+
+  private void verifySchemaQualifier( String schemaName, String tableName ) {
+    String combinedSchemaTable = schemaName == null ? tableName
+      : schemaName + "." + tableName;
+    assertThat( sparkSimbaDatabaseMeta.getSQLTableExists( combinedSchemaTable ),
+      is( "SELECT 1 FROM " + DB_NAME + "." + tableName ) );
+    assertThat( sparkSimbaDatabaseMeta.getTruncateTableStatement( combinedSchemaTable ),
+      is( "TRUNCATE TABLE " + DB_NAME + "." + tableName ) );
+    assertThat( sparkSimbaDatabaseMeta.getSQLColumnExists( "column", combinedSchemaTable ),
+      is( "SELECT column FROM " + DB_NAME + "." + tableName ) );
+    assertThat( sparkSimbaDatabaseMeta.getSQLQueryFields( combinedSchemaTable ),
+      is( "SELECT * FROM " + DB_NAME + "." + "foo LIMIT 0" ) );
+    assertThat( sparkSimbaDatabaseMeta.getSelectCountStatement( combinedSchemaTable ),
+      is( SparkSimbaDatabaseMeta.SELECT_COUNT_STATEMENT + " " + DB_NAME + "." + tableName ) );
+  }
+
+
+  @Test
+  public void testUnsupportedDrop() {
+    exception.expect( UnsupportedOperationException.class );
+    sparkSimbaDatabaseMeta.getDropColumnStatement( "tab", null, "tk", false, "pk", false );
+  }
+
+  @Test
+  public void testUnsupportedAddCol() {
+    exception.expect( UnsupportedOperationException.class );
+    sparkSimbaDatabaseMeta.getAddColumnStatement( "tab", null, "tk", false, "pk", false );
+  }
+
+  @Test
+  public void testUnsupportedModCol() {
+    exception.expect( UnsupportedOperationException.class );
+    sparkSimbaDatabaseMeta.getModifyColumnStatement( "tab", null, "tk", false, "pk", false );
+  }
+
+  @Test
+  public void testGetDriverClass() {
+    assertThat( sparkSimbaDatabaseMeta.getDriverClass(),
+      is( SparkSimbaDatabaseMeta.DRIVER_CLASS_NAME ) );
+  }
+}


### PR DESCRIPTION
Changes include a new DatabaseMeta for Spark, plus a wrapper
implementation in impl-shim.  Also refactored the other Simba
DatabaseMetas to eliminate code duplication.

http://jira.pentaho.com/browse/BACKLOG-8748