### PR TITLE
[BACKLOG-8389] - Upgrade antlr to version 3.5.2 across Pentaho product suite - changes for pentaho big-data-plugin repository

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -15,9 +15,9 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>antlr</groupId>
-      <artifactId>antlr</artifactId>
-      <version>2.7.7</version>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr-complete</artifactId>
+      <version>3.5.2</version>
     </dependency>
     <dependency>
       <groupId>ascsapjco3wrp</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -27,7 +27,6 @@
       <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}
       </outputFileNameMapping>
       <includes>
-        <include>antlr:antlr</include>
         <include>ascsapjco3wrp:ascsapjco3wrp</include>
         <include>asm:asm</include>
         <include>bouncycastle:bcmail-jdk14</include>
@@ -106,7 +105,7 @@
         <include>net.sf.scannotation:scannotation</include>
         <include>net.sourceforge.nekohtml:nekohtml</include>
         <include>ognl:ognl</include>
-        <include>org.antlr:antlr</include>
+        <include>org.antlr:antlr-complete</include>
         <include>org.apache.ant:ant</include>
         <include>org.apache.ant:ant-launcher</include>
         <include>org.apache.axis:axis</include>


### PR DESCRIPTION
Replace antlr-2.7.7 with antlr-complete-3.5.2 which contains antlr-2.7.7.

To build pentaho-big-data-assemblies-pmr-libraries it previously needs to build:

- pentaho-reporting-engine-classic-core as it was changed to use antlr-complete-3.5.2 (pentaho/pentaho-reporting#792);
- pentaho-kettle-engine (pentaho/pentaho-kettle#2665) as it uses pentaho-reporting-engine-classic-core;
- pentaho-platform  (pentaho/pentaho-platform#2964) as it has dependency on antlr-complete-3.5.2, pentaho-kettle-engine, pentaho-reporting-engine-classic-core.