### PR TITLE
[BACKLOG-9978] Adding support for LIMIT to the SparkSimbaDatabaseMeta.

### DIFF
--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMeta.java
@@ -83,6 +83,11 @@ public class SparkSimbaDatabaseMeta extends BaseSimbaDatabaseMeta {
   }
 
   @Override
+  public String getLimitClause( int nrRows ) {
+    return " LIMIT " + nrRows;
+  }
+
+  @Override
   public String getSelectCountStatement( String tableName ) {
     return SELECT_COUNT_STATEMENT + " " + tableName;
   }

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/SparkSimbaDatabaseMetaTest.java
@@ -159,7 +159,13 @@ public class SparkSimbaDatabaseMetaTest {
 
     Map<String, String> options = meta.getDefaultOptions();
     assertThat( options, IsMapWithSize.aMapWithSize( 1 ) );
-    assertThat( options, IsMapContaining.hasEntry( meta.getPluginId() + "." +
-      SparkSimbaDatabaseMeta.SOCKET_TIMEOUT_OPTION, "10" ) );
+    assertThat( options, IsMapContaining.hasEntry( meta.getPluginId() + "."
+      + SparkSimbaDatabaseMeta.SOCKET_TIMEOUT_OPTION, "10" ) );
+  }
+
+  @Test
+  public void testLimit() {
+    assertThat(
+      sparkSimbaDatabaseMeta.getLimitClause( 100 ), is( " LIMIT 100" ) );
   }
 }


### PR DESCRIPTION
This will allow preview from the "Explore" dialog to limit results on
the server.