### PR TITLE
[PPP-3572] - Vulnerability CVE-2012-2098 - commons-compress-1.4.jar h…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -430,7 +430,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
…aving implicit dependency on kettle-core-5.2.0.2-84.jar

@mbatchelor, @mkambol. @hudak, could you please take a look?  

kettle part: https://github.com/pentaho/pentaho-kettle/pull/3038 