### PR TITLE
[BACKLOG-11621] Removes JCIFS driver dependency

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -320,11 +320,6 @@
       <version>1.1</version>
     </dependency>
     <dependency>
-      <groupId>jcifs</groupId>
-      <artifactId>jcifs</artifactId>
-      <version>1.3.3</version>
-    </dependency>
-    <dependency>
       <groupId>jdom</groupId>
       <artifactId>jdom</artifactId>
       <version>1.0</version>
@@ -649,11 +644,6 @@
       <groupId>org.safehaus.jug</groupId>
       <artifactId>jug-lgpl</artifactId>
       <version>2.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.samba.jcifs</groupId>
-      <artifactId>jcifs</artifactId>
-      <version>1.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.scannotation</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -91,7 +91,6 @@
         <include>javax.validation:validation-api</include>
         <include>javax.xml:jaxrpc-api</include>
         <include>jaxen:jaxen</include>
-        <include>jcifs:jcifs</include>
         <include>jdom:jdom</include>
         <include>jexcelapi:jxl</include>
         <include>jfree:jcommon</include>
@@ -169,7 +168,6 @@
         <include>org.owasp.esapi:esapi</include>
         <include>org.postgresql:postgresql</include>
         <include>org.safehaus.jug:jug-lgpl</include>
-        <include>org.samba.jcifs:jcifs</include>
         <include>org.scannotation:scannotation</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:slf4j-log4j12</include>


### PR DESCRIPTION
@CodeOnCoffee @rmansoor @mbatchelor @pentaho/rogueone Please review

Related PRs:
https://github.com/pentaho/pentaho-platform/pull/3207
https://github.com/pentaho/pentaho-reporting/pull/869
https://github.com/pentaho/pentaho-reportdesigner-ee/pull/53
https://github.com/pentaho/pentaho-kettle/pull/3087
https://github.com/pentaho/pdi-platform-plugin/pull/40
https://github.com/pentaho/pentaho-platform-migrator/pull/323
https://github.com/pentaho/big-data-plugin/pull/761