### PR TITLE
[SP-2975] - Backport of PPP-3567 - Use of vulnerable component drools…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -551,18 +551,18 @@
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
-      <artifactId>drools-api</artifactId>
-      <version>5.0.1</version>
+      <artifactId>knowledge-api</artifactId>
+      <version>6.4.0.Final</version>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
-      <version>5.0.1</version>
+      <version>6.4.0.Final</version>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-core</artifactId>
-      <version>5.0.1</version>
+      <version>6.4.0.Final</version>
     </dependency>
     <dependency>
       <groupId>org.eobjects.sassyreader</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -142,7 +142,7 @@
         <include>org.codehaus.jackson:jackson-core-asl</include>
         <include>org.codehaus.jackson:jackson-jaxrs</include>
         <include>org.codehaus.jackson:jackson-mapper-asl</include>
-        <include>org.drools:drools-api</include>
+        <include>org.drools:knowledge-api</include>
         <include>org.drools:drools-compiler</include>
         <include>org.drools:drools-core</include>
         <include>org.eclipse.jetty:jetty-continuation</include>


### PR DESCRIPTION
@graimundo, @matt, @hudak, @mbatchelor, here is the backport of https://github.com/pentaho/big-data-plugin/pull/752 to 6.1. Thanks.