### PR TITLE
[PDI-15565] PDI is not able to find Hadoop HA cluster name when it's defined in UPPERCASE

### DIFF
--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileNameParser.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileNameParser.java
@@ -1,28 +1,28 @@
 /*******************************************************************************
- *
  * Pentaho Big Data
- *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  ******************************************************************************/
 
 package org.pentaho.big.data.impl.vfs.hdfs;
 
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.URLFileName;
 import org.apache.commons.vfs2.provider.URLFileNameParser;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.apache.commons.vfs2.provider.VfsComponentContext;
 
 public class HDFSFileNameParser extends URLFileNameParser {
 
@@ -34,5 +34,42 @@ public class HDFSFileNameParser extends URLFileNameParser {
 
   public static HDFSFileNameParser getInstance() {
     return INSTANCE;
+  }
+
+  @Override public FileName parseUri( VfsComponentContext context, FileName base, String filename )
+    throws FileSystemException {
+    URLFileName fileNameURLFileName = (URLFileName) super.parseUri( context, base, filename );
+
+    return new URLFileName(
+      fileNameURLFileName.getScheme(),
+      getHostNameCaseSensitive( filename ),
+      fileNameURLFileName.getPort(),
+      fileNameURLFileName.getDefaultPort(),
+      fileNameURLFileName.getUserName(),
+      fileNameURLFileName.getPassword(),
+      fileNameURLFileName.getPath(),
+      fileNameURLFileName.getType(),
+      fileNameURLFileName.getQueryString() );
+  }
+
+  /**
+   * PDI-15565
+   * <p>
+   * the same logic as for extracting in org.apache.commons.vfs2.provider.HostFileNameParser.extractToPath
+   *
+   * @param fileUri file uri for hdfs file
+   * @return case sensitive host name
+   * @throws FileSystemException when format of url is not correct
+   */
+  private String getHostNameCaseSensitive( String fileUri ) throws FileSystemException {
+    StringBuilder fullNameBuilder = new StringBuilder();
+    UriParser.extractScheme( fileUri, fullNameBuilder );
+    if ( fullNameBuilder.length() < 2 || fullNameBuilder.charAt( 0 ) != '/' || fullNameBuilder.charAt( 1 ) != '/' ) {
+      throw new FileSystemException( "vfs.provider/missing-double-slashes.error", fileUri );
+    }
+    fullNameBuilder.delete( 0, 2 );
+    extractPort( fullNameBuilder, fileUri );
+    extractUserInfo( fullNameBuilder );
+    return extractHostName( fullNameBuilder );
   }
 }

--- a/impl/vfs/hdfs/src/test/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileNameParserTest.java
+++ b/impl/vfs/hdfs/src/test/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileNameParserTest.java
@@ -1,28 +1,28 @@
 /*******************************************************************************
- *
  * Pentaho Big Data
- *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
- *
- *******************************************************************************
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
+ * <p>
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  ******************************************************************************/
 
 package org.pentaho.big.data.impl.vfs.hdfs;
 
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.URLFileName;
+import org.apache.commons.vfs2.provider.URLFileNameParser;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -30,8 +30,51 @@ import static org.junit.Assert.assertEquals;
  * Created by bryan on 8/7/15.
  */
 public class HDFSFileNameParserTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
   @Test
   public void testDefaultPort() {
     assertEquals( -1, HDFSFileNameParser.getInstance().getDefaultPort() );
+  }
+
+  @Test
+  public void testParseUriNullInput() throws FileSystemException {
+    HDFSFileNameParser.getInstance().parseUri( null, null, "testfs://test" );
+  }
+
+  @Test
+  public void testParseUriMixedCase() throws FileSystemException {
+    URLFileName urlFileName =
+      (URLFileName) HDFSFileNameParser.getInstance().parseUri( null, null, "hdfs://testUpperCaseHost" );
+    assertEquals( "testUpperCaseHost", urlFileName.getHostName() );
+  }
+
+  @Test
+  public void testParseUriMixedCaseLongName() throws FileSystemException {
+    URLFileName urlFileName =
+      (URLFileName) HDFSFileNameParser.getInstance().parseUri( null, null, "hdfs://testUpperCaseHost/long/test/name" );
+    assertEquals( "testUpperCaseHost", urlFileName.getHostName() );
+  }
+
+  @Test
+  public void testParseUriThrowExceptionNoProtocol() throws FileSystemException {
+    exception.expect( FileSystemException.class );
+    HDFSFileNameParser.getInstance().parseUri( null, null, "testUpperCaseHost/long/test/name" );
+  }
+
+  @Test
+  public void testParseUriUserNameFilePath() throws FileSystemException {
+    String filename = "hdfs://root:password@testUpperCaseHost:8080/long/test/name";
+    URLFileName hdfsFileName =
+      (URLFileName) HDFSFileNameParser.getInstance()
+        .parseUri( null, null, filename );
+    URLFileName urlFileName = (URLFileName) new URLFileNameParser( 7000 ).parseUri( null, null, filename );
+    assertEquals( 8080, hdfsFileName.getPort() );
+    assertEquals( "root", hdfsFileName.getUserName() );
+    assertEquals( "/long/test/name", hdfsFileName.getPath() );
+    assertEquals( "password", hdfsFileName.getPassword() );
+    assertEquals( urlFileName.getType(), hdfsFileName.getType() );
+    assertEquals( urlFileName.getQueryString(), hdfsFileName.getQueryString() );
   }
 }


### PR DESCRIPTION
fixed with overriding in HDFSFileNameParser method parseUri which in comparison to URLFileNameParser doesn't make host lower cased