### PR TITLE
[BACKLOG-10623] Upgrades the spring framework and security version

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -12,6 +12,8 @@
   <packaging>pom</packaging>
   <properties>
     <publish-sonar-phase>site</publish-sonar-phase>
+	<spring.framework.version>4.3.2.RELEASE</spring.framework.version>
+	<spring.security.version>4.1.3.RELEASE</spring.security.version>
   </properties>
   <dependencies>
     <dependency>
@@ -671,36 +673,38 @@
       <artifactId>snmp4j</artifactId>
       <version>1.9.3d</version>
     </dependency>
+	<!-- TODO: Analyze if the following spring dependencies are needed -->
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>2.0.8.RELEASE</version>
+      <version>${spring.security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>3.2.14.RELEASE</version>
+      <version>${spring.framework.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>3.2.14.RELEASE</version>
+      <version>${spring.framework.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>3.2.14.RELEASE</version>
+      <version>${spring.framework.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>3.2.14.RELEASE</version>
+      <version>${spring.framework.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
-      <version>3.2.14.RELEASE</version>
+      <version>${spring.framework.version}</version>
     </dependency>
+	<!-- TODO: Analyze if the above spring dependencies are needed -->
     <dependency>
       <groupId>org.syslog4j</groupId>
       <artifactId>syslog4j</artifactId>


### PR DESCRIPTION
This is part of a set of pull requests for the spring 4 upgrade work:

https://github.com/pentaho/pentaho-platform/pull/3104
https://github.com/webdetails/cpf/pull/98
https://github.com/webdetails/cdf/pull/870
https://github.com/webdetails/cda/pull/209
https://github.com/webdetails/cde/pull/718
https://github.com/pentaho/data-access/pull/783
https://github.com/pentaho/pentaho-reporting/pull/828
https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/436
https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/842
https://github.com/pentaho/marketplace/pull/115
https://github.com/pentaho/big-data-plugin/pull/739
https://github.com/pentaho/pentaho-platform-ee/pull/972
https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/477
https://github.com/pentaho/pentaho-platform-plugin-dashboards/pull/319
https://github.com/pentaho/pdi-ee-plugin/pull/321
https://github.com/pentaho/pentaho-analyzer/pull/1196
https://github.com/pentaho/pdi-scheduler-plugin/pull/36
https://github.com/pentaho/pentaho-platform-plugin-geo/pull/114
https://github.com/pentaho/pentaho-metadata-editor/pull/70
https://github.com/pentaho/pentaho-aggdesigner/pull/46
https://github.com/webdetails/cpk/pull/51
https://github.com/pentaho/pentaho-osgi-bundles/pull/141
https://github.com/pentaho/pentaho-karaf-assembly/pull/231