### PR TITLE
[BACKLOG-8856] Support for SparkSQL in EE.

### DIFF
--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
@@ -87,19 +87,19 @@ public class SparkSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
   @Override
   public String getDropColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean use_autoinc,
                                         String pk, boolean semicolon ) {
-    throw new UnsupportedOperationException( "Cannot DROP columns with SparkSQL" );
+    return "";
   }
 
   @Override
   public String getAddColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
                                        String pk, boolean semicolon ) {
-    throw new UnsupportedOperationException( "Cannot ADD columns with SparkSQL" );
+    return "";
   }
 
   @Override
   public String getModifyColumnStatement( String tablename, ValueMetaInterface v, String tk, boolean useAutoinc,
                                           String pk, boolean semicolon ) {
-    throw new UnsupportedOperationException( "Cannot MODIFY columns with SparkSQL" );
+    return "";
   }
 
   @Override

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
@@ -120,20 +120,23 @@ public class SparkSimbaDatabaseMetaTest {
 
   @Test
   public void testUnsupportedDrop() {
-    exception.expect( UnsupportedOperationException.class );
-    sparkSimbaDatabaseMeta.getDropColumnStatement( "tab", null, "tk", false, "pk", false );
+    assertThat(
+      sparkSimbaDatabaseMeta.getDropColumnStatement( "tab", null, "tk", false, "pk", false ),
+      is( "" ) );
   }
 
   @Test
   public void testUnsupportedAddCol() {
-    exception.expect( UnsupportedOperationException.class );
-    sparkSimbaDatabaseMeta.getAddColumnStatement( "tab", null, "tk", false, "pk", false );
+    assertThat(
+      sparkSimbaDatabaseMeta.getAddColumnStatement( "tab", null, "tk", false, "pk", false ),
+      is( "" ) );
   }
 
   @Test
   public void testUnsupportedModCol() {
-    exception.expect( UnsupportedOperationException.class );
-    sparkSimbaDatabaseMeta.getModifyColumnStatement( "tab", null, "tk", false, "pk", false );
+    assertThat(
+      sparkSimbaDatabaseMeta.getModifyColumnStatement( "tab", null, "tk", false, "pk", false ),
+      is( "" ) );
   }
 
   @Test


### PR DESCRIPTION
Throwing an UnsupportedOperationException doesn't play
nicely with the "Feature List" option in the database dialog.
Returning empty strings for unsupported SQL instead.

http://jira.pentaho.com/browse/BACKLOG-8856