### PR TITLE
[OTHER] - fix list of shims in ce for 7.0.0.1 

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -150,13 +150,6 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-cdh57-package</artifactId>
-      <version>${dependency.hadoop-shims-cdh57.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh58-package</artifactId>
       <version>${dependency.hadoop-shims-cdh58.revision}</version>
       <type>zip</type>
@@ -171,13 +164,6 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-mapr410-package</artifactId>
-      <version>${dependency.hadoop-shims-mapr410.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
       <version>${dependency.hadoop-shims-mapr510.revision}</version>
       <type>zip</type>
@@ -185,8 +171,8 @@
     </dependency>
      <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-emr46-package</artifactId>
-      <version>${dependency.hadoop-shims-emr46.revision}</version>
+      <artifactId>pentaho-hadoop-shims-emr41-package</artifactId>
+      <version>${dependency.hadoop-shims-emr41.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -227,12 +213,6 @@
             </goals>
             <configuration>
               <artifactItems>
-				<artifactItem>
-                  <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-cdh57-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
                 <artifactItem>
                   <groupId>pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-cdh58-package</artifactId>
@@ -247,19 +227,13 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-mapr410-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-emr46-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-emr41-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency.json.revision>7.0-SNAPSHOT</dependency.json.revision>
     <dependency.maven-bundle-plugin.version>2.4.0</dependency.maven-bundle-plugin.version>
     <dependency.httpcomponents.revision>4.4</dependency.httpcomponents.revision>
-    <dependency.hadoop-shims-emr46.revision>7.0-SNAPSHOT</dependency.hadoop-shims-emr46.revision>
+    <dependency.hadoop-shims-emr41.revision>7.0-SNAPSHOT</dependency.hadoop-shims-emr41.revision>
     <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
     <plugin.org.codehaus.mojo.build-helper-maven-plugin.version>1.5</plugin.org.codehaus.mojo.build-helper-maven-plugin.version>
     <dependency.pentaho-registry.revision>7.0-SNAPSHOT</dependency.pentaho-registry.revision>
@@ -56,12 +56,10 @@
     <dependency.pentaho-reporting.revision>7.0-SNAPSHOT</dependency.pentaho-reporting.revision>
     <dependency.slf4j.revision>1.7.3</dependency.slf4j.revision>
     <dependency.jets3t.revision>0.9.3</dependency.jets3t.revision>
-	<dependency.hadoop-shims-cdh57.revision>7.0-SNAPSHOT</dependency.hadoop-shims-cdh57.revision>
     <dependency.hadoop-shims-cdh58.revision>7.0-SNAPSHOT</dependency.hadoop-shims-cdh58.revision>
     <dependency.xmlpull.revision>1.1.3.1</dependency.xmlpull.revision>
     <dependency.xpp3.revision>1.1.4c</dependency.xpp3.revision>
     <dependency.xstream.revision>1.4.9</dependency.xstream.revision>
-    <dependency.hadoop-shims-mapr410.revision>7.0-SNAPSHOT</dependency.hadoop-shims-mapr410.revision>
     <dependency.hadoop-shims-mapr510.revision>7.0-SNAPSHOT</dependency.hadoop-shims-mapr510.revision>
     <dependency.oozie.revision>3.1.3-incubating</dependency.oozie.revision>
     <dependency.pentaho-metadata.revision>7.0-SNAPSHOT</dependency.pentaho-metadata.revision>


### PR DESCRIPTION
according to the list of supported shims from here https://help.pentaho.com/Documentation/7.0/0D0/160/000
The following shims are included in the Pentaho Big Data plugin for Pentaho Version 7.0: Cloudera Distribution for Hadoop 5.8, Amazon EMR 4.1, Hortonworks 2.4, and MapR 5.1. Other supported shims can be downloaded from the Pentaho Support Portal.