### PR TITLE
[BACKLOG-8869] Open URL Hadoop Cluster list gets it's information inc…

### DIFF
--- a/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/NamedClusterWidgetImpl.java
+++ b/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/plugins/common/ui/NamedClusterWidgetImpl.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -70,8 +70,8 @@ public class NamedClusterWidgetImpl extends Composite {
       props.setLook( nameLabel );
     }
 
-    nameClusterCombo = new Combo( this, SWT.DROP_DOWN | SWT.READ_ONLY );
-    nameClusterCombo.setLayoutData( new RowData( 150, SWT.DEFAULT ) );
+    setNameClusterCombo( new Combo( this, SWT.DROP_DOWN | SWT.READ_ONLY ) );
+    getNameClusterCombo().setLayoutData( new RowData( 150, SWT.DEFAULT ) );
 
     Button editButton = new Button( this, SWT.NONE );
     editButton.setText( BaseMessages.getString( PKG, "NamedClusterWidget.NamedCluster.Edit" ) );
@@ -112,7 +112,7 @@ public class NamedClusterWidgetImpl extends Composite {
         //Ignore
       }
 
-      int index = nameClusterCombo.getSelectionIndex();
+      int index = getNameClusterCombo().getSelectionIndex();
       if ( index > -1 && namedClusters != null && namedClusters.size() > 0 ) {
         ncDelegate.editNamedCluster( spoon.getMetaStore(), namedClusters
           .get( index ), getShell() );
@@ -121,7 +121,7 @@ public class NamedClusterWidgetImpl extends Composite {
     }
   }
 
-  private String[] getNamedClusterNames() {
+  protected String[] getNamedClusterNames() {
     try {
       return namedClusterService.listNames( Spoon.getInstance().getMetaStore() )
         .toArray( new String[ 0 ] );
@@ -131,17 +131,17 @@ public class NamedClusterWidgetImpl extends Composite {
   }
 
   public void initiate() {
-    int selectedIndex = nameClusterCombo.getSelectionIndex();
-    nameClusterCombo.removeAll();
-    nameClusterCombo.setItems( getNamedClusterNames() );
-    nameClusterCombo.select( selectedIndex );
+    int selectedIndex = getNameClusterCombo().getSelectionIndex();
+    getNameClusterCombo().removeAll();
+    getNameClusterCombo().setItems( getNamedClusterNames() );
+    getNameClusterCombo().select( selectedIndex );
   }
 
   public NamedCluster getSelectedNamedCluster() {
     Spoon spoon = Spoon.getInstance();
-    int index = nameClusterCombo.getSelectionIndex();
+    int index = getNameClusterCombo().getSelectionIndex();
     if ( index > -1 ) {
-      String name = nameClusterCombo.getItem( index );
+      String name = getNameClusterCombo().getItem( index );
       try {
         return namedClusterService.read( name, spoon.getMetaStore() );
       } catch ( MetaStoreException e ) {
@@ -152,16 +152,24 @@ public class NamedClusterWidgetImpl extends Composite {
   }
 
   public void setSelectedNamedCluster( String name ) {
-    nameClusterCombo.deselectAll();
-    for ( int i = 0; i < nameClusterCombo.getItemCount(); i++ ) {
-      if ( nameClusterCombo.getItem( i ).equals( name ) ) {
-        nameClusterCombo.select( i );
+    getNameClusterCombo().deselectAll();
+    for ( int i = 0; i < getNameClusterCombo().getItemCount(); i++ ) {
+      if ( getNameClusterCombo().getItem( i ).equals( name ) ) {
+        getNameClusterCombo().select( i );
         return;
       }
     }
   }
 
   public void addSelectionListener( SelectionListener selectionListener ) {
-    nameClusterCombo.addSelectionListener( selectionListener );
+    getNameClusterCombo().addSelectionListener( selectionListener );
+  }
+
+  public Combo getNameClusterCombo() {
+    return nameClusterCombo;
+  }
+
+  protected void setNameClusterCombo( Combo nameClusterCombo ) {
+    this.nameClusterCombo = nameClusterCombo;
   }
 }

--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/vfs/HadoopVfsFileChooserDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/vfs/HadoopVfsFileChooserDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -110,8 +110,8 @@ public class HadoopVfsFileChooserDialog extends CustomVfsUiPanel {
     connectionGroup.setLayoutData( gData );
     connectionGroup.setLayout( connectionGroupLayout );
 
-    namedClusterWidget = new NamedClusterWidgetImpl( connectionGroup, true, namedClusterService, runtimeTestActionService, runtimeTester );
-    namedClusterWidget.addSelectionListener( new SelectionAdapter() {
+    setNamedClusterWidget( new NamedClusterWidgetImpl( connectionGroup, true, namedClusterService, runtimeTestActionService, runtimeTester ) );
+    getNamedClusterWidget().addSelectionListener( new SelectionAdapter() {
       public void widgetSelected( SelectionEvent evt ) {
         try {
           connect();
@@ -158,6 +158,10 @@ public class HadoopVfsFileChooserDialog extends CustomVfsUiPanel {
     return namedClusterWidget;
   }
 
+  protected void setNamedClusterWidget( NamedClusterWidgetImpl namedClusterWidget ) {
+    this.namedClusterWidget = namedClusterWidget;
+  }
+
   public void setNamedCluster( String namedCluster ) {
     this.namedCluster = namedCluster;
   }
@@ -167,13 +171,14 @@ public class HadoopVfsFileChooserDialog extends CustomVfsUiPanel {
     vfsFileChooserDialog.setInitialFile( null );
     vfsFileChooserDialog.openFileCombo.setText( "hdfs://" );
     vfsFileChooserDialog.vfsBrowser.fileSystemTree.removeAll();
-    namedClusterWidget.setSelectedNamedCluster( namedCluster );
+    getNamedClusterWidget().initiate();
+    getNamedClusterWidget().setSelectedNamedCluster( namedCluster );
     super.activate();
   }
 
   public void connect() {
     HadoopVfsConnection hdfsConnection =
-        new HadoopVfsConnection( namedClusterWidget.getSelectedNamedCluster(), getVariableSpace() );
+        new HadoopVfsConnection( getNamedClusterWidget().getSelectedNamedCluster(), getVariableSpace() );
     hdfsConnection.setCustomParameters( Props.getInstance() );
 
     FileObject root = rootFile;

--- a/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/vfs/HadoopVfsFileChooserDialogTest.java
+++ b/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/vfs/HadoopVfsFileChooserDialogTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.hdfs.vfs;
+
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Tree;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedClusterService;
+import org.pentaho.big.data.plugins.common.ui.NamedClusterWidgetImpl;
+import org.pentaho.runtime.test.RuntimeTester;
+import org.pentaho.runtime.test.action.RuntimeTestActionService;
+import org.pentaho.vfs.ui.VfsBrowser;
+import org.pentaho.vfs.ui.VfsFileChooserDialog;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+
+public class HadoopVfsFileChooserDialogTest {
+
+  private HadoopVfsFileChooserDialog hadoopVfsFileChooserDialog = null;
+  private static final Integer SELECTED_INDEX = -1;
+  private static final String[] NAMED_CLUSTER_NAMES = {"name1", "name2", "name3"};
+
+  @Before
+  public void Initialization() {
+    hadoopVfsFileChooserDialog = mock( HadoopVfsFileChooserDialog.class );
+  }
+
+  @After
+  public void finalize() {
+    hadoopVfsFileChooserDialog = null;
+  }
+
+  @Test
+  public void testActivate() {
+    doCallRealMethod().when( hadoopVfsFileChooserDialog ).activate();
+
+    VfsFileChooserDialog vfsFileChooserDialog = mock( VfsFileChooserDialog.class );
+    Combo combo = mock( Combo.class );
+    Tree tree = mock( Tree.class );
+    VfsBrowser vfsBrowser = mock( VfsBrowser.class );
+    doNothing().when( combo ).setText( anyString() );
+    vfsFileChooserDialog.openFileCombo = combo;
+    doNothing().when( tree ).removeAll();
+    vfsBrowser.fileSystemTree = tree;
+    vfsFileChooserDialog.vfsBrowser = vfsBrowser;
+    doCallRealMethod().when( vfsFileChooserDialog ).setRootFile( null );
+    doCallRealMethod().when( vfsFileChooserDialog ).setInitialFile( null );
+    hadoopVfsFileChooserDialog.vfsFileChooserDialog = vfsFileChooserDialog;
+
+    NamedClusterWidgetImplExtend namedClusterWidgetImpl = mock( NamedClusterWidgetImplExtend.class );
+    Combo namedClusterCombo = mock( Combo.class );
+    when( namedClusterCombo.getSelectionIndex() ).thenReturn( SELECTED_INDEX );
+    doNothing().when( namedClusterCombo ).removeAll();
+    doNothing().when( namedClusterCombo ).setItems( any() );
+    doNothing().when( namedClusterCombo ).select( SELECTED_INDEX );
+    when( namedClusterWidgetImpl.getNameClusterCombo() ).thenReturn( namedClusterCombo );
+    when( namedClusterWidgetImpl.getNamedClusterNames() ).thenReturn( NAMED_CLUSTER_NAMES );
+    doCallRealMethod().when( namedClusterWidgetImpl ).initiate();
+    doNothing().when( namedClusterWidgetImpl ).setSelectedNamedCluster( anyString() );
+    when( hadoopVfsFileChooserDialog.getNamedClusterWidget() ).thenReturn( namedClusterWidgetImpl );
+
+    hadoopVfsFileChooserDialog.activate();
+    verify( namedClusterWidgetImpl, times( 1 ) ).initiate();
+  }
+
+  private class NamedClusterWidgetImplExtend extends NamedClusterWidgetImpl {
+    public NamedClusterWidgetImplExtend( Composite parent, boolean showLabel, NamedClusterService namedClusterService, RuntimeTestActionService runtimeTestActionService, RuntimeTester clusterTester ) {
+      super( parent, showLabel, namedClusterService, runtimeTestActionService, clusterTester );
+    }
+
+    /*Overriding for visibility change only*/
+    @Override
+    public String[] getNamedClusterNames() {
+      return super.getNamedClusterNames();
+    }
+  }
+
+}


### PR DESCRIPTION
…onsistently

      - Minor change on activate method in HadoopVfsFileChooserDialog.java, to call initiate() method (forcing the refresh of the NamedCluster Combo)
      - Added unit tests for activate method
      - Refactored NamedClusterWidgetImpl.java and HadoopVfsFileChooserDialog.java classes to only call the getters instead of the having the attributes being called directly (useful for unit testing mocking )