### PR TITLE
[SP-2971] - Backport of PPP-3572 - Vulnerability CVE-2012-2098 - comm…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -422,7 +422,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
…ons-compress-1.4.jar having implicit dependency on kettle-core-5.2.0.2-84.jar (6.1 Suite)

@graimundo, @mkambol, @mbatchelor, here is backport of https://github.com/pentaho/big-data-plugin/pull/753/files to 6.1. Kettle part: https://github.com/pentaho/pentaho-kettle/pull/3107Thanks.  