### PR TITLE
[BACKLOG-10984] ClusterInitiazation during driver load causes sys init to hang

### DIFF
--- a/api/jdbc/src/main/java/org/pentaho/big/data/api/jdbc/impl/ClusterInitializingDriver.java
+++ b/api/jdbc/src/main/java/org/pentaho/big/data/api/jdbc/impl/ClusterInitializingDriver.java
@@ -87,7 +87,12 @@ public class ClusterInitializingDriver implements Driver {
 
   private void initializeCluster( String url ) {
     try {
-      clusterInitializer.initialize( jdbcUrlParser.parse( url ).getNamedCluster() );
+      // Initialize with a null namedCluster, since jdbc connections are not
+      // associated with namedClusters.
+      // Formerly this method used the following to determine cluster:
+      //      jdbcUrlParser.parse( url ).getNamedCluster() );
+      // But this had the potential to create a block.  BACKLOG-10983
+      clusterInitializer.initialize( null );
     } catch ( Exception e ) {
       logger.warn( "Can't parse " + url, e );
     }

--- a/api/jdbc/src/test/java/org/pentaho/big/data/api/jdbc/impl/ClusterInitializingDriverTest.java
+++ b/api/jdbc/src/test/java/org/pentaho/big/data/api/jdbc/impl/ClusterInitializingDriverTest.java
@@ -90,7 +90,7 @@ public class ClusterInitializingDriverTest {
   @Test
   public void testConnect() throws SQLException, ClusterInitializationException {
     assertNull( clusterInitializingDriver.connect( testUrl, null ) );
-    verify( clusterInitializer ).initialize( namedCluster );
+    verify( clusterInitializer ).initialize( null );
   }
 
   @Test
@@ -102,7 +102,7 @@ public class ClusterInitializingDriverTest {
   @Test
   public void testAccept() throws SQLException, ClusterInitializationException {
     assertFalse( clusterInitializingDriver.acceptsURL( testUrl ) );
-    verify( clusterInitializer ).initialize( namedCluster );
+    verify( clusterInitializer ).initialize( null );
   }
 
   @Test


### PR DESCRIPTION
Removing some logic which determined the named cluster to
associated with a jdbc connection by looking at the Url.
That association is currently unnecessary since we are not yet
supporting jdbc connections within named clusters.  The logic
was creating circularity during init:  the ClusterInitializingDriver
could be called when JackRabbit makes a repository connection.
But determining named cluster in turn requires a Repository.

We'll need to rethink this design when we have functional requirements
to associate named clusters and JDBC connections.