### PR TITLE
[BACKLOG-11177] - Hadoop Hive 2 (Simba) shows up as a database type i…

### DIFF
--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/Activator.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/Activator.java
@@ -43,7 +43,7 @@ public class Activator implements BundleActivator {
   private final List<ServiceRegistration> serviceRegistrations = new ArrayList<>();
 
   private final List<Supplier<IDatabaseDialect>> databaseDialectSuppliers = Collections.unmodifiableList( Arrays
-    .asList( Hive2DatabaseDialect::new, Hive2SimbaDatabaseDialect::new, ImpalaDatabaseDialect::new,
+    .asList( Hive2DatabaseDialect::new, ImpalaDatabaseDialect::new,
       ImpalaSimbaDatabaseDialect::new, SparkSimbaDatabaseDialect::new ) );
 
   @Override public void start( BundleContext context ) throws Exception {


### PR DESCRIPTION
…n PUC

Remove Hive2SimbaDatabaseDialect from registration list.