### PR TITLE
[BACKLOG-13800]-Update ant pentaho-big-data-plugin project in relation to transfering of pentaho-hadoop-shims to maven

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -33,7 +33,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
     </dependency>
@@ -160,35 +160,35 @@
       <version>${dependency.xstream.revision}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh58-package</artifactId>
       <version>${dependency.hadoop-shims-cdh58.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh59-package</artifactId>
       <version>${dependency.hadoop-shims-cdh59.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
 	<dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-hdp25-package</artifactId>
       <version>${dependency.hadoop-shims-hdp25.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
       <version>${dependency.hadoop-shims-mapr510.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-emr46-package</artifactId>
       <version>${dependency.hadoop-shims-emr46.revision}</version>
       <type>zip</type>
@@ -232,31 +232,31 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>pentaho</groupId>
+                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-cdh58-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>pentaho</groupId>
+                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-cdh59-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>pentaho</groupId>
+                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-hdp25-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>pentaho</groupId>
+                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>
                 <artifactItem>
-                  <groupId>pentaho</groupId>
+                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-emr46-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>

--- a/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
+++ b/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
@@ -61,7 +61,7 @@
                 <include>libthrift:libthrift</include>
                 <include>org.apache.oozie:oozie-client</include>
                 <include>org.apache.oozie:oozie-core</include>
-                <include>pentaho:pentaho-hadoop-shims-api</include>
+                <include>org.pentaho:pentaho-hadoop-shims-api</include>
                 <include>pentaho:pentaho-s3-vfs</include>
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.slf4j:slf4j-log4j12</include>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -830,7 +830,7 @@
       <version>${dependency.pentaho-database-model.revision}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
     </dependency>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -208,7 +208,7 @@
         <include>pentaho:mondrian</include>
         <include>pentaho:pentaho-capability-manager</include>
         <include>pentaho:pentaho-database-model</include>
-        <include>pentaho:pentaho-hadoop-shims-api</include>
+        <include>org.pentaho:pentaho-hadoop-shims-api</include>
         <include>pentaho:pentaho-metadata</include>
         <include>pentaho:pentaho-osgi-utils-api</include>
         <include>pentaho:pentaho-registry</include>

--- a/impl/shim/hbase/pom.xml
+++ b/impl/shim/hbase/pom.xml
@@ -41,7 +41,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
     </dependency>

--- a/impl/shim/hdfs/pom.xml
+++ b/impl/shim/hdfs/pom.xml
@@ -33,7 +33,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>provided</scope>

--- a/impl/shim/hive/pom.xml
+++ b/impl/shim/hive/pom.xml
@@ -29,7 +29,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>provided</scope>

--- a/impl/shim/initializer/pom.xml
+++ b/impl/shim/initializer/pom.xml
@@ -33,7 +33,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>provided</scope>

--- a/impl/shim/mapreduce/pom.xml
+++ b/impl/shim/mapreduce/pom.xml
@@ -63,7 +63,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>provided</scope>

--- a/impl/shim/oozie/pom.xml
+++ b/impl/shim/oozie/pom.xml
@@ -29,7 +29,7 @@
       <version>${oozie.version}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
     </dependency>

--- a/impl/shim/pig/pom.xml
+++ b/impl/shim/pig/pom.xml
@@ -63,7 +63,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>provided</scope>

--- a/impl/shim/shimTests/pom.xml
+++ b/impl/shim/shimTests/pom.xml
@@ -48,7 +48,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>provided</scope>

--- a/impl/shim/sqoop/pom.xml
+++ b/impl/shim/sqoop/pom.xml
@@ -91,7 +91,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
     </dependency>

--- a/kettle-plugins/hbase/pom.xml
+++ b/kettle-plugins/hbase/pom.xml
@@ -104,7 +104,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>test</scope>

--- a/kettle-plugins/hdfs/pom.xml
+++ b/kettle-plugins/hdfs/pom.xml
@@ -86,7 +86,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>test</scope>

--- a/kettle-plugins/mapreduce/pom.xml
+++ b/kettle-plugins/mapreduce/pom.xml
@@ -104,7 +104,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>test</scope>

--- a/kettle-plugins/pig/pom.xml
+++ b/kettle-plugins/pig/pom.xml
@@ -91,7 +91,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
       <scope>test</scope>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -48,7 +48,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>pentaho</groupId>
+      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
     </dependency>
@@ -234,9 +234,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-api-test</artifactId>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
According to Pentaho requirements groupId for CE shims was changed from "pentaho" to "org.pentaho". Necessary changes were applied to big-data-plugin.

The following pull requests should be merged at the same time:
 - https://github.com/pentaho/pentaho-hadoop-shims/pull/431;
 - https://github.com/pentaho/pentaho-big-data-ee/pull/161;
 - https://github.com/pentaho/pentaho-yarn-kettle-plugin/pull/264.