### PR TITLE
[PPP-3506] - XXE Security Vulnerability in xml parsers

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -239,7 +239,7 @@
     <dependency>
       <groupId>eigenbase</groupId>
       <artifactId>eigenbase-xom</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.5</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch</groupId>


### PR DESCRIPTION
 - eigenbase-xom dependency is updated to 1.3.5

@mbatchelor, @pamval, @lucboudreau, @mkambol, could you please take a look?
