### PR TITLE
[BAD-569]: Unable to load for editing ktr with HBase Input/Output steps if KDC host is unavailable

### DIFF
--- a/assemblies/features/src/main/resources/features.xml
+++ b/assemblies/features/src/main/resources/features.xml
@@ -38,7 +38,7 @@
     <bundle>mvn:pentaho/pentaho-big-data-api-jdbc/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-shim-common/${project.version}</bundle>
   </feature>
-  
+
   <feature name="pentaho-big-data-plugin-shim-impl" version="1.0">
     <feature>pentaho-big-data-plugin-api</feature>
     <conditional>
@@ -61,6 +61,8 @@
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-common-job/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-common-named-cluster-bridge/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-guiTestActionHandlers/${project.version}</bundle>
+    <bundle>wrap:mvn:pentaho/pentaho-hadoop-shims-api/${project.version}</bundle>
+	<bundle>mvn:pentaho/pentaho-big-data-impl-shim-hbase/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-hdfs/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-hbase/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-mapreduce/${project.version}</bundle>

--- a/impl/shim/hbase/pom.xml
+++ b/impl/shim/hbase/pom.xml
@@ -96,7 +96,8 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Import-Package>!org.pentaho.hbase.shim.api,!org.pentaho.hbase.shim.spi,!org.apache.hadoop.*,!org.pentaho.di.core.hadoop.*,!org.pentaho.hadoop.*,!org.pentaho.yarn.*,!org.apache.log4j,*</Import-Package>
+            <Import-Package>!org.pentaho.hbase.shim.spi,!org.apache.hadoop.*,!org.pentaho.di.core.hadoop.*,!org.pentaho.hadoop.*,!org.pentaho.yarn.*,!org.apache.log4j,*</Import-Package>
+            <Export-Package>com.pentaho.big.data.bundles.impl.shim.hbase.mapping,com.pentaho.big.data.bundles.impl.shim.hbase.meta, com.pentaho.big.data.bundles.impl.shim.hbase</Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/kettle-plugins/hbase/pom.xml
+++ b/kettle-plugins/hbase/pom.xml
@@ -107,7 +107,6 @@
       <groupId>pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
@@ -132,6 +131,11 @@
       <artifactId>xercesImpl</artifactId>
       <version>${dependency.xerces.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>pentaho</groupId>
+    	<artifactId>pentaho-big-data-impl-shim-hbase</artifactId>
+    	<version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtil.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtil.java
@@ -1,0 +1,82 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilter;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
+import org.pentaho.bigdata.api.hbase.mapping.Mapping;
+import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.w3c.dom.Node;
+
+public class HBaseDataLoadSaveUtil {
+
+  public static Mapping loadMapping( Node stepNode, MappingFactory mappingFactory ) throws KettleXMLException {
+    Mapping mapping = mappingFactory.createMapping();
+    if ( !mapping.loadXML( stepNode ) ) {
+      mapping = null;
+    }
+    return mapping;
+  }
+
+  public static Mapping loadMapping( Repository rep, ObjectId id_step, MappingFactory mappingFactory ) throws KettleException {
+    Mapping mapping = mappingFactory.createMapping();
+    if ( !mapping.readRep( rep, id_step ) ) {
+      mapping = null;
+    }
+    return mapping;
+  }
+
+  public static List<ColumnFilter> loadFilters( Node stepNode, ColumnFilterFactory colFtFactory ) {
+    List<ColumnFilter> colFilters = null;
+    Node filters = XMLHandler.getSubNode( stepNode, "column_filters" );
+    int nrFilters = XMLHandler.countNodes( filters, "filter" );
+    if ( nrFilters > 0 ) {
+      colFilters = new ArrayList<ColumnFilter>( nrFilters );
+      for ( int i = 0; i < nrFilters; i++ ) {
+        Node filterNode = XMLHandler.getSubNodeByNr( filters, "filter", i );
+        colFilters.add( colFtFactory.createFilter( filterNode ) );
+      }
+    }
+    return colFilters;
+  }
+
+  public static List<ColumnFilter> loadFilters( Repository rep, ObjectId id_step, ColumnFilterFactory colFtFactory ) throws KettleException {
+    List<ColumnFilter> colFilters = null;
+    int nrFilters = rep.countNrStepAttributes( id_step, "cf_comparison_opp" );
+    if ( nrFilters > 0 ) {
+      colFilters = new ArrayList<ColumnFilter>( nrFilters );
+      for ( int i = 0; i < nrFilters; i++ ) {
+        colFilters.add( colFtFactory.createFilter( rep, i, id_step ) );
+      }
+    }
+    return colFilters;
+  }
+
+}

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImp.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImp.java
@@ -1,0 +1,72 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import java.io.IOException;
+
+import org.pentaho.bigdata.api.hbase.ByteConversionUtil;
+import org.pentaho.bigdata.api.hbase.HBaseConnection;
+import org.pentaho.bigdata.api.hbase.HBaseService;
+import org.pentaho.bigdata.api.hbase.ResultFactory;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
+import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+
+import com.pentaho.big.data.bundles.impl.shim.hbase.ByteConversionUtilImpl;
+import com.pentaho.big.data.bundles.impl.shim.hbase.mapping.ColumnFilterFactoryImpl;
+import com.pentaho.big.data.bundles.impl.shim.hbase.mapping.MappingFactoryImpl;
+import com.pentaho.big.data.bundles.impl.shim.hbase.meta.HBaseValueMetaInterfaceFactoryImpl;
+
+public class HBaseServiceLocalImp implements HBaseService {
+
+  @Override
+  public HBaseConnection getHBaseConnection( VariableSpace variableSpace, String siteConfig, String defaultConfig, LogChannelInterface logChannelInterface ) throws IOException {
+    return null;
+  }
+
+  @Override
+  public ColumnFilterFactory getColumnFilterFactory() {
+    return new ColumnFilterFactoryImpl();
+  }
+
+  @Override
+  public MappingFactory getMappingFactory() {
+    return new MappingFactoryImpl( null, getHBaseValueMetaInterfaceFactory() );
+  }
+
+  @Override
+  public HBaseValueMetaInterfaceFactoryImpl getHBaseValueMetaInterfaceFactory() {
+    return new HBaseValueMetaInterfaceFactoryImpl( null );
+  }
+
+  @Override
+  public ByteConversionUtil getByteConversionUtil() {
+    return new ByteConversionUtilImpl( null );
+  }
+
+  @Override
+  public ResultFactory getResultFactory() {
+    return null;
+  }
+
+}

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/input/HBaseInputMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/input/HBaseInputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -27,12 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
 import org.pentaho.big.data.kettle.plugins.hbase.FilterDefinition;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseDataLoadSaveUtil;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseServiceLocalImp;
 import org.pentaho.big.data.kettle.plugins.hbase.MappingDefinition;
 import org.pentaho.big.data.kettle.plugins.hbase.NamedClusterLoadSaveUtil;
 import org.pentaho.big.data.kettle.plugins.hbase.mapping.MappingAdmin;
@@ -43,12 +44,10 @@ import org.pentaho.bigdata.api.hbase.HBaseService;
 import org.pentaho.bigdata.api.hbase.mapping.ColumnFilter;
 import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
 import org.pentaho.bigdata.api.hbase.mapping.Mapping;
-import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
 import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
 import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterfaceFactory;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -61,9 +60,11 @@ import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.repository.ObjectId;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.Trans;
@@ -78,17 +79,17 @@ import org.pentaho.runtime.test.RuntimeTester;
 import org.pentaho.runtime.test.action.RuntimeTestActionService;
 import org.w3c.dom.Node;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Class providing an input step for reading data from an HBase table according to meta data mapping info stored in a
  * separate HBase table called "pentaho_mappings". See org.pentaho.hbase.mapping.Mapping for details on the meta data
  * format.
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
-@Step( id = "HBaseInput", image = "HB.svg", name = "HBaseInput.Name", description = "HBaseInput.Description",
-    categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.BigData",
-    documentationUrl = "http://wiki.pentaho.com/display/EAI/HBase+Input",
-    i18nPackageName = "org.pentaho.di.trans.steps.hbaseinput" )
+@Step( id = "HBaseInput", image = "HB.svg", name = "HBaseInput.Name", description = "HBaseInput.Description", categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.BigData",
+    documentationUrl = "http://wiki.pentaho.com/display/EAI/HBase+Input", i18nPackageName = "org.pentaho.di.trans.steps.hbaseinput" )
 @InjectionSupported( localizationPrefix = "HBaseInput.Injection.", groups = { "OUTPUT_FIELDS", "MAPPING", "FILTER" } )
 public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
@@ -163,19 +164,26 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   @InjectionDeep
   protected MappingDefinition mappingDefinition;
 
-  public HBaseInputMeta( NamedClusterService namedClusterService,
-                         NamedClusterServiceLocator namedClusterServiceLocator,
-                         RuntimeTestActionService runtimeTestActionService, RuntimeTester runtimeTester ) {
+  private HBaseService hBaseLocalService;
+
+  public HBaseInputMeta( NamedClusterService namedClusterService, NamedClusterServiceLocator namedClusterServiceLocator, RuntimeTestActionService runtimeTestActionService,
+      RuntimeTester runtimeTester ) {
     this.namedClusterService = namedClusterService;
     this.namedClusterServiceLocator = namedClusterServiceLocator;
     this.runtimeTestActionService = runtimeTestActionService;
     this.runtimeTester = runtimeTester;
     namedClusterLoadSaveUtil = new NamedClusterLoadSaveUtil();
+    hBaseLocalService = new HBaseServiceLocalImp();
+  }
+
+
+  private HBaseService getHBaseLocalService() {
+    return hBaseLocalService;
   }
 
   /**
    * Set the mapping to use for decoding the row
-   * 
+   *
    * @param m
    *          the mapping to use
    */
@@ -185,7 +193,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the mapping to use for decoding the row
-   * 
+   *
    * @return the mapping to use
    */
   public Mapping getMapping() {
@@ -194,7 +202,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Set the URL to the hbase-site.xml. Either this OR the zookeeper host list can be used to establish a connection.
-   * 
+   *
    * @param coreConfig
    */
   public void setCoreConfigURL( String coreConfig ) {
@@ -204,7 +212,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the URL to the hbase-site.xml file.
-   * 
+   *
    * @return the URL to the hbase-site.xml file or null if not set.
    */
   public String getCoreConfigURL() {
@@ -214,7 +222,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   /**
    * Set the URL to the hbase-default.xml file. This can be optionally supplied in conjuction with hbase-site.xml. If
    * not supplied, then the default hbase-default.xml included in the main hbase jar file is used.
-   * 
+   *
    * @param defaultConfig
    *          URL to the hbase-default.xml file.
    */
@@ -225,7 +233,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the URL to hbase-default.xml
-   * 
+   *
    * @return the URL to hbase-default.xml or null if not set.
    */
   public String getDefaultConfigURL() {
@@ -239,7 +247,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the name of the HBase table to read from.
-   * 
+   *
    * @return the name of the source HBase table.
    */
   public String getSourceTableName() {
@@ -248,7 +256,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Set the name of the mapping to use that defines column names and types for the source table.
-   * 
+   *
    * @param sourceMapping
    *          the name of the mapping to use.
    */
@@ -259,7 +267,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the name of the mapping to use for reading and decoding column values for the source table.
-   * 
+   *
    * @return the name of the mapping to use.
    */
   public String getSourceMappingName() {
@@ -268,7 +276,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Set whether a given row needs to match at least one of the user specified column filters.
-   * 
+   *
    * @param a
    *          true if at least one filter needs to match before a given row is returned. If false then *all* filters
    *          must match.
@@ -279,7 +287,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get whether a given row needs to match at least one of the user-specified column filters.
-   * 
+   *
    * @return true if a given row needs to match at least one of the user specified column filters. Returns false if
    *         *all* column filters need to match
    */
@@ -289,7 +297,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Set the starting value (inclusive) of the key for range scans
-   * 
+   *
    * @param start
    *          the starting value of the key to use in range scans.
    */
@@ -299,7 +307,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the starting value of the key to use in range scans
-   * 
+   *
    * @return the starting value of the key
    */
   public String getKeyStartValue() {
@@ -309,7 +317,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   /**
    * Set the stop value (exclusive) of the key to use in range scans. May be null to indicate scan to the end of the
    * table
-   * 
+   *
    * @param stop
    *          the stop value of the key to use in range scans
    */
@@ -319,7 +327,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the stop value of the key to use in range scans
-   * 
+   *
    * @return the stop value of the key
    */
   public String getKeyStopValue() {
@@ -329,7 +337,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   /**
    * Set the number of rows to cache for scans. Higher values result in improved performance since there will be fewer
    * requests to HBase but at the expense of increased memory consumption.
-   * 
+   *
    * @param s
    *          the number of rows to cache for scans.
    */
@@ -339,7 +347,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * The number of rows to cache for scans.
-   * 
+   *
    * @return the number of rows to cache for scans.
    */
   public String getScannerCacheSize() {
@@ -349,7 +357,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   /**
    * Set a list of fields to emit from this steo. If not specified, then all fields defined in the mapping for the
    * source table will be emitted.
-   * 
+   *
    * @param fields
    *          a list of fields to emit from this step.
    */
@@ -360,7 +368,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   /**
    * Get the list of fields to emit from this step. May return null, which indicates that *all* fields defined in the
    * mapping for the source table will be emitted.
-   * 
+   *
    * @return the fields that will be output or null (indicating all fields defined in the mapping will be output).
    */
   public List<HBaseValueMetaInterface> getOutputFields() {
@@ -369,7 +377,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Set a list of column filters to use to refine the query
-   * 
+   *
    * @param list
    *          a list of column filters to refine the query
    */
@@ -379,7 +387,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the list of column filters to use for refining the results of a scan. May return null if no filters are in use.
-   * 
+   *
    * @return a list of columm filters by which to refine the results of a query scan.
    */
   public List<ColumnFilter> getColumnFilters() {
@@ -416,50 +424,51 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     if ( namedCluster == null ) {
       throw new KettleException( "Named cluster was not initialized!" );
     }
-    try {
-      HBaseService hBaseService = namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class );
-      Mapping tempMapping = null;
-      if ( mappingDefinition != null ) {
-        tempMapping = getMapping( mappingDefinition, hBaseService );
-        setMapping( tempMapping );
-      }
 
-      if ( outputFieldsDefinition != null && !outputFieldsDefinition.isEmpty() ) {
-        if ( mappingDefinition == null ) {
-          if ( !Const.isEmpty( m_sourceMappingName ) ) {
-            tempMapping =
-              getMappingFromHBase( hBaseService, space, m_sourceTableName, m_sourceMappingName, m_coreConfigURL,
-                m_defaultConfigURL );
-          } else {
-            tempMapping = m_mapping;
-          }
+    if ( !isInjectionApplicable() ) {
+      return;
+    }
+
+    Mapping tempMapping = null;
+    if ( mappingDefinition != null ) {
+      tempMapping = getMapping( mappingDefinition, getHBaseLocalService() );
+      setMapping( tempMapping );
+    }
+
+    if ( outputFieldsDefinition != null && !outputFieldsDefinition.isEmpty() ) {
+      if ( mappingDefinition == null ) {
+        if ( !Utils.isEmpty( m_sourceMappingName ) ) {
+          tempMapping = getMappingFromHBase( getHBaseLocalService(), space, m_sourceTableName, m_sourceMappingName, m_coreConfigURL, m_defaultConfigURL );
+        } else {
+          tempMapping = m_mapping;
         }
-        setOutputFields( createOutputFieldsDefinition( tempMapping, hBaseService ) );
       }
+      setOutputFields( createOutputFieldsDefinition( tempMapping, getHBaseLocalService() ) );
+    }
 
-      if ( filtersDefinition != null && !filtersDefinition.isEmpty() ) {
-        ColumnFilterFactory columnFilterFactory = hBaseService.getColumnFilterFactory();
-        setColumnFilters( createColumnFiltersFromDefinition( columnFilterFactory ) );
-      }
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleException( e );
+    if ( filtersDefinition != null && !filtersDefinition.isEmpty() ) {
+      ColumnFilterFactory columnFilterFactory = getHBaseLocalService().getColumnFilterFactory();
+      setColumnFilters( createColumnFiltersFromDefinition( columnFilterFactory ) );
     }
   }
 
+  boolean isInjectionApplicable() {
+    return mappingDefinition != null || outputFieldsDefinition != null && !outputFieldsDefinition.isEmpty() || filtersDefinition != null && !filtersDefinition.isEmpty();
+  }
+
   @VisibleForTesting
-  Mapping getMapping( MappingDefinition mappingDefinition, HBaseService hBaseService ) throws KettleException {
+    Mapping getMapping( MappingDefinition mappingDefinition, HBaseService hBaseService ) throws KettleException {
     return MappingUtils.getMapping( mappingDefinition, hBaseService );
   }
 
-  static Mapping getMappingFromHBase( HBaseService hBaseService, VariableSpace space, String tableName,
-      String mappingName, String coreConfigURL, String defaultConfigURL ) throws KettleException {
+  static Mapping getMappingFromHBase( HBaseService hBaseService, VariableSpace space, String tableName, String mappingName, String coreConfigURL, String defaultConfigURL ) throws KettleException {
     try {
       String siteConfig = "";
-      if ( !Const.isEmpty( coreConfigURL ) ) {
+      if ( !Utils.isEmpty( coreConfigURL ) ) {
         siteConfig = space.environmentSubstitute( coreConfigURL );
       }
       String defaultConfig = "";
-      if ( !Const.isEmpty( ( defaultConfigURL ) ) ) {
+      if ( !Utils.isEmpty( ( defaultConfigURL ) ) ) {
         defaultConfig = space.environmentSubstitute( defaultConfigURL );
       }
       MappingAdmin mappingAdmin = MappingUtils.getMappingAdmin( hBaseService, space, siteConfig, defaultConfig );
@@ -470,12 +479,11 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   @VisibleForTesting
-  List<HBaseValueMetaInterface> createOutputFieldsDefinition( Mapping mapping, HBaseService hBaseService ) {
+    List<HBaseValueMetaInterface> createOutputFieldsDefinition( Mapping mapping, HBaseService hBaseService ) {
     return createOutputFieldsDefinition( outputFieldsDefinition, mapping, hBaseService );
   }
 
-  static List<HBaseValueMetaInterface> createOutputFieldsDefinition(
-      List<OutputFieldDefinition> outputFieldsDefinition, Mapping m_mapping, HBaseService hBaseService ) {
+  static List<HBaseValueMetaInterface> createOutputFieldsDefinition( List<OutputFieldDefinition> outputFieldsDefinition, Mapping m_mapping, HBaseService hBaseService ) {
     HBaseValueMetaInterfaceFactory valueMetaInterfaceFactory = hBaseService.getHBaseValueMetaInterfaceFactory();
     ByteConversionUtil byteConversionUtil = hBaseService.getByteConversionUtil();
 
@@ -483,9 +491,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     Map<String, HBaseValueMetaInterface> columns = m_mapping.getMappedColumns();
     for ( OutputFieldDefinition fieldDefinition : outputFieldsDefinition ) {
       HBaseValueMetaInterface valueMeta =
-          valueMetaInterfaceFactory.createHBaseValueMetaInterface( fieldDefinition.getFamily(), fieldDefinition
-              .getColumnName(), fieldDefinition.getAlias(), ValueMeta.getType( fieldDefinition.getHbaseType() ), -1,
-              -1 );
+          valueMetaInterfaceFactory.createHBaseValueMetaInterface( fieldDefinition.getFamily(), fieldDefinition.getColumnName(), fieldDefinition.getAlias(), ValueMeta.getType( fieldDefinition
+              .getHbaseType() ), -1, -1 );
       valueMeta.setKey( fieldDefinition.isKey() );
       valueMeta.setConversionMask( fieldDefinition.getFormat() );
       HBaseValueMetaInterface mappedColumn = columns.get( fieldDefinition.getAlias() );
@@ -503,12 +510,11 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   @VisibleForTesting
-  List<ColumnFilter> createColumnFiltersFromDefinition( ColumnFilterFactory c ) {
+    List<ColumnFilter> createColumnFiltersFromDefinition( ColumnFilterFactory c ) {
     return createColumnFiltersFromDefinition( filtersDefinition, c );
   }
 
-  static List<ColumnFilter> createColumnFiltersFromDefinition( List<FilterDefinition> filtersDefinition,
-    ColumnFilterFactory columnFilterFactory ) {
+  static List<ColumnFilter> createColumnFiltersFromDefinition( List<FilterDefinition> filtersDefinition, ColumnFilterFactory columnFilterFactory ) {
     List<ColumnFilter> filters = new ArrayList<>();
     for ( FilterDefinition filterDefinition : filtersDefinition ) {
       ColumnFilter columnFilter = columnFilterFactory.createFilter( filterDefinition.getAlias() );
@@ -522,7 +528,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     return filters;
   }
 
-  @Override public String getXML() {
+  @Override
+  public String getXML() {
     try {
       applyInjection( new Variables() );
     } catch ( KettleException e ) {
@@ -530,28 +537,27 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
     StringBuilder retval = new StringBuilder();
 
-    namedClusterLoadSaveUtil
-      .getXml( retval, namedClusterService, namedCluster, repository == null ? null : repository.getMetaStore(), getLog() );
+    namedClusterLoadSaveUtil.getXml( retval, namedClusterService, namedCluster, repository == null ? null : repository.getMetaStore(), getLog() );
 
-    if ( !Const.isEmpty( m_coreConfigURL ) ) {
+    if ( !Utils.isEmpty( m_coreConfigURL ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "core_config_url", m_coreConfigURL ) );
     }
-    if ( !Const.isEmpty( m_defaultConfigURL ) ) {
+    if ( !Utils.isEmpty( m_defaultConfigURL ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "default_config_url", m_defaultConfigURL ) );
     }
-    if ( !Const.isEmpty( m_sourceTableName ) ) {
+    if ( !Utils.isEmpty( m_sourceTableName ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "source_table_name", m_sourceTableName ) );
     }
-    if ( !Const.isEmpty( m_sourceMappingName ) ) {
+    if ( !Utils.isEmpty( m_sourceMappingName ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "source_mapping_name", m_sourceMappingName ) );
     }
-    if ( !Const.isEmpty( m_keyStart ) ) {
+    if ( !Utils.isEmpty( m_keyStart ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "key_start", m_keyStart ) );
     }
-    if ( !Const.isEmpty( m_keyStop ) ) {
+    if ( !Utils.isEmpty( m_keyStop ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "key_stop", m_keyStop ) );
     }
-    if ( !Const.isEmpty( m_scannerCacheSize ) ) {
+    if ( !Utils.isEmpty( m_scannerCacheSize ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "scanner_cache_size", m_scannerCacheSize ) );
     }
 
@@ -583,21 +589,10 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     return retval.toString();
   }
 
-  @Override public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore )
-    throws KettleXMLException {
-    System.out.println( "loading data" );
-    this.namedCluster =
-      namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, null, repository, metaStore, stepnode, getLog() );
-
-    HBaseService hBaseService;
-    try {
-      hBaseService = namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class );
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleXMLException( e );
-    }
-    HBaseValueMetaInterfaceFactory valueMetaInterfaceFactory = hBaseService.getHBaseValueMetaInterfaceFactory();
-    ColumnFilterFactory columnFilterFactory = hBaseService.getColumnFilterFactory();
-    MappingFactory mappingFactory = hBaseService.getMappingFactory();
+  @Override
+  public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
+    logDebug( BaseMessages.getString( HBaseInputMeta.PKG, "HBaseInputMeta.Message.Loading" ) );
+    this.namedCluster = namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, null, repository, metaStore, stepnode, getLog() );
 
     m_coreConfigURL = XMLHandler.getTagValue( stepnode, "core_config_url" );
     m_defaultConfigURL = XMLHandler.getTagValue( stepnode, "default_config_url" );
@@ -607,53 +602,39 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     m_keyStop = XMLHandler.getTagValue( stepnode, "key_stop" );
     m_scannerCacheSize = XMLHandler.getTagValue( stepnode, "scanner_cache_size" );
     String m = XMLHandler.getTagValue( stepnode, "match_any_filter" );
-    if ( !Const.isEmpty( m ) ) {
+    if ( !Utils.isEmpty( m ) ) {
       m_matchAnyFilter = m.equalsIgnoreCase( "Y" );
     }
 
-    m_outputFields = valueMetaInterfaceFactory.createListFromNode( stepnode );
+    m_outputFields = getHBaseLocalService().getHBaseValueMetaInterfaceFactory().createListFromNode( stepnode );
+    m_filters = HBaseDataLoadSaveUtil.loadFilters( stepnode, getHBaseLocalService().getColumnFilterFactory() );
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( stepnode, getHBaseLocalService().getMappingFactory() );
 
-    Node filters = XMLHandler.getSubNode( stepnode, "column_filters" );
-    if ( filters != null && XMLHandler.countNodes( filters, "filter" ) > 0 ) {
-      int nrFilters = XMLHandler.countNodes( filters, "filter" );
-      m_filters = new ArrayList<ColumnFilter>();
-
-      for ( int i = 0; i < nrFilters; i++ ) {
-        Node filterNode = XMLHandler.getSubNodeByNr( filters, "filter", i );
-        m_filters.add( columnFilterFactory.createFilter( filterNode ) );
-      }
-    }
-
-    Mapping tempMapping = mappingFactory.createMapping();
-    if ( tempMapping.loadXML( stepnode ) ) {
-      m_mapping = tempMapping;
-    } else {
-      m_mapping = null;
-    }
   }
 
-  @Override public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
+  @Override
+  public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
     namedClusterLoadSaveUtil.saveRep( rep, metaStore, id_transformation, id_step, namedClusterService, namedCluster, getLog() );
 
-    if ( !Const.isEmpty( m_coreConfigURL ) ) {
+    if ( !Utils.isEmpty( m_coreConfigURL ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "core_config_url", m_coreConfigURL );
     }
-    if ( !Const.isEmpty( m_defaultConfigURL ) ) {
+    if ( !Utils.isEmpty( m_defaultConfigURL ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "default_config_url", m_defaultConfigURL );
     }
-    if ( !Const.isEmpty( m_sourceTableName ) ) {
+    if ( !Utils.isEmpty( m_sourceTableName ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "source_table_name", m_sourceTableName );
     }
-    if ( !Const.isEmpty( m_sourceMappingName ) ) {
+    if ( !Utils.isEmpty( m_sourceMappingName ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "source_mapping_name", m_sourceMappingName );
     }
-    if ( !Const.isEmpty( m_keyStart ) ) {
+    if ( !Utils.isEmpty( m_keyStart ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "key_start", m_keyStart );
     }
-    if ( !Const.isEmpty( m_keyStop ) ) {
+    if ( !Utils.isEmpty( m_keyStop ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "key_stop", m_keyStop );
     }
-    if ( !Const.isEmpty( m_scannerCacheSize ) ) {
+    if ( !Utils.isEmpty( m_scannerCacheSize ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "scanner_cache_size", m_scannerCacheSize );
     }
 
@@ -678,20 +659,9 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  @Override public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
-    throws KettleException {
-
+  @Override
+  public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases ) throws KettleException {
     this.namedCluster = namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, id_step, rep, metaStore, null, getLog() );
-
-    HBaseService hBaseService = null;
-    try {
-      hBaseService = namedClusterServiceLocator.getService( namedCluster, HBaseService.class );
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleException( e );
-    }
-    HBaseValueMetaInterfaceFactory valueMetaInterfaceFactory = hBaseService.getHBaseValueMetaInterfaceFactory();
-    ColumnFilterFactory columnFilterFactory = hBaseService.getColumnFilterFactory();
-    MappingFactory mappingFactory = hBaseService.getMappingFactory();
 
     m_coreConfigURL = rep.getStepAttributeString( id_step, 0, "core_config_url" );
     m_defaultConfigURL = rep.getStepAttributeString( id_step, 0, "default_config_url" );
@@ -702,34 +672,20 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     m_matchAnyFilter = rep.getStepAttributeBoolean( id_step, 0, "match_any_filter" );
     m_scannerCacheSize = rep.getStepAttributeString( id_step, 0, "scanner_cache_size" );
 
-    m_outputFields = valueMetaInterfaceFactory.createListFromRepository( rep, id_step );
-
-    int nrFilters = rep.countNrStepAttributes( id_step, "cf_comparison_opp" );
-    if ( nrFilters > 0 ) {
-      m_filters = new ArrayList<>();
-
-      for ( int i = 0; i < nrFilters; i++ ) {
-        m_filters.add( columnFilterFactory.createFilter( rep, i, id_step ) );
-      }
-    }
-
-    Mapping tempMapping = mappingFactory.createMapping();
-    if ( tempMapping.readRep( rep, id_step ) ) {
-      m_mapping = tempMapping;
-    } else {
-      m_mapping = null;
-    }
+    m_outputFields = getHBaseLocalService().getHBaseValueMetaInterfaceFactory().createListFromRepository( rep, id_step );
+    m_filters = HBaseDataLoadSaveUtil.loadFilters( rep, id_step, getHBaseLocalService().getColumnFilterFactory() );
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( rep, id_step, getHBaseLocalService().getMappingFactory() );
   }
 
-  @Override public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta, RowMetaInterface prev,
-      String[] input, String[] output, RowMetaInterface info, VariableSpace variableSpace, Repository repository, IMetaStore metaStore ) {
+  @Override
+  public void check( List<CheckResultInterface> remarks, TransMeta transMeta, StepMeta stepMeta, RowMetaInterface prev, String[] input, String[] output, RowMetaInterface info,
+      VariableSpace variableSpace, Repository repository, IMetaStore metaStore ) {
 
     RowMeta r = new RowMeta();
     try {
       getFields( r, "testName", null, null, null, repository, metaStore );
 
-      CheckResult cr =
-          new CheckResult( CheckResult.TYPE_RESULT_OK, "Step can connect to HBase. Named mapping exists", stepMeta );
+      CheckResult cr = new CheckResult( CheckResult.TYPE_RESULT_OK, "Step can connect to HBase. Named mapping exists", stepMeta );
       remarks.add( cr );
     } catch ( Exception ex ) {
       CheckResult cr = new CheckResult( CheckResult.TYPE_RESULT_ERROR, ex.getMessage(), stepMeta );
@@ -737,8 +693,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     }
   }
 
-  public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr,
-      TransMeta transMeta, Trans trans ) {
+  public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta, Trans trans ) {
 
     return new HBaseInput( stepMeta, stepDataInterface, copyNr, transMeta, trans, namedClusterServiceLocator );
   }
@@ -755,11 +710,11 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
     } catch ( ClusterInitializationException e ) {
       throw new KettleStepException( e );
     }
-    if ( Const.isEmpty( m_coreConfigURL ) && Const.isEmpty( namedCluster.getZooKeeperHost() ) ) {
+    if ( Utils.isEmpty( m_coreConfigURL ) && Utils.isEmpty( namedCluster.getZooKeeperHost() ) ) {
       throw new KettleStepException( "No output fields available (missing " + "connection details)!" );
     }
 
-    if ( m_mapping == null && ( Const.isEmpty( m_sourceTableName ) || Const.isEmpty( m_sourceMappingName ) ) ) {
+    if ( m_mapping == null && ( Utils.isEmpty( m_sourceTableName ) || Utils.isEmpty( m_sourceMappingName ) ) ) {
       throw new KettleStepException( "No output fields available (missing table " + "mapping details)!" );
     }
 
@@ -772,10 +727,10 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
         String defaultConf = null;
 
         try {
-          if ( !Const.isEmpty( m_coreConfigURL ) ) {
+          if ( !Utils.isEmpty( m_coreConfigURL ) ) {
             coreConf = space.environmentSubstitute( m_coreConfigURL );
           }
-          if ( !Const.isEmpty( ( m_defaultConfigURL ) ) ) {
+          if ( !Utils.isEmpty( ( m_defaultConfigURL ) ) ) {
             defaultConf = space.environmentSubstitute( m_defaultConfigURL );
           }
 
@@ -803,8 +758,8 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
   }
 
   @Override
-  public void getFields( RowMetaInterface rowMeta, String origin, RowMetaInterface[] info, StepMeta nextStep,
-      VariableSpace space, Repository repository, IMetaStore metaStore ) throws KettleStepException {
+  public void getFields( RowMetaInterface rowMeta, String origin, RowMetaInterface[] info, StepMeta nextStep, VariableSpace space, Repository repository, IMetaStore metaStore )
+    throws KettleStepException {
 
     rowMeta.clear(); // start afresh - eats the input
 
@@ -820,8 +775,7 @@ public class HBaseInputMeta extends BaseStepMeta implements StepMetaInterface {
       setupCachedMapping( space );
 
       int kettleType;
-      if ( m_cachedMapping.getKeyType() == Mapping.KeyType.DATE
-          || m_cachedMapping.getKeyType() == Mapping.KeyType.UNSIGNED_DATE ) {
+      if ( m_cachedMapping.getKeyType() == Mapping.KeyType.DATE || m_cachedMapping.getKeyType() == Mapping.KeyType.UNSIGNED_DATE ) {
         kettleType = ValueMetaInterface.TYPE_DATE;
       } else if ( m_cachedMapping.getKeyType() == Mapping.KeyType.STRING ) {
         kettleType = ValueMetaInterface.TYPE_STRING;

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,6 +28,8 @@ import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseDataLoadSaveUtil;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseServiceLocalImp;
 import org.pentaho.big.data.kettle.plugins.hbase.MappingDefinition;
 import org.pentaho.big.data.kettle.plugins.hbase.NamedClusterLoadSaveUtil;
 import org.pentaho.big.data.kettle.plugins.hbase.mapping.MappingUtils;
@@ -35,7 +37,6 @@ import org.pentaho.bigdata.api.hbase.HBaseService;
 import org.pentaho.bigdata.api.hbase.mapping.Mapping;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -44,6 +45,7 @@ import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -67,7 +69,7 @@ import com.google.common.annotations.VisibleForTesting;
  * Class providing an output step for writing data to an HBase table according to meta data column/type mapping info
  * stored in a separate HBase table called "pentaho_mappings". See org.pentaho.hbase.mapping.Mapping for details on the
  * meta data format.
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
 @Step( id = "HBaseOutput", image = "HBO.svg", name = "HBaseOutput.Name", description = "HBaseOutput.Description",
@@ -120,6 +122,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
   private final NamedClusterServiceLocator namedClusterServiceLocator;
   private final RuntimeTestActionService runtimeTestActionService;
   private final RuntimeTester runtimeTester;
+  private HBaseService hBaseLocalService;
 
   public NamedClusterService getNamedClusterService() {
     return namedClusterService;
@@ -135,6 +138,10 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
 
   public RuntimeTester getRuntimeTester() {
     return runtimeTester;
+  }
+
+  private HBaseService getHBaseLocalService() {
+    return hBaseLocalService;
   }
 
   public HBaseOutputMeta( NamedClusterService namedClusterService,
@@ -155,12 +162,13 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
 
     this.runtimeTester = runtimeTester;
     this.namedClusterLoadSaveUtil = namedClusterLoadSaveUtil;
+    this.hBaseLocalService = new HBaseServiceLocalImp();
 
   }
 
   /**
    * Set the mapping to use for decoding the row
-   * 
+   *
    * @param m
    *          the mapping to use
    */
@@ -170,7 +178,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the mapping to use for decoding the row
-   * 
+   *
    * @return the mapping to use
    */
   public Mapping getMapping() {
@@ -284,19 +292,19 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     namedClusterLoadSaveUtil
       .getXml( retval, namedClusterService, namedCluster, repository == null ? null : repository.getMetaStore(), getLog() );
 
-    if ( !Const.isEmpty( m_coreConfigURL ) ) {
+    if ( !Utils.isEmpty( m_coreConfigURL ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "core_config_url", m_coreConfigURL ) );
     }
-    if ( !Const.isEmpty( m_defaultConfigURL ) ) {
+    if ( !Utils.isEmpty( m_defaultConfigURL ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "default_config_url", m_defaultConfigURL ) );
     }
-    if ( !Const.isEmpty( m_targetTableName ) ) {
+    if ( !Utils.isEmpty( m_targetTableName ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "target_table_name", m_targetTableName ) );
     }
-    if ( !Const.isEmpty( m_targetMappingName ) ) {
+    if ( !Utils.isEmpty( m_targetMappingName ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "target_mapping_name", m_targetMappingName ) );
     }
-    if ( !Const.isEmpty( m_writeBufferSize ) ) {
+    if ( !Utils.isEmpty( m_writeBufferSize ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "write_buffer_size", m_writeBufferSize ) );
     }
     retval.append( "\n    " ).append( XMLHandler.addTagValue( "disable_wal", m_disableWriteToWAL ) );
@@ -330,19 +338,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     m_writeBufferSize = XMLHandler.getTagValue( stepnode, "write_buffer_size" );
     String disableWAL = XMLHandler.getTagValue( stepnode, "disable_wal" );
     m_disableWriteToWAL = disableWAL.equalsIgnoreCase( "Y" );
-
-    Mapping tempMapping;
-    try {
-      tempMapping =
-        namedClusterServiceLocator.getService( namedCluster, HBaseService.class ).getMappingFactory().createMapping();
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleXMLException( e );
-    }
-    if ( tempMapping.loadXML( stepnode ) ) {
-      m_mapping = tempMapping;
-    } else {
-      m_mapping = null;
-    }
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( stepnode, getHBaseLocalService().getMappingFactory() );
   }
 
   @Override public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
@@ -356,37 +352,25 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     m_targetMappingName = rep.getStepAttributeString( id_step, 0, "target_mapping_name" );
     m_writeBufferSize = rep.getStepAttributeString( id_step, 0, "write_buffer_size" );
     m_disableWriteToWAL = rep.getStepAttributeBoolean( id_step, 0, "disable_wal" );
-
-    Mapping tempMapping;
-    try {
-      tempMapping =
-        namedClusterServiceLocator.getService( namedCluster, HBaseService.class ).getMappingFactory().createMapping();
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleException( e );
-    }
-    if ( tempMapping.readRep( rep, id_step ) ) {
-      m_mapping = tempMapping;
-    } else {
-      m_mapping = null;
-    }
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( rep, id_step, getHBaseLocalService().getMappingFactory() );
   }
 
   @Override public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
     namedClusterLoadSaveUtil.saveRep( rep, metaStore, id_transformation, id_step, namedClusterService, namedCluster, getLog() );
 
-    if ( !Const.isEmpty( m_coreConfigURL ) ) {
+    if ( !Utils.isEmpty( m_coreConfigURL ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "core_config_url", m_coreConfigURL );
     }
-    if ( !Const.isEmpty( m_defaultConfigURL ) ) {
+    if ( !Utils.isEmpty( m_defaultConfigURL ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "default_config_url", m_defaultConfigURL );
     }
-    if ( !Const.isEmpty( m_targetTableName ) ) {
+    if ( !Utils.isEmpty( m_targetTableName ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "target_table_name", m_targetTableName );
     }
-    if ( !Const.isEmpty( m_targetMappingName ) ) {
+    if ( !Utils.isEmpty( m_targetMappingName ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "target_mapping_name", m_targetMappingName );
     }
-    if ( !Const.isEmpty( m_writeBufferSize ) ) {
+    if ( !Utils.isEmpty( m_writeBufferSize ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "write_buffer_size", m_writeBufferSize );
     }
     rep.saveStepAttribute( id_transformation, id_step, 0, "disable_wal", m_disableWriteToWAL );

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,6 +31,8 @@ import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseDataLoadSaveUtil;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseServiceLocalImp;
 import org.pentaho.big.data.kettle.plugins.hbase.MappingDefinition;
 import org.pentaho.big.data.kettle.plugins.hbase.NamedClusterLoadSaveUtil;
 import org.pentaho.big.data.kettle.plugins.hbase.mapping.MappingUtils;
@@ -39,7 +41,6 @@ import org.pentaho.bigdata.api.hbase.mapping.Mapping;
 import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -51,6 +52,7 @@ import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMeta;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -103,6 +105,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
   private final NamedClusterService namedClusterService;
   private final RuntimeTestActionService runtimeTestActionService;
   private final RuntimeTester runtimeTester;
+  private HBaseService hBaseLocalService;
 
   private final NamedClusterLoadSaveUtil namedClusterLoadSaveUtil;
 
@@ -114,9 +117,12 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
     this.runtimeTestActionService = runtimeTestActionService;
     this.runtimeTester = runtimeTester;
     this.namedClusterLoadSaveUtil = new NamedClusterLoadSaveUtil();
+    this.hBaseLocalService = new HBaseServiceLocalImp();
   }
 
-
+  private HBaseService getHBaseLocalService() {
+    return hBaseLocalService;
+  }
 
   /**
    * @param namedCluster the namedCluster to set
@@ -270,15 +276,14 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
     if ( namedCluster == null ) {
       throw new KettleException( "Named cluster was not initialized!" );
     }
-    try {
-      HBaseService hBaseService = namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class );
-      Mapping tempMapping = null;
-      if ( mappingDefinition != null ) {
-        tempMapping = MappingUtils.getMapping( mappingDefinition, hBaseService );
+    if ( mappingDefinition != null ) {
+      try {
+        HBaseService hBaseService = namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class );
+        Mapping tempMapping = MappingUtils.getMapping( mappingDefinition, hBaseService );
         m_mapping = tempMapping;
+      } catch ( ClusterInitializationException e ) {
+        throw new KettleException( e );
       }
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleException( e );
     }
   }
 
@@ -301,10 +306,10 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
     }
     StringBuilder retval = new StringBuilder();
 
-    if ( !Const.isEmpty( m_incomingKeyField ) ) {
+    if ( !Utils.isEmpty( m_incomingKeyField ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "incoming_key_field", m_incomingKeyField ) );
     }
-    if ( !Const.isEmpty( m_incomingResultField ) ) {
+    if ( !Utils.isEmpty( m_incomingResultField ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "incoming_result_field", m_incomingResultField ) );
     }
 
@@ -320,41 +325,25 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
   public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
     m_incomingKeyField = XMLHandler.getTagValue( stepnode, "incoming_key_field" );
     m_incomingResultField = XMLHandler.getTagValue( stepnode, "incoming_result_field" );
-    this.namedCluster =
-        namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, null, repository, metaStore, stepnode, log );
-    try {
-      m_mapping =
-          namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class ).getMappingFactory()
-              .createMapping();
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleXMLException( e );
-    }
-    m_mapping.loadXML( stepnode );
+    this.namedCluster = namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, null, repository, metaStore, stepnode, log );
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( stepnode, getHBaseLocalService().getMappingFactory() );
   }
 
   public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
     throws KettleException {
-
     m_incomingKeyField = rep.getStepAttributeString( id_step, 0, "incoming_key_field" );
     m_incomingResultField = rep.getStepAttributeString( id_step, 0, "incoming_result_field" );
     this.namedCluster =
         namedClusterLoadSaveUtil.loadClusterConfig( namedClusterService, id_step, rep, metaStore, null, log );
-    try {
-      m_mapping =
-          namedClusterServiceLocator.getService( this.namedCluster, HBaseService.class ).getMappingFactory()
-              .createMapping();
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleXMLException( e );
-    }
-    m_mapping.readRep( rep, id_step );
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( rep, id_step, getHBaseLocalService().getMappingFactory() );
   }
 
   public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
 
-    if ( !Const.isEmpty( m_incomingKeyField ) ) {
+    if ( !Utils.isEmpty( m_incomingKeyField ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "incoming_key_field", m_incomingKeyField );
     }
-    if ( !Const.isEmpty( m_incomingResultField ) ) {
+    if ( !Utils.isEmpty( m_incomingResultField ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "incoming_result_field", m_incomingResultField );
     }
 

--- a/kettle-plugins/hbase/src/main/resources/org/pentaho/big/data/kettle/plugins/hbase/input/messages/messages_en_US.properties
+++ b/kettle-plugins/hbase/src/main/resources/org/pentaho/big/data/kettle/plugins/hbase/input/messages/messages_en_US.properties
@@ -1,5 +1,7 @@
 HBaseInput.Name=HBase Input
-HBaseInput.Description=Reads data from a HBase table according to a mapping 
+HBaseInput.Description=Reads data from a HBase table according to a mapping
+
+HBaseInputMeta.Message.Loading=Loading data...
 
 HBaseInputDialog.Shell.Title=HBase input
 HBaseInputDialog.StepName.Label=Step name

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtilTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtilTest.java
@@ -1,0 +1,175 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilter;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
+import org.pentaho.bigdata.api.hbase.mapping.Mapping;
+import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.w3c.dom.Node;
+
+/**
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class HBaseDataLoadSaveUtilTest {
+  private MappingFactory mappingFactoryMock = mock( MappingFactory.class );
+  private ColumnFilterFactory cfFactoryMock = mock( ColumnFilterFactory.class );
+  private Mapping mappingMock = mock( Mapping.class );
+  private Repository repMock = mock( Repository.class );
+  private ObjectId objIdMock = mock( ObjectId.class );
+  private final static String STEP_NODE_STRING = "<step_node/>";
+  private Node stepNode;
+
+  @Before
+  public void setUp() throws KettleXMLException {
+    stepNode = XMLHandler.loadXMLString( STEP_NODE_STRING );
+
+    when( mappingFactoryMock.createMapping() ).thenReturn( mappingMock );
+
+  }
+
+  @Test
+  public void testLoadMappingFromNodeSuccessfully() throws KettleException {
+    // Mapping loaded successfully from Node
+    when( mappingMock.loadXML( stepNode ) ).thenReturn( true );
+
+    verify( mappingMock, times( 0 ) ).loadXML( stepNode );
+    assertSame( mappingMock, HBaseDataLoadSaveUtil.loadMapping( stepNode, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).loadXML( stepNode );
+  }
+
+  @Test
+  public void testLoadMappingFromNodeReturnsNull() throws KettleException {
+    // Mapping NOT loaded successfully from Node
+    when( mappingMock.loadXML( stepNode ) ).thenReturn( false );
+
+    verify( mappingMock, times( 0 ) ).loadXML( stepNode );
+    assertNull( HBaseDataLoadSaveUtil.loadMapping( stepNode, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).loadXML( stepNode );
+  }
+
+  @Test
+  public void testLoadMappingFromRepoSuccessfully() throws KettleException {
+    // Mapping loaded successfully from repo
+    when( mappingMock.readRep( repMock, objIdMock ) ).thenReturn( true );
+
+    verify( mappingMock, times( 0 ) ).readRep( repMock, objIdMock );
+    assertSame( mappingMock, HBaseDataLoadSaveUtil.loadMapping( repMock, objIdMock, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).readRep( repMock, objIdMock );
+  }
+
+  @Test
+  public void testLoadMappingFromRepoReturnsNull() throws KettleException {
+    // Mapping NOT loaded successfully from repo
+    when( mappingMock.readRep( repMock, objIdMock ) ).thenReturn( false );
+
+    verify( mappingMock, times( 0 ) ).readRep( repMock, objIdMock );
+    assertNull( HBaseDataLoadSaveUtil.loadMapping( repMock, objIdMock, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).readRep( repMock, objIdMock );
+  }
+
+  @Test
+  public void testLoadFiltersFromNodeSuccessfully() throws KettleException {
+    stepNode = XMLHandler.loadXMLFile( "src/test/resources/Filters.xml" );
+    int expectedFiltersNb = 2;
+    List<ColumnFilter> clFilterList = getExpectedFilterMocks( expectedFiltersNb );
+    verify( cfFactoryMock, times( 0 ) ).createFilter( any( Node.class ) );
+    when( cfFactoryMock.createFilter( any( Node.class ) ) ).thenAnswer( i -> getColumnFilterMock( clFilterList, (Node) i.getArguments()[0] ) );
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( stepNode, cfFactoryMock );
+    assertNotNull( actualFilters );
+    assertEquals( expectedFiltersNb, actualFilters.size() );
+    verify( cfFactoryMock, times( 2 ) ).createFilter( any( Node.class ) );
+    for ( int i = 0; i < expectedFiltersNb; i++ ) {
+      assertSame( clFilterList.get( i ), actualFilters.get( i ) );
+    }
+  }
+
+  @Test
+  public void testLoadFiltersFromNodeReturnsNull() throws KettleException {
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( stepNode, cfFactoryMock );
+    assertNull( actualFilters );
+  }
+
+  @Test
+  public void testLoadFiltersFromRepoSuccessfully() throws KettleException {
+    when( repMock.countNrStepAttributes( objIdMock, "cf_comparison_opp" ) ).thenReturn( 2 );
+    int expectedFiltersNb = 2;
+    List<ColumnFilter> clFilterList = getExpectedFilterMocks( expectedFiltersNb );
+    verify( cfFactoryMock, times( 0 ) ).createFilter( eq( repMock ), anyInt(), eq( objIdMock ) );
+    when( cfFactoryMock.createFilter( eq( repMock ), anyInt(), eq( objIdMock ) ) ).thenAnswer( i -> getColumnFilterMock( clFilterList, (Integer) i.getArguments()[1] ) );
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( repMock, objIdMock, cfFactoryMock );
+    assertNotNull( actualFilters );
+    assertEquals( expectedFiltersNb, actualFilters.size() );
+    for ( int i = 0; i < expectedFiltersNb; i++ ) {
+      assertSame( clFilterList.get( i ), actualFilters.get( i ) );
+    }
+  }
+
+  @Test
+  public void testLoadFiltersFromRepoReturnsNull() throws KettleException {
+    when( repMock.countNrStepAttributes( objIdMock, "cf_comparison_opp" ) ).thenReturn( 0 );
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( repMock, objIdMock, cfFactoryMock );
+    assertNull( actualFilters );
+  }
+
+  private List<ColumnFilter> getExpectedFilterMocks( int filterNb ) {
+    List<ColumnFilter> colFilters = new ArrayList<ColumnFilter>( filterNb );
+    for ( int i = 0; i < filterNb; i++ ) {
+      colFilters.add( mock( ColumnFilter.class ) );
+    }
+    return colFilters;
+  }
+
+  private ColumnFilter getColumnFilterMock( List<ColumnFilter> filters, Node node ) {
+    int nb = Integer.parseInt( XMLHandler.getTagValue( node, "alias" ) );
+    return filters.get( nb );
+  }
+
+  private ColumnFilter getColumnFilterMock( List<ColumnFilter> filters, int i ) {
+    return filters.get( i );
+  }
+
+}

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImpTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImpTest.java
@@ -1,0 +1,73 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+
+public class HBaseServiceLocalImpTest {
+  private HBaseServiceLocalImp hBaseLocalService;
+
+  @Before
+  public void setup() {
+    hBaseLocalService = new HBaseServiceLocalImp();
+  }
+
+  @Test
+  public void testGetHBaseConnection() throws IOException {
+    assertNull( hBaseLocalService.getHBaseConnection( mock( VariableSpace.class ), "siteConfig", "defConfig", mock( LogChannelInterface.class ) ) );
+  }
+
+  @Test
+  public void testGetColumnFilterFactory() {
+    assertNotNull( hBaseLocalService.getColumnFilterFactory() );
+  }
+
+  @Test
+  public void testGetMappingFactory() {
+    assertNotNull( hBaseLocalService.getMappingFactory() );
+  }
+
+  @Test
+  public void testGetHBaseValueMetaInterfaceFactory() {
+    assertNotNull( hBaseLocalService.getHBaseValueMetaInterfaceFactory() );
+  }
+
+  @Test
+  public void testGetByteConversionUtil() {
+    assertNotNull( hBaseLocalService.getByteConversionUtil() );
+  }
+
+  @Test
+  public void testGetResultFactory() {
+    assertNull( hBaseLocalService.getResultFactory() );
+  }
+
+}

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMetaTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -75,18 +75,17 @@ public class HBaseOutputMetaTest {
 
   @Test
   public void testReadRepSetsNamedCluster() throws Exception {
-    when( namedClusterLoadSaveUtil.loadClusterConfig( any(), any(), any(), any(), any(), any() ) )
-      .thenReturn( namedCluster );
+    when( namedClusterLoadSaveUtil.loadClusterConfig( any(), any(), any(), any(), any(), any() ) ).thenReturn( namedCluster );
     when( namedClusterServiceLocator.getService( namedCluster, HBaseService.class ) ).thenReturn( hBaseService );
-    when( hBaseService.getMappingFactory() )
-      .thenReturn( mock( MappingFactory.class ) );
+    HBaseOutputMeta hBaseOutputMetaSpy = Mockito.spy( this.hBaseOutputMeta );
+    when( hBaseOutputMetaSpy.getHBaseLocalService() ).thenReturn( hBaseService );
+    when( hBaseService.getMappingFactory() ).thenReturn( mock( MappingFactory.class ) );
     Mapping mapping = mock( Mapping.class );
     when( mapping.readRep( rep, id_step ) ).thenReturn( true );
     when( hBaseService.getMappingFactory().createMapping() ).thenReturn( mapping );
-
-    hBaseOutputMeta.readRep( rep, metaStore, id_step, databases );
-    assertThat( hBaseOutputMeta.getNamedCluster(), is( namedCluster ) );
-    assertThat( hBaseOutputMeta.getMapping(), is( mapping ) );
+    hBaseOutputMetaSpy.readRep( rep, metaStore, id_step, databases );
+    assertThat( hBaseOutputMetaSpy.getNamedCluster(), is( namedCluster ) );
+    assertThat( hBaseOutputMetaSpy.getMapping(), is( mapping ) );
   }
 
   /**

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMetaTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,24 +22,30 @@
 
 package org.pentaho.big.data.kettle.plugins.hbase.rowdecoder;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.pentaho.big.data.api.cluster.NamedClusterService;
-import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
-import org.pentaho.bigdata.api.hbase.mapping.Mapping;
-import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
-import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.runtime.test.RuntimeTester;
-import org.pentaho.runtime.test.action.RuntimeTestActionService;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedCluster;
+import org.pentaho.big.data.api.cluster.NamedClusterService;
+import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
+import org.pentaho.big.data.kettle.plugins.hbase.MappingDefinition;
+import org.pentaho.bigdata.api.hbase.HBaseService;
+import org.pentaho.bigdata.api.hbase.mapping.Mapping;
+import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.runtime.test.RuntimeTester;
+import org.pentaho.runtime.test.action.RuntimeTestActionService;
 
 /**
  * @author Tatsiana_Kasiankova
@@ -48,22 +54,21 @@ import static org.mockito.Mockito.when;
 public class HBaseRowDecoderMetaTest {
 
   private static final String MAPPING_NAME = "MappingName";
-
   private static final String TABLE_NAME = "TableName";
-
-  private static final String COLUMN_NAME = "ColumnName";
-  private static final String FAMILY_NAME = "fm";
   private static final String ALIAS = "alias";
   private static final String MAPPING_KEY_NAME = "mappingKeyName";
   private static final String ORIGIN = "HBase Row Decoder";
   private HBaseRowDecoderMeta hbRowDecoderMeta;
   private RowMeta rowMeta;
+  private VariableSpace vsMock = mock( VariableSpace.class );
+  private NamedClusterServiceLocator ncLocatorMock = mock( NamedClusterServiceLocator.class );
+  private NamedClusterService ncsMock = mock( NamedClusterService.class );
+  private NamedCluster ncMock = mock( NamedCluster.class );
+  private MappingDefinition mapDefMock = mock( MappingDefinition.class );
 
   @Before
   public void setup() {
-    hbRowDecoderMeta =
-      new HBaseRowDecoderMeta( mock( NamedClusterServiceLocator.class ), mock( NamedClusterService.class ), mock(
-        RuntimeTestActionService.class ), mock( RuntimeTester.class ) );
+    hbRowDecoderMeta = new HBaseRowDecoderMeta( ncLocatorMock, ncsMock, mock( RuntimeTestActionService.class ), mock( RuntimeTester.class ) );
     rowMeta = new RowMeta();
   }
 
@@ -111,4 +116,12 @@ public class HBaseRowDecoderMetaTest {
     return maping;
   }
 
+  @Test
+  public void testNotAppliedInjectionWhenMappingDefinitionNull() throws Exception {
+    when( ncsMock.getClusterTemplate() ).thenReturn( ncMock );
+    hbRowDecoderMeta.setNamedCluster( ncsMock.getClusterTemplate() );
+    hbRowDecoderMeta.setMappingDefinition( null );
+    hbRowDecoderMeta.applyInjection( vsMock );
+    verify( ncLocatorMock, times( 0 ) ).getService( ncMock, HBaseService.class );
+  }
 }

--- a/kettle-plugins/hbase/src/test/resources/Filters.xml
+++ b/kettle-plugins/hbase/src/test/resources/Filters.xml
@@ -1,0 +1,16 @@
+<column_filters>
+	<filter>
+		<alias>0</alias>
+		<type>String</type>
+		<comparison_opp>Substring</comparison_opp>
+		<signed_comp>N</signed_comp>
+		<constant>value1</constant>
+	</filter>
+	<filter>
+		<alias>1</alias>
+		<type>String</type>
+		<comparison_opp>&#x3d;</comparison_opp>
+		<signed_comp>Y</signed_comp>
+		<constant>value2</constant>
+	</filter>
+</column_filters>


### PR DESCRIPTION
This issue was introduced with changes from 6.0 to 6.1 related with OSGIing Hbase: BACKLOG-3896
see commit: https://github.com/pentaho/big-data-plugin/commit/ba87357871ba74c504909e3e9845b793b12b6ef3
More detailed the cause of the issue and investigations are described in the JIRA: http://jira.pentaho.com/browse/BAD-569?focusedCommentId=281763&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-281763

The fix consists in  don't to use HBase service for HBase steps on design time (in meta and dialog) but create HBaseValueMetaInterfaceFactory, ColumnFilterFactory and MappingFactory locally as it was before.
Also it has been added unit tests, fixed minor checkstyle issues and using deprecated method Const.isEmpty.