### PR TITLE
[BACKLOG-13629]-Clean up SHIM projects in github - remove old versions

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -171,13 +171,6 @@
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-mapr410-package</artifactId>
-      <version>${dependency.hadoop-shims-mapr410.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
       <version>${dependency.hadoop-shims-mapr510.revision}</version>
       <type>zip</type>
@@ -242,12 +235,6 @@
                 <artifactItem>
                   <groupId>pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-hdp25-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-mapr410-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <dependency.slf4j.revision>1.7.3</dependency.slf4j.revision>
     <dependency.jets3t.revision>0.9.3</dependency.jets3t.revision>
     <dependency.xstream.revision>1.4.9</dependency.xstream.revision>
-    <dependency.hadoop-shims-mapr410.revision>7.1-SNAPSHOT</dependency.hadoop-shims-mapr410.revision>
     <dependency.oozie.revision>3.1.3-incubating</dependency.oozie.revision>
     <dependency.pentaho-metadata.revision>7.1-SNAPSHOT</dependency.pentaho-metadata.revision>
     <dependency.maven-clean-plugin.revision>2.5</dependency.maven-clean-plugin.revision>


### PR DESCRIPTION
Updated:
 - assemblies/legacy-plugin/pom.xml (removed mapr410);
 - pom.xml (removed mapr410).