### PR TITLE
[BACKLOG-9186]: Exception `invalid constant type` appears in PMR mapper logs on cluster

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -280,9 +280,9 @@
       <version>20081125</version>
     </dependency>
     <dependency>
-      <groupId>javassist</groupId>
+      <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.12.1.GA</version>
+      <version>3.20.0-GA</version>
     </dependency>
     <dependency>
       <groupId>javax.activation</groupId>
@@ -388,6 +388,12 @@
       <groupId>net.sf.scannotation</groupId>
       <artifactId>scannotation</artifactId>
       <version>1.0.2</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>javassist</artifactId>
+          <groupId>javassist</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.nekohtml</groupId>
@@ -653,6 +659,12 @@
       <groupId>org.scannotation</groupId>
       <artifactId>scannotation</artifactId>
       <version>1.0.2</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>javassist</artifactId>
+          <groupId>javassist</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.snmp4j</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -83,7 +83,7 @@
         <include>janino:janino</include>
         <include>javacup:javacup</include>
         <include>javadbf:javadbf</include>
-        <include>javassist:javassist</include>
+        <include>org.javassist:javassist</include>
         <include>javax.activation:activation</include>
         <include>javax.mail:mail</include>
         <include>javax.servlet:jsp-api</include>


### PR DESCRIPTION
The problem is:
During configuration the map runner is creating a new transformation.
The process creation of the transformation involves calling at org.pentaho.di.core.KettleEnvironment.init().
And then we are trying to register plugins and types: PluginRegistry.init(), BasePluginType.registerPluginJars();
We use scannotation to find all annotated classes in jars but scannotation uses javassist for this.

So if any of classes in jar contains Java 8 lambdas, we will have this issue.
This occurs because Java 8 lambdas uses invokedynamic to generate code in runtime but javassist 3.12.1.GA doesn't support it.

With the fix https://issues.jboss.org/browse/JASSIST-174 javassist has got support for the CONSTANT_InvokeDynamic=18
So the fix is just to upgrade javassist to the latest release 3.20.0-GA.