### PR TITLE
PDI-15515 - Removing legacy ESAPI encoder from projects

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -636,9 +636,9 @@
       <version>1.2.0</version>
     </dependency>
     <dependency>
-      <groupId>org.owasp.esapi</groupId>
-      <artifactId>esapi</artifactId>
-      <version>2.0.1</version>
+      <groupId>org.owasp.encoder</groupId>
+      <artifactId>encoder</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -166,7 +166,7 @@
         <include>org.odftoolkit:odfdom-java</include>
         <include>org.olap4j:olap4j</include>
         <include>org.olap4j:olap4j-xmla</include>
-        <include>org.owasp.esapi:esapi</include>
+        <include>org.owasp.encoder:encoder</include>
         <include>org.postgresql:postgresql</include>
         <include>org.safehaus.jug:jug-lgpl</include>
         <include>org.samba.jcifs:jcifs</include>


### PR DESCRIPTION
Removing legacy ESAPI encoder from projects and replacing it by org.owasp.encoder