### PR TITLE
[SP-2806] Backport of BAD-487 - HBase cache size not set for hbase input (6.1 Suite)

### DIFF
--- a/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/table/HBaseTableImpl.java
+++ b/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/table/HBaseTableImpl.java
@@ -122,7 +122,7 @@ public class HBaseTableImpl implements HBaseTable {
 
   @Override public ResultScannerBuilder createScannerBuilder( byte[] keyLowerBound, byte[] keyUpperBound ) {
     return new ResultScannerBuilderImpl( hBaseConnectionPool, hBaseValueMetaInterfaceFactory, hBaseBytesUtilShim, name,
-      keyLowerBound, keyUpperBound );
+      0, keyLowerBound, keyUpperBound );
   }
 
   @Override
@@ -256,7 +256,7 @@ public class HBaseTableImpl implements HBaseTable {
       }
     }
     return new ResultScannerBuilderImpl( hBaseConnectionPool, hBaseValueMetaInterfaceFactory, hBaseBytesUtilShim, name,
-      keyLowerBound, keyUpperBound );
+      cacheSize, keyLowerBound, keyUpperBound );
   }
 
   @Override public List<String> getColumnFamilies() throws IOException {

--- a/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/table/ResultScannerBuilderImpl.java
+++ b/impl/shim/hbase/src/main/java/com/pentaho/big/data/bundles/impl/shim/hbase/table/ResultScannerBuilderImpl.java
@@ -22,6 +22,7 @@
 
 package com.pentaho.big.data.bundles.impl.shim.hbase.table;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.pentaho.big.data.bundles.impl.shim.hbase.BatchHBaseConnectionOperation;
 import com.pentaho.big.data.bundles.impl.shim.hbase.HBaseConnectionOperation;
 import com.pentaho.big.data.bundles.impl.shim.hbase.HBaseConnectionWrapper;
@@ -52,6 +53,7 @@ public class ResultScannerBuilderImpl implements ResultScannerBuilder {
   public ResultScannerBuilderImpl( HBaseConnectionPool hBaseConnectionPool,
                                    HBaseValueMetaInterfaceFactoryImpl hBaseValueMetaInterfaceFactory,
                                    HBaseBytesUtilShim hBaseBytesUtilShim, String tableName,
+                                   final int caching,
                                    final byte[] keyLowerBound,
                                    final byte[] keyUpperBound ) {
     this.hBaseConnectionPool = hBaseConnectionPool;
@@ -59,10 +61,12 @@ public class ResultScannerBuilderImpl implements ResultScannerBuilder {
     this.hBaseBytesUtilShim = hBaseBytesUtilShim;
     this.batchHBaseConnectionOperation = new BatchHBaseConnectionOperation();
     this.tableName = tableName;
+    this.caching = caching;
     batchHBaseConnectionOperation.addOperation( new HBaseConnectionOperation() {
       @Override public void perform( HBaseConnectionWrapper hBaseConnectionWrapper ) throws IOException {
         try {
-          hBaseConnectionWrapper.newSourceTableScan( keyLowerBound, keyUpperBound, caching );
+          hBaseConnectionWrapper
+            .newSourceTableScan( keyLowerBound, keyUpperBound, ResultScannerBuilderImpl.this.caching );
         } catch ( Exception e ) {
           throw new IOException( e );
         }
@@ -110,6 +114,11 @@ public class ResultScannerBuilderImpl implements ResultScannerBuilder {
 
   @Override public void setCaching( int cacheSize ) {
     this.caching = cacheSize;
+  }
+
+  @VisibleForTesting
+  int getCaching() {
+    return caching;
   }
 
   @Override public ResultScanner build() throws IOException {

--- a/impl/shim/hbase/src/test/java/com/pentaho/big/data/bundles/impl/shim/hbase/table/ResultScannerBuilderImplTest.java
+++ b/impl/shim/hbase/src/test/java/com/pentaho/big/data/bundles/impl/shim/hbase/table/ResultScannerBuilderImplTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package com.pentaho.big.data.bundles.impl.shim.hbase.table;
+
+import com.pentaho.big.data.bundles.impl.shim.hbase.connectionPool.HBaseConnectionPool;
+import com.pentaho.big.data.bundles.impl.shim.hbase.meta.HBaseValueMetaInterfaceFactoryImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.hbase.shim.spi.HBaseBytesUtilShim;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Created by bryan on 2/29/16.
+ */
+public class ResultScannerBuilderImplTest {
+  public static final Charset UTF_8 = Charset.forName( "UTF-8" );
+  private HBaseConnectionPool hBaseConnectionPool;
+  private HBaseValueMetaInterfaceFactoryImpl hBaseValueMetaInterfaceFactory;
+  private HBaseBytesUtilShim hBaseBytesUtilShim;
+  private String testTableName;
+  private int caching;
+  private byte[] keyLowerBound;
+  private byte[] keyUpperBound;
+  private ResultScannerBuilderImpl resultScannerBuilder;
+
+  @Before
+  public void setup() {
+    hBaseConnectionPool = mock( HBaseConnectionPool.class );
+    hBaseValueMetaInterfaceFactory = mock( HBaseValueMetaInterfaceFactoryImpl.class );
+    hBaseBytesUtilShim = mock( HBaseBytesUtilShim.class );
+    testTableName = "testTableName";
+    caching = 11;
+    keyLowerBound = "lower".getBytes( UTF_8 );
+    keyUpperBound = "upper".getBytes( UTF_8 );
+    init();
+  }
+
+  private void init() {
+    resultScannerBuilder =
+        new ResultScannerBuilderImpl( hBaseConnectionPool, hBaseValueMetaInterfaceFactory, hBaseBytesUtilShim,
+            testTableName, caching, keyLowerBound, keyUpperBound );
+  }
+
+  @Test
+  public void testCachingConstructorArg() {
+    assertEquals( caching, resultScannerBuilder.getCaching() );
+    caching = 12;
+    init();
+    assertEquals( caching, resultScannerBuilder.getCaching() );
+  }
+}


### PR DESCRIPTION
- Fix https://github.com/pentaho/big-data-plugin/pull/624/files was backported.