### PR TITLE
[BACKLOG-8748] Support for SparkSQL

### DIFF
--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
@@ -30,6 +30,7 @@ public class SparkSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
   @VisibleForTesting static final String DRIVER_CLASS_NAME = "org.apache.hive.jdbc.SparkSqlSimbaDriver";
   @VisibleForTesting static final String JAR_FILE = "SparkJDBC41.jar";
   @VisibleForTesting static final int DEFAULT_PORT = 10015;
+  private final String LIMIT_1 = " LIMIT 1";
 
   public SparkSimbaDatabaseMeta( DriverLocator driverLocator ) {
     super( driverLocator );
@@ -50,7 +51,7 @@ public class SparkSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
 
   @Override
   public String getSQLQueryFields( String tableName ) {
-    return "SELECT * FROM " + getTableReference( tableName ) + " LIMIT 0";
+    return "SELECT * FROM " + tableName + LIMIT_1;
   }
 
   @Override
@@ -63,37 +64,24 @@ public class SparkSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
     return "`";
   }
 
-  private String getTableReference( String tableName ) {
-    if ( !isTableNameQualified( tableName ) ) {
-      return getSchemaTableCombination( getDatabaseName(), tableName );
-    } else {
-      return tableName;
-    }
-  }
-
-  private boolean isTableNameQualified( String tableName ) {
-    String quotedDbName = getStartQuote() + getDatabaseName() + getEndQuote();
-    return tableName.startsWith( getDatabaseName() ) || tableName.startsWith( quotedDbName );
-  }
-
   @Override
   public String getSQLTableExists( String tablename ) {
-    return "SELECT 1 FROM " + getTableReference( tablename );
+    return "SELECT 1 FROM " + tablename + LIMIT_1;
   }
 
   @Override
   public String getTruncateTableStatement( String tableName ) {
-    return "TRUNCATE TABLE " + getTableReference( tableName );
+    return "TRUNCATE TABLE " + tableName;
   }
 
   @Override
   public String getSQLColumnExists( String columnname, String tablename ) {
-    return "SELECT " + columnname + " FROM " + getTableReference( tablename );
+    return "SELECT " + columnname + " FROM " + tablename + LIMIT_1;
   }
 
   @Override
   public String getSelectCountStatement( String tableName ) {
-    return SELECT_COUNT_STATEMENT + " " + getTableReference( tableName );
+    return SELECT_COUNT_STATEMENT + " " + tableName;
   }
 
   @Override

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
@@ -94,27 +94,27 @@ public class SparkSimbaDatabaseMetaTest {
 
   @Test
   public void testGeneratedSQLContainsSchemaReferenceWhenTableUnqualified() {
-    verifySchemaQualifier( null, "foo" );
+    verifyExpectedSql( null, "foo" );
   }
 
   @Test
   public void testGeneratedSQLContainsSchemaReferenceWhenTableQualified() {
-    verifySchemaQualifier( DB_NAME, "foo" );
+    verifyExpectedSql( DB_NAME, "foo" );
   }
 
-  private void verifySchemaQualifier( String schemaName, String tableName ) {
-    String combinedSchemaTable = schemaName == null ? tableName
+  private void verifyExpectedSql( String schemaName, String tableName ) {
+    String expectedTableName = schemaName == null ? tableName
       : schemaName + "." + tableName;
-    assertThat( sparkSimbaDatabaseMeta.getSQLTableExists( combinedSchemaTable ),
-      is( "SELECT 1 FROM " + DB_NAME + "." + tableName ) );
-    assertThat( sparkSimbaDatabaseMeta.getTruncateTableStatement( combinedSchemaTable ),
-      is( "TRUNCATE TABLE " + DB_NAME + "." + tableName ) );
-    assertThat( sparkSimbaDatabaseMeta.getSQLColumnExists( "column", combinedSchemaTable ),
-      is( "SELECT column FROM " + DB_NAME + "." + tableName ) );
-    assertThat( sparkSimbaDatabaseMeta.getSQLQueryFields( combinedSchemaTable ),
-      is( "SELECT * FROM " + DB_NAME + "." + "foo LIMIT 0" ) );
-    assertThat( sparkSimbaDatabaseMeta.getSelectCountStatement( combinedSchemaTable ),
-      is( SparkSimbaDatabaseMeta.SELECT_COUNT_STATEMENT + " " + DB_NAME + "." + tableName ) );
+    assertThat( sparkSimbaDatabaseMeta.getSQLTableExists( expectedTableName ),
+      is( "SELECT 1 FROM " + expectedTableName + " LIMIT 1" ) );
+    assertThat( sparkSimbaDatabaseMeta.getTruncateTableStatement( expectedTableName ),
+      is( "TRUNCATE TABLE " + expectedTableName ) );
+    assertThat( sparkSimbaDatabaseMeta.getSQLColumnExists( "column", expectedTableName ),
+      is( "SELECT column FROM " + expectedTableName  + " LIMIT 1" ) );
+    assertThat( sparkSimbaDatabaseMeta.getSQLQueryFields( expectedTableName ),
+      is( "SELECT * FROM " + expectedTableName + " LIMIT 1" ) );
+    assertThat( sparkSimbaDatabaseMeta.getSelectCountStatement( expectedTableName ),
+      is( SparkSimbaDatabaseMeta.SELECT_COUNT_STATEMENT + " " + expectedTableName ) );
   }
 
 


### PR DESCRIPTION
Minor change to eliminate qualifying schema name
for table name references.  Not necessary with the
Simba Spark 1.0.2.1004 (was required with 1001).

http://jira.pentaho.com/browse/BACKLOG-8748