### PR TITLE
[SP-2858] - Backport of PDI-8984 - Sorting fields on the HBase Output…

### DIFF
--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingEditor.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingEditor.java
@@ -318,13 +318,13 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
           new ColumnInfo( Messages.getString( "HBaseInputDialog.Fields.FIELD_ALIAS" ), ColumnInfo.COLUMN_TYPE_TEXT,
               false ),
           new ColumnInfo( Messages.getString( "HBaseInputDialog.Fields.FIELD_KEY" ), ColumnInfo.COLUMN_TYPE_CCOMBO,
-              true ),
+              false ),
           new ColumnInfo( Messages.getString( "HBaseInputDialog.Fields.FIELD_FAMILY" ), ColumnInfo.COLUMN_TYPE_CCOMBO,
-              true ),
+              false ),
           new ColumnInfo( Messages.getString( "HBaseInputDialog.Fields.FIELD_NAME" ), ColumnInfo.COLUMN_TYPE_TEXT,
               false ),
           new ColumnInfo( Messages.getString( "HBaseInputDialog.Fields.FIELD_TYPE" ), ColumnInfo.COLUMN_TYPE_CCOMBO,
-              true ),
+              false ),
           new ColumnInfo( Messages.getString( "HBaseInputDialog.Fields.FIELD_INDEXED" ), ColumnInfo.COLUMN_TYPE_TEXT,
               false ), };
 


### PR DESCRIPTION
… Create/Edit Mappings tab Causes Data Conversion Error (6.1 Suite)

@mchen-len-son, @pamval, here is backport of https://github.com/pentaho/big-data-plugin/commit/bc6abbc228ed70e7aafcf0099ca1ecf8fcf541c4 to 6.1. Thanks. 