### PR TITLE
[BAD-569]: Unable to load for editing ktr with HBase Input/Output steps if KDC host is unavailable

### DIFF
--- a/assemblies/features/src/main/resources/features.xml
+++ b/assemblies/features/src/main/resources/features.xml
@@ -38,7 +38,7 @@
     <bundle>mvn:pentaho/pentaho-big-data-api-jdbc/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-impl-shim-common/${project.version}</bundle>
   </feature>
-  
+
   <feature name="pentaho-big-data-plugin-shim-impl" version="1.0">
     <feature>pentaho-big-data-plugin-api</feature>
     <conditional>
@@ -61,6 +61,8 @@
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-common-job/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-common-named-cluster-bridge/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-guiTestActionHandlers/${project.version}</bundle>
+    <bundle>wrap:mvn:pentaho/pentaho-hadoop-shims-api/${project.version}</bundle>
+	<bundle>mvn:pentaho/pentaho-big-data-impl-shim-hbase/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-hdfs/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-hbase/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-mapreduce/${project.version}</bundle>

--- a/impl/shim/hbase/pom.xml
+++ b/impl/shim/hbase/pom.xml
@@ -96,7 +96,8 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Import-Package>!org.pentaho.hbase.shim.api,!org.pentaho.hbase.shim.spi,!org.apache.hadoop.*,!org.pentaho.di.core.hadoop.*,!org.pentaho.hadoop.*,!org.pentaho.yarn.*,!org.apache.log4j,*</Import-Package>
+            <Import-Package>!org.pentaho.hbase.shim.spi,!org.apache.hadoop.*,!org.pentaho.di.core.hadoop.*,!org.pentaho.hadoop.*,!org.pentaho.yarn.*,!org.apache.log4j,*</Import-Package>
+            <Export-Package>com.pentaho.big.data.bundles.impl.shim.hbase.mapping,com.pentaho.big.data.bundles.impl.shim.hbase.meta, com.pentaho.big.data.bundles.impl.shim.hbase</Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/kettle-plugins/hbase/pom.xml
+++ b/kettle-plugins/hbase/pom.xml
@@ -107,7 +107,6 @@
       <groupId>pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-api</artifactId>
       <version>${dependency.hadoop-shims-api.revision}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>
@@ -132,6 +131,11 @@
       <artifactId>xercesImpl</artifactId>
       <version>${dependency.xerces.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>pentaho</groupId>
+    	<artifactId>pentaho-big-data-impl-shim-hbase</artifactId>
+    	<version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtil.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtil.java
@@ -1,0 +1,82 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilter;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
+import org.pentaho.bigdata.api.hbase.mapping.Mapping;
+import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.w3c.dom.Node;
+
+public class HBaseDataLoadSaveUtil {
+
+  public static Mapping loadMapping( Node stepNode, MappingFactory mappingFactory ) throws KettleXMLException {
+    Mapping mapping = mappingFactory.createMapping();
+    if ( !mapping.loadXML( stepNode ) ) {
+      mapping = null;
+    }
+    return mapping;
+  }
+
+  public static Mapping loadMapping( Repository rep, ObjectId id_step, MappingFactory mappingFactory ) throws KettleException {
+    Mapping mapping = mappingFactory.createMapping();
+    if ( !mapping.readRep( rep, id_step ) ) {
+      mapping = null;
+    }
+    return mapping;
+  }
+
+  public static List<ColumnFilter> loadFilters( Node stepNode, ColumnFilterFactory colFtFactory ) {
+    List<ColumnFilter> colFilters = null;
+    Node filters = XMLHandler.getSubNode( stepNode, "column_filters" );
+    int nrFilters = XMLHandler.countNodes( filters, "filter" );
+    if ( nrFilters > 0 ) {
+      colFilters = new ArrayList<ColumnFilter>( nrFilters );
+      for ( int i = 0; i < nrFilters; i++ ) {
+        Node filterNode = XMLHandler.getSubNodeByNr( filters, "filter", i );
+        colFilters.add( colFtFactory.createFilter( filterNode ) );
+      }
+    }
+    return colFilters;
+  }
+
+  public static List<ColumnFilter> loadFilters( Repository rep, ObjectId id_step, ColumnFilterFactory colFtFactory ) throws KettleException {
+    List<ColumnFilter> colFilters = null;
+    int nrFilters = rep.countNrStepAttributes( id_step, "cf_comparison_opp" );
+    if ( nrFilters > 0 ) {
+      colFilters = new ArrayList<ColumnFilter>( nrFilters );
+      for ( int i = 0; i < nrFilters; i++ ) {
+        colFilters.add( colFtFactory.createFilter( rep, i, id_step ) );
+      }
+    }
+    return colFilters;
+  }
+
+}

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImp.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImp.java
@@ -1,0 +1,72 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import java.io.IOException;
+
+import org.pentaho.bigdata.api.hbase.ByteConversionUtil;
+import org.pentaho.bigdata.api.hbase.HBaseConnection;
+import org.pentaho.bigdata.api.hbase.HBaseService;
+import org.pentaho.bigdata.api.hbase.ResultFactory;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
+import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+
+import com.pentaho.big.data.bundles.impl.shim.hbase.ByteConversionUtilImpl;
+import com.pentaho.big.data.bundles.impl.shim.hbase.mapping.ColumnFilterFactoryImpl;
+import com.pentaho.big.data.bundles.impl.shim.hbase.mapping.MappingFactoryImpl;
+import com.pentaho.big.data.bundles.impl.shim.hbase.meta.HBaseValueMetaInterfaceFactoryImpl;
+
+public class HBaseServiceLocalImp implements HBaseService {
+
+  @Override
+  public HBaseConnection getHBaseConnection( VariableSpace variableSpace, String siteConfig, String defaultConfig, LogChannelInterface logChannelInterface ) throws IOException {
+    return null;
+  }
+
+  @Override
+  public ColumnFilterFactory getColumnFilterFactory() {
+    return new ColumnFilterFactoryImpl();
+  }
+
+  @Override
+  public MappingFactory getMappingFactory() {
+    return new MappingFactoryImpl( null, getHBaseValueMetaInterfaceFactory() );
+  }
+
+  @Override
+  public HBaseValueMetaInterfaceFactoryImpl getHBaseValueMetaInterfaceFactory() {
+    return new HBaseValueMetaInterfaceFactoryImpl( null );
+  }
+
+  @Override
+  public ByteConversionUtil getByteConversionUtil() {
+    return new ByteConversionUtilImpl( null );
+  }
+
+  @Override
+  public ResultFactory getResultFactory() {
+    return null;
+  }
+
+}

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingEditor.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/mapping/MappingEditor.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -56,6 +56,7 @@ import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
 import org.pentaho.big.data.kettle.plugins.hbase.HBaseConnectionException;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseServiceLocalImp;
 import org.pentaho.big.data.kettle.plugins.hbase.input.HBaseInput;
 import org.pentaho.big.data.kettle.plugins.hbase.input.Messages;
 import org.pentaho.big.data.plugins.common.ui.NamedClusterWidgetImpl;
@@ -69,6 +70,7 @@ import org.pentaho.bigdata.api.hbase.table.HBaseTable;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.ui.core.PropsUI;
@@ -138,6 +140,8 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
   protected TransMeta m_transMeta;
 
+  private HBaseService hBaseLocalService;
+
   public MappingEditor( Shell shell, Composite parent, ConfigurationProducer configProducer,
                         FieldProducer fieldProducer, int tableViewStyle, boolean allowTableCreate, PropsUI props,
                         TransMeta transMeta, NamedClusterService namedClusterService,
@@ -160,6 +164,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     m_incomingFieldsProducer = fieldProducer;
 
     m_allowTableCreate = allowTableCreate;
+    hBaseLocalService = new HBaseServiceLocalImp();
     int middle = props.getMiddlePct();
     int margin = Const.MARGIN;
 
@@ -354,7 +359,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
         String[] comboValues = null;
 
         String keyOrNot = tableItem.getText( 2 );
-        if ( Const.isEmpty( keyOrNot ) || keyOrNot.equalsIgnoreCase( "N" ) ) {
+        if ( Utils.isEmpty( keyOrNot ) || keyOrNot.equalsIgnoreCase( "N" ) ) {
           comboValues =
               new String[] { "String", "Integer", "Long", "Float", "Double", "Boolean", "Date", "BigNumber",
                 "Serializable", "Binary" };
@@ -442,6 +447,10 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     m_fieldsView.setLayoutData( fd );
   }
 
+  public HBaseService getHBaseLocalService() {
+    return hBaseLocalService;
+  }
+
   private void populateTableWithTupleTemplate() {
     Table table = m_fieldsView.table;
 
@@ -449,7 +458,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     for ( int i = 0; i < table.getItemCount(); i++ ) {
       TableItem tableItem = table.getItem( i );
       String alias = tableItem.getText( 1 );
-      if ( !Const.isEmpty( alias ) ) {
+      if ( !Utils.isEmpty( alias ) ) {
         existingRowAliases.add( alias );
       }
     }
@@ -505,7 +514,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
         for ( int i = 0; i < table.getItemCount(); i++ ) {
           TableItem tableItem = table.getItem( i );
           String alias = tableItem.getText( 1 );
-          if ( !Const.isEmpty( alias ) ) {
+          if ( !Utils.isEmpty( alias ) ) {
             existingRowAliases.add( alias );
           }
         }
@@ -533,12 +542,6 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
           m_fieldsView.clearAll();
         }
 
-        ByteConversionUtil byteConversionUtil = null;
-        try {
-          byteConversionUtil = m_configProducer.getHBaseService().getByteConversionUtil();
-        } catch ( Exception e ) {
-          throw new RuntimeException( e );
-        }
         for ( int i = 0; i < incomingRowMeta.size(); i++ ) {
           ValueMetaInterface vm = incomingRowMeta.getValueMeta( i );
           boolean addIt = true;
@@ -573,7 +576,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
             }
             if ( vm.getStorageType() == ValueMetaInterface.STORAGE_TYPE_INDEXED ) {
               Object[] indexValus = vm.getIndex();
-              String indexValsS = byteConversionUtil.objectIndexValuesToString( indexValus );
+              String indexValsS = getHBaseLocalService().getByteConversionUtil().objectIndexValuesToString( indexValus );
               item.setText( 6, indexValsS );
             }
           }
@@ -620,7 +623,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
           m_existingTableNamesCombo.add( currentTableName );
         }
         // restore any previous value
-        if ( !Const.isEmpty( existingName ) ) {
+        if ( !Utils.isEmpty( existingName ) ) {
           m_existingTableNamesCombo.setText( existingName );
         }
       } catch ( Exception e ) {
@@ -655,14 +658,14 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
       return;
     }
     String tableName = "";
-    if ( !Const.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
+    if ( !Utils.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
       tableName = m_existingTableNamesCombo.getText().trim();
 
       if ( tableName.indexOf( '@' ) > 0 ) {
         tableName = tableName.substring( 0, tableName.indexOf( '@' ) );
       }
     }
-    if ( Const.isEmpty( tableName ) || Const.isEmpty( m_existingMappingNamesCombo.getText().trim() ) ) {
+    if ( Utils.isEmpty( tableName ) || Utils.isEmpty( m_existingMappingNamesCombo.getText().trim() ) ) {
       MessageDialog.openError( m_shell, Messages.getString( "MappingDialog.Error.Title.MissingTableMappingName" ),
           Messages.getString( "MappingDialog.Error.Message.MissingTableMappingName" ) );
       return;
@@ -717,7 +720,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
    */
   public Mapping getMapping( boolean performChecksAndShowGUIErrorDialog, List<String> problems, Boolean includeKeyToColumns ) {
     String tableName = "";
-    if ( !Const.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
+    if ( !Utils.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
       tableName = m_existingTableNamesCombo.getText().trim();
 
       if ( tableName.indexOf( '@' ) > 0 ) {
@@ -727,7 +730,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
     // empty table name or mapping name does not force an abort
     if ( performChecksAndShowGUIErrorDialog
-        && ( Const.isEmpty( m_existingMappingNamesCombo.getText().trim() ) || Const.isEmpty( tableName ) ) ) {
+        && ( Utils.isEmpty( m_existingMappingNamesCombo.getText().trim() ) || Utils.isEmpty( tableName ) ) ) {
       MessageDialog.openError( m_shell, Messages.getString( "MappingDialog.Error.Title.MissingTableMappingName" ),
           Messages.getString( "MappingDialog.Error.Message.MissingTableMappingName" ) );
       if ( problems != null ) {
@@ -746,15 +749,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
       return null;
     }
     // do we have a key defined in the table?
-    HBaseService hBaseService = null;
-    try {
-      hBaseService = m_configProducer.getHBaseService();
-    } catch ( Exception e ) {
-      problems.add( e.getMessage() );
-      return null;
-    }
-    Mapping theMapping =
-      hBaseService.getMappingFactory().createMapping( tableName, m_existingMappingNamesCombo.getText().trim() );
+    Mapping theMapping = getHBaseLocalService().getMappingFactory().createMapping( tableName, m_existingMappingNamesCombo.getText().trim() );
     boolean keyDefined = false;
     boolean moreThanOneKey = false;
     List<String> missingFamilies = new ArrayList<String>();
@@ -787,10 +782,10 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
       TableItem item = m_fieldsView.getNonEmpty( i );
       boolean isKey = false;
       String alias = null;
-      if ( !Const.isEmpty( item.getText( 1 ) ) ) {
+      if ( !Utils.isEmpty( item.getText( 1 ) ) ) {
         alias = item.getText( 1 ).trim();
       }
-      if ( !Const.isEmpty( item.getText( 2 ) ) ) {
+      if ( !Utils.isEmpty( item.getText( 2 ) ) ) {
         isKey = item.getText( 2 ).trim().equalsIgnoreCase( "Y" );
 
         if ( isKey && keyDefined ) {
@@ -804,7 +799,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
       }
       // String family = null;
       String family = "";
-      if ( !Const.isEmpty( item.getText( 3 ) ) ) {
+      if ( !Utils.isEmpty( item.getText( 3 ) ) ) {
         family = item.getText( 3 );
       } else {
         if ( !isKey && !isTupleMapping ) {
@@ -813,7 +808,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
       }
       // String colName = null;
       String colName = "";
-      if ( !Const.isEmpty( item.getText( 4 ) ) ) {
+      if ( !Utils.isEmpty( item.getText( 4 ) ) ) {
         colName = item.getText( 4 );
       } else {
         if ( !isKey && !isTupleMapping ) {
@@ -821,20 +816,20 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
         }
       }
       String type = null;
-      if ( !Const.isEmpty( item.getText( 5 ) ) ) {
+      if ( !Utils.isEmpty( item.getText( 5 ) ) ) {
         type = item.getText( 5 );
       } else {
         missingTypes.add( item.getText( 0 ) );
       }
       String indexedVals = null;
-      if ( !Const.isEmpty( item.getText( 6 ) ) ) {
+      if ( !Utils.isEmpty( item.getText( 6 ) ) ) {
         indexedVals = item.getText( 6 );
       }
 
-      HBaseValueMetaInterfaceFactory valueMetaInterfaceFactory = hBaseService.getHBaseValueMetaInterfaceFactory();
+      HBaseValueMetaInterfaceFactory valueMetaInterfaceFactory = getHBaseLocalService().getHBaseValueMetaInterfaceFactory();
       // only add if we have all data and its all correct
       if ( isKey && !moreThanOneKey ) {
-        if ( Const.isEmpty( alias ) ) {
+        if ( Utils.isEmpty( alias ) ) {
           // pop up an error dialog - key must have an alias because it does not
           // belong to a column family or have a column name
           if ( performChecksAndShowGUIErrorDialog ) {
@@ -847,7 +842,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
           return null;
         }
 
-        if ( Const.isEmpty( type ) ) {
+        if ( Utils.isEmpty( type ) ) {
           // pop up an error dialog - must have a type for the key
           if ( performChecksAndShowGUIErrorDialog ) {
             MessageDialog.openError( m_shell, Messages.getString( "MappingDialog.Error.Title.NoTypeForKey" ), Messages
@@ -890,7 +885,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
           // Ignore
         }
       } else {
-        ByteConversionUtil byteConversionUtil = hBaseService.getByteConversionUtil();
+        ByteConversionUtil byteConversionUtil = getHBaseLocalService().getByteConversionUtil();
         // don't bother adding if there are any errors
         if ( missingFamilies.size() == 0 && missingColumnNames.size() == 0 && missingTypes.size() == 0 ) {
           HBaseValueMetaInterface vm =
@@ -1099,25 +1094,25 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     if ( mapping == null ) {
       return;
     }
-    if ( !Const.isEmpty( mapping.getTableName() ) ) {
+    if ( !Utils.isEmpty( mapping.getTableName() ) ) {
       m_existingTableNamesCombo.setText( mapping.getTableName() );
     }
 
-    if ( !Const.isEmpty( mapping.getMappingName() ) ) {
+    if ( !Utils.isEmpty( mapping.getMappingName() ) ) {
       m_existingMappingNamesCombo.setText( mapping.getMappingName() );
     }
 
     m_fieldsView.clearAll();
     // do the key first
     TableItem keyItem = new TableItem( m_fieldsView.table, SWT.NONE );
-    if ( !Const.isEmpty( mapping.getKeyName() ) ) {
+    if ( !Utils.isEmpty( mapping.getKeyName() ) ) {
       keyItem.setText( 1, mapping.getKeyName() );
     }
     keyItem.setText( 2, "Y" );
-    if ( mapping.getKeyType() != null && !Const.isEmpty( mapping.getKeyType().toString() ) ) {
+    if ( mapping.getKeyType() != null && !Utils.isEmpty( mapping.getKeyType().toString() ) ) {
       keyItem.setText( 5, mapping.getKeyType().toString() );
     }
-    if ( mapping.isTupleMapping() && !Const.isEmpty( mapping.getTupleFamilies() ) ) {
+    if ( mapping.isTupleMapping() && !Utils.isEmpty( mapping.getTupleFamilies() ) ) {
       keyItem.setText( 3, mapping.getTupleFamilies() );
     }
 
@@ -1149,7 +1144,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
       if ( vm.getStorageType() == ValueMetaInterface.STORAGE_TYPE_INDEXED ) {
         item.setText( 6,
-          m_admin.getConnection().getService().getByteConversionUtil().objectIndexValuesToString( vm.getIndex() ) );
+          getHBaseLocalService().getByteConversionUtil().objectIndexValuesToString( vm.getIndex() ) );
       }
     }
 
@@ -1160,7 +1155,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
   private void loadTableViewFromMapping() {
     String tableName = "";
-    if ( !Const.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
+    if ( !Utils.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
       tableName = m_existingTableNamesCombo.getText().trim();
 
       if ( tableName.indexOf( '@' ) > 0 ) {
@@ -1185,7 +1180,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
 
   private void populateMappingComboAndFamilyStuff() {
     String tableName = "";
-    if ( !Const.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
+    if ( !Utils.isEmpty( m_existingTableNamesCombo.getText().trim() ) ) {
       tableName = m_existingTableNamesCombo.getText().trim();
 
       if ( tableName.indexOf( '@' ) > 0 ) {
@@ -1197,7 +1192,7 @@ public class MappingEditor extends Composite implements ConfigurationProducer {
     m_familyCI.setComboValues( new String[] { "" } );
     m_existingMappingNamesCombo.removeAll();
 
-    if ( m_admin != null && !Const.isEmpty( tableName ) ) {
+    if ( m_admin != null && !Utils.isEmpty( tableName ) ) {
       try {
 
         // first get the existing mapping names (if any)

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -28,6 +28,8 @@ import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseDataLoadSaveUtil;
+import org.pentaho.big.data.kettle.plugins.hbase.HBaseServiceLocalImp;
 import org.pentaho.big.data.kettle.plugins.hbase.MappingDefinition;
 import org.pentaho.big.data.kettle.plugins.hbase.NamedClusterLoadSaveUtil;
 import org.pentaho.big.data.kettle.plugins.hbase.mapping.MappingUtils;
@@ -35,7 +37,6 @@ import org.pentaho.bigdata.api.hbase.HBaseService;
 import org.pentaho.bigdata.api.hbase.mapping.Mapping;
 import org.pentaho.di.core.CheckResult;
 import org.pentaho.di.core.CheckResultInterface;
-import org.pentaho.di.core.Const;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.exception.KettleException;
@@ -44,6 +45,7 @@ import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
@@ -67,7 +69,7 @@ import com.google.common.annotations.VisibleForTesting;
  * Class providing an output step for writing data to an HBase table according to meta data column/type mapping info
  * stored in a separate HBase table called "pentaho_mappings". See org.pentaho.hbase.mapping.Mapping for details on the
  * meta data format.
- * 
+ *
  * @author Mark Hall (mhall{[at]}pentaho{[dot]}com)
  */
 @Step( id = "HBaseOutput", image = "HBO.svg", name = "HBaseOutput.Name", description = "HBaseOutput.Description",
@@ -120,6 +122,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
   private final NamedClusterServiceLocator namedClusterServiceLocator;
   private final RuntimeTestActionService runtimeTestActionService;
   private final RuntimeTester runtimeTester;
+  private HBaseService hBaseLocalService;
 
   public NamedClusterService getNamedClusterService() {
     return namedClusterService;
@@ -135,6 +138,10 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
 
   public RuntimeTester getRuntimeTester() {
     return runtimeTester;
+  }
+
+  public HBaseService getHBaseLocalService() {
+    return hBaseLocalService;
   }
 
   public HBaseOutputMeta( NamedClusterService namedClusterService,
@@ -155,12 +162,13 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
 
     this.runtimeTester = runtimeTester;
     this.namedClusterLoadSaveUtil = namedClusterLoadSaveUtil;
+    this.hBaseLocalService = new HBaseServiceLocalImp();
 
   }
 
   /**
    * Set the mapping to use for decoding the row
-   * 
+   *
    * @param m
    *          the mapping to use
    */
@@ -170,7 +178,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
 
   /**
    * Get the mapping to use for decoding the row
-   * 
+   *
    * @return the mapping to use
    */
   public Mapping getMapping() {
@@ -284,19 +292,19 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     namedClusterLoadSaveUtil
       .getXml( retval, namedClusterService, namedCluster, repository == null ? null : repository.getMetaStore(), getLog() );
 
-    if ( !Const.isEmpty( m_coreConfigURL ) ) {
+    if ( !Utils.isEmpty( m_coreConfigURL ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "core_config_url", m_coreConfigURL ) );
     }
-    if ( !Const.isEmpty( m_defaultConfigURL ) ) {
+    if ( !Utils.isEmpty( m_defaultConfigURL ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "default_config_url", m_defaultConfigURL ) );
     }
-    if ( !Const.isEmpty( m_targetTableName ) ) {
+    if ( !Utils.isEmpty( m_targetTableName ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "target_table_name", m_targetTableName ) );
     }
-    if ( !Const.isEmpty( m_targetMappingName ) ) {
+    if ( !Utils.isEmpty( m_targetMappingName ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "target_mapping_name", m_targetMappingName ) );
     }
-    if ( !Const.isEmpty( m_writeBufferSize ) ) {
+    if ( !Utils.isEmpty( m_writeBufferSize ) ) {
       retval.append( "\n    " ).append( XMLHandler.addTagValue( "write_buffer_size", m_writeBufferSize ) );
     }
     retval.append( "\n    " ).append( XMLHandler.addTagValue( "disable_wal", m_disableWriteToWAL ) );
@@ -330,19 +338,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     m_writeBufferSize = XMLHandler.getTagValue( stepnode, "write_buffer_size" );
     String disableWAL = XMLHandler.getTagValue( stepnode, "disable_wal" );
     m_disableWriteToWAL = disableWAL.equalsIgnoreCase( "Y" );
-
-    Mapping tempMapping;
-    try {
-      tempMapping =
-        namedClusterServiceLocator.getService( namedCluster, HBaseService.class ).getMappingFactory().createMapping();
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleXMLException( e );
-    }
-    if ( tempMapping.loadXML( stepnode ) ) {
-      m_mapping = tempMapping;
-    } else {
-      m_mapping = null;
-    }
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( stepnode, getHBaseLocalService().getMappingFactory() );
   }
 
   @Override public void readRep( Repository rep, IMetaStore metaStore, ObjectId id_step, List<DatabaseMeta> databases )
@@ -356,37 +352,25 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     m_targetMappingName = rep.getStepAttributeString( id_step, 0, "target_mapping_name" );
     m_writeBufferSize = rep.getStepAttributeString( id_step, 0, "write_buffer_size" );
     m_disableWriteToWAL = rep.getStepAttributeBoolean( id_step, 0, "disable_wal" );
-
-    Mapping tempMapping;
-    try {
-      tempMapping =
-        namedClusterServiceLocator.getService( namedCluster, HBaseService.class ).getMappingFactory().createMapping();
-    } catch ( ClusterInitializationException e ) {
-      throw new KettleException( e );
-    }
-    if ( tempMapping.readRep( rep, id_step ) ) {
-      m_mapping = tempMapping;
-    } else {
-      m_mapping = null;
-    }
+    m_mapping = HBaseDataLoadSaveUtil.loadMapping( rep, id_step, getHBaseLocalService().getMappingFactory() );
   }
 
   @Override public void saveRep( Repository rep, IMetaStore metaStore, ObjectId id_transformation, ObjectId id_step ) throws KettleException {
     namedClusterLoadSaveUtil.saveRep( rep, metaStore, id_transformation, id_step, namedClusterService, namedCluster, getLog() );
 
-    if ( !Const.isEmpty( m_coreConfigURL ) ) {
+    if ( !Utils.isEmpty( m_coreConfigURL ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "core_config_url", m_coreConfigURL );
     }
-    if ( !Const.isEmpty( m_defaultConfigURL ) ) {
+    if ( !Utils.isEmpty( m_defaultConfigURL ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "default_config_url", m_defaultConfigURL );
     }
-    if ( !Const.isEmpty( m_targetTableName ) ) {
+    if ( !Utils.isEmpty( m_targetTableName ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "target_table_name", m_targetTableName );
     }
-    if ( !Const.isEmpty( m_targetMappingName ) ) {
+    if ( !Utils.isEmpty( m_targetMappingName ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "target_mapping_name", m_targetMappingName );
     }
-    if ( !Const.isEmpty( m_writeBufferSize ) ) {
+    if ( !Utils.isEmpty( m_writeBufferSize ) ) {
       rep.saveStepAttribute( id_transformation, id_step, 0, "write_buffer_size", m_writeBufferSize );
     }
     rep.saveStepAttribute( id_transformation, id_step, 0, "disable_wal", m_disableWriteToWAL );

--- a/kettle-plugins/hbase/src/main/resources/org/pentaho/big/data/kettle/plugins/hbase/input/messages/messages_en_US.properties
+++ b/kettle-plugins/hbase/src/main/resources/org/pentaho/big/data/kettle/plugins/hbase/input/messages/messages_en_US.properties
@@ -1,5 +1,7 @@
 HBaseInput.Name=HBase Input
-HBaseInput.Description=Reads data from a HBase table according to a mapping 
+HBaseInput.Description=Reads data from a HBase table according to a mapping
+
+HBaseInputMeta.Message.Loading=Loading data...
 
 HBaseInputDialog.Shell.Title=HBase input
 HBaseInputDialog.StepName.Label=Step name

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtilTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseDataLoadSaveUtilTest.java
@@ -1,0 +1,175 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilter;
+import org.pentaho.bigdata.api.hbase.mapping.ColumnFilterFactory;
+import org.pentaho.bigdata.api.hbase.mapping.Mapping;
+import org.pentaho.bigdata.api.hbase.mapping.MappingFactory;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.ObjectId;
+import org.pentaho.di.repository.Repository;
+import org.w3c.dom.Node;
+
+/**
+ * @author Tatsiana_Kasiankova
+ *
+ */
+public class HBaseDataLoadSaveUtilTest {
+  private MappingFactory mappingFactoryMock = mock( MappingFactory.class );
+  private ColumnFilterFactory cfFactoryMock = mock( ColumnFilterFactory.class );
+  private Mapping mappingMock = mock( Mapping.class );
+  private Repository repMock = mock( Repository.class );
+  private ObjectId objIdMock = mock( ObjectId.class );
+  private final static String STEP_NODE_STRING = "<step_node/>";
+  private Node stepNode;
+
+  @Before
+  public void setUp() throws KettleXMLException {
+    stepNode = XMLHandler.loadXMLString( STEP_NODE_STRING );
+
+    when( mappingFactoryMock.createMapping() ).thenReturn( mappingMock );
+
+  }
+
+  @Test
+  public void testLoadMappingFromNodeSuccessfully() throws KettleException {
+    // Mapping loaded successfully from Node
+    when( mappingMock.loadXML( stepNode ) ).thenReturn( true );
+
+    verify( mappingMock, times( 0 ) ).loadXML( stepNode );
+    assertSame( mappingMock, HBaseDataLoadSaveUtil.loadMapping( stepNode, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).loadXML( stepNode );
+  }
+
+  @Test
+  public void testLoadMappingFromNodeReturnsNull() throws KettleException {
+    // Mapping NOT loaded successfully from Node
+    when( mappingMock.loadXML( stepNode ) ).thenReturn( false );
+
+    verify( mappingMock, times( 0 ) ).loadXML( stepNode );
+    assertNull( HBaseDataLoadSaveUtil.loadMapping( stepNode, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).loadXML( stepNode );
+  }
+
+  @Test
+  public void testLoadMappingFromRepoSuccessfully() throws KettleException {
+    // Mapping loaded successfully from repo
+    when( mappingMock.readRep( repMock, objIdMock ) ).thenReturn( true );
+
+    verify( mappingMock, times( 0 ) ).readRep( repMock, objIdMock );
+    assertSame( mappingMock, HBaseDataLoadSaveUtil.loadMapping( repMock, objIdMock, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).readRep( repMock, objIdMock );
+  }
+
+  @Test
+  public void testLoadMappingFromRepoReturnsNull() throws KettleException {
+    // Mapping NOT loaded successfully from repo
+    when( mappingMock.readRep( repMock, objIdMock ) ).thenReturn( false );
+
+    verify( mappingMock, times( 0 ) ).readRep( repMock, objIdMock );
+    assertNull( HBaseDataLoadSaveUtil.loadMapping( repMock, objIdMock, mappingFactoryMock ) );
+    verify( mappingMock, times( 1 ) ).readRep( repMock, objIdMock );
+  }
+
+  @Test
+  public void testLoadFiltersFromNodeSuccessfully() throws KettleException {
+    stepNode = XMLHandler.loadXMLFile( "src/test/resources/Filters.xml" );
+    int expectedFiltersNb = 2;
+    List<ColumnFilter> clFilterList = getExpectedFilterMocks( expectedFiltersNb );
+    verify( cfFactoryMock, times( 0 ) ).createFilter( any( Node.class ) );
+    when( cfFactoryMock.createFilter( any( Node.class ) ) ).thenAnswer( i -> getColumnFilterMock( clFilterList, (Node) i.getArguments()[0] ) );
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( stepNode, cfFactoryMock );
+    assertNotNull( actualFilters );
+    assertEquals( expectedFiltersNb, actualFilters.size() );
+    verify( cfFactoryMock, times( 2 ) ).createFilter( any( Node.class ) );
+    for ( int i = 0; i < expectedFiltersNb; i++ ) {
+      assertSame( clFilterList.get( i ), actualFilters.get( i ) );
+    }
+  }
+
+  @Test
+  public void testLoadFiltersFromNodeReturnsNull() throws KettleException {
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( stepNode, cfFactoryMock );
+    assertNull( actualFilters );
+  }
+
+  @Test
+  public void testLoadFiltersFromRepoSuccessfully() throws KettleException {
+    when( repMock.countNrStepAttributes( objIdMock, "cf_comparison_opp" ) ).thenReturn( 2 );
+    int expectedFiltersNb = 2;
+    List<ColumnFilter> clFilterList = getExpectedFilterMocks( expectedFiltersNb );
+    verify( cfFactoryMock, times( 0 ) ).createFilter( eq( repMock ), anyInt(), eq( objIdMock ) );
+    when( cfFactoryMock.createFilter( eq( repMock ), anyInt(), eq( objIdMock ) ) ).thenAnswer( i -> getColumnFilterMock( clFilterList, (Integer) i.getArguments()[1] ) );
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( repMock, objIdMock, cfFactoryMock );
+    assertNotNull( actualFilters );
+    assertEquals( expectedFiltersNb, actualFilters.size() );
+    for ( int i = 0; i < expectedFiltersNb; i++ ) {
+      assertSame( clFilterList.get( i ), actualFilters.get( i ) );
+    }
+  }
+
+  @Test
+  public void testLoadFiltersFromRepoReturnsNull() throws KettleException {
+    when( repMock.countNrStepAttributes( objIdMock, "cf_comparison_opp" ) ).thenReturn( 0 );
+    List<ColumnFilter> actualFilters = HBaseDataLoadSaveUtil.loadFilters( repMock, objIdMock, cfFactoryMock );
+    assertNull( actualFilters );
+  }
+
+  private List<ColumnFilter> getExpectedFilterMocks( int filterNb ) {
+    List<ColumnFilter> colFilters = new ArrayList<ColumnFilter>( filterNb );
+    for ( int i = 0; i < filterNb; i++ ) {
+      colFilters.add( mock( ColumnFilter.class ) );
+    }
+    return colFilters;
+  }
+
+  private ColumnFilter getColumnFilterMock( List<ColumnFilter> filters, Node node ) {
+    int nb = Integer.parseInt( XMLHandler.getTagValue( node, "alias" ) );
+    return filters.get( nb );
+  }
+
+  private ColumnFilter getColumnFilterMock( List<ColumnFilter> filters, int i ) {
+    return filters.get( i );
+  }
+
+}

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImpTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/HBaseServiceLocalImpTest.java
@@ -1,0 +1,73 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+package org.pentaho.big.data.kettle.plugins.hbase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+
+public class HBaseServiceLocalImpTest {
+  private HBaseServiceLocalImp hBaseLocalService;
+
+  @Before
+  public void setup() {
+    hBaseLocalService = new HBaseServiceLocalImp();
+  }
+
+  @Test
+  public void testGetHBaseConnection() throws IOException {
+    assertNull( hBaseLocalService.getHBaseConnection( mock( VariableSpace.class ), "siteConfig", "defConfig", mock( LogChannelInterface.class ) ) );
+  }
+
+  @Test
+  public void testGetColumnFilterFactory() {
+    assertNotNull( hBaseLocalService.getColumnFilterFactory() );
+  }
+
+  @Test
+  public void testGetMappingFactory() {
+    assertNotNull( hBaseLocalService.getMappingFactory() );
+  }
+
+  @Test
+  public void testGetHBaseValueMetaInterfaceFactory() {
+    assertNotNull( hBaseLocalService.getHBaseValueMetaInterfaceFactory() );
+  }
+
+  @Test
+  public void testGetByteConversionUtil() {
+    assertNotNull( hBaseLocalService.getByteConversionUtil() );
+  }
+
+  @Test
+  public void testGetResultFactory() {
+    assertNull( hBaseLocalService.getResultFactory() );
+  }
+
+}

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMetaTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -75,18 +75,17 @@ public class HBaseOutputMetaTest {
 
   @Test
   public void testReadRepSetsNamedCluster() throws Exception {
-    when( namedClusterLoadSaveUtil.loadClusterConfig( any(), any(), any(), any(), any(), any() ) )
-      .thenReturn( namedCluster );
+    when( namedClusterLoadSaveUtil.loadClusterConfig( any(), any(), any(), any(), any(), any() ) ).thenReturn( namedCluster );
     when( namedClusterServiceLocator.getService( namedCluster, HBaseService.class ) ).thenReturn( hBaseService );
-    when( hBaseService.getMappingFactory() )
-      .thenReturn( mock( MappingFactory.class ) );
+    HBaseOutputMeta hBaseOutputMetaSpy = Mockito.spy( this.hBaseOutputMeta );
+    when( hBaseOutputMetaSpy.getHBaseLocalService() ).thenReturn( hBaseService );
+    when( hBaseService.getMappingFactory() ).thenReturn( mock( MappingFactory.class ) );
     Mapping mapping = mock( Mapping.class );
     when( mapping.readRep( rep, id_step ) ).thenReturn( true );
     when( hBaseService.getMappingFactory().createMapping() ).thenReturn( mapping );
-
-    hBaseOutputMeta.readRep( rep, metaStore, id_step, databases );
-    assertThat( hBaseOutputMeta.getNamedCluster(), is( namedCluster ) );
-    assertThat( hBaseOutputMeta.getMapping(), is( mapping ) );
+    hBaseOutputMetaSpy.readRep( rep, metaStore, id_step, databases );
+    assertThat( hBaseOutputMetaSpy.getNamedCluster(), is( namedCluster ) );
+    assertThat( hBaseOutputMetaSpy.getMapping(), is( mapping ) );
   }
 
   /**

--- a/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMetaTest.java
+++ b/kettle-plugins/hbase/src/test/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMetaTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,24 +22,30 @@
 
 package org.pentaho.big.data.kettle.plugins.hbase.rowdecoder;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.pentaho.big.data.api.cluster.NamedClusterService;
-import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
-import org.pentaho.bigdata.api.hbase.mapping.Mapping;
-import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
-import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.ValueMetaInterface;
-import org.pentaho.runtime.test.RuntimeTester;
-import org.pentaho.runtime.test.action.RuntimeTestActionService;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.big.data.api.cluster.NamedCluster;
+import org.pentaho.big.data.api.cluster.NamedClusterService;
+import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
+import org.pentaho.big.data.kettle.plugins.hbase.MappingDefinition;
+import org.pentaho.bigdata.api.hbase.HBaseService;
+import org.pentaho.bigdata.api.hbase.mapping.Mapping;
+import org.pentaho.bigdata.api.hbase.meta.HBaseValueMetaInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.runtime.test.RuntimeTester;
+import org.pentaho.runtime.test.action.RuntimeTestActionService;
 
 /**
  * @author Tatsiana_Kasiankova
@@ -48,22 +54,21 @@ import static org.mockito.Mockito.when;
 public class HBaseRowDecoderMetaTest {
 
   private static final String MAPPING_NAME = "MappingName";
-
   private static final String TABLE_NAME = "TableName";
-
-  private static final String COLUMN_NAME = "ColumnName";
-  private static final String FAMILY_NAME = "fm";
   private static final String ALIAS = "alias";
   private static final String MAPPING_KEY_NAME = "mappingKeyName";
   private static final String ORIGIN = "HBase Row Decoder";
   private HBaseRowDecoderMeta hbRowDecoderMeta;
   private RowMeta rowMeta;
+  private VariableSpace vsMock = mock( VariableSpace.class );
+  private NamedClusterServiceLocator ncLocatorMock = mock( NamedClusterServiceLocator.class );
+  private NamedClusterService ncsMock = mock( NamedClusterService.class );
+  private NamedCluster ncMock = mock( NamedCluster.class );
+  private MappingDefinition mapDefMock = mock( MappingDefinition.class );
 
   @Before
   public void setup() {
-    hbRowDecoderMeta =
-      new HBaseRowDecoderMeta( mock( NamedClusterServiceLocator.class ), mock( NamedClusterService.class ), mock(
-        RuntimeTestActionService.class ), mock( RuntimeTester.class ) );
+    hbRowDecoderMeta = new HBaseRowDecoderMeta( ncLocatorMock, ncsMock, mock( RuntimeTestActionService.class ), mock( RuntimeTester.class ) );
     rowMeta = new RowMeta();
   }
 
@@ -111,4 +116,12 @@ public class HBaseRowDecoderMetaTest {
     return maping;
   }
 
+  @Test
+  public void testNotAppliedInjectionWhenMappingDefinitionNull() throws Exception {
+    when( ncsMock.getClusterTemplate() ).thenReturn( ncMock );
+    hbRowDecoderMeta.setNamedCluster( ncsMock.getClusterTemplate() );
+    hbRowDecoderMeta.setMappingDefinition( null );
+    hbRowDecoderMeta.applyInjection( vsMock );
+    verify( ncLocatorMock, times( 0 ) ).getService( ncMock, HBaseService.class );
+  }
 }

--- a/kettle-plugins/hbase/src/test/resources/Filters.xml
+++ b/kettle-plugins/hbase/src/test/resources/Filters.xml
@@ -1,0 +1,16 @@
+<column_filters>
+	<filter>
+		<alias>0</alias>
+		<type>String</type>
+		<comparison_opp>Substring</comparison_opp>
+		<signed_comp>N</signed_comp>
+		<constant>value1</constant>
+	</filter>
+	<filter>
+		<alias>1</alias>
+		<type>String</type>
+		<comparison_opp>&#x3d;</comparison_opp>
+		<signed_comp>Y</signed_comp>
+		<constant>value2</constant>
+	</filter>
+</column_filters>


### PR DESCRIPTION
This issue was introduced with changes from 6.0 to 6.1 related with OSGIing Hbase: BACKLOG-3896
see commit: ba87357
More detailed the cause of the issue and investigations are described in the JIRA: http://jira.pentaho.com/browse/BAD-569?focusedCommentId=281763&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-281763

The fix consists in don't to use HBase service for HBase steps on design time (in meta and dialog) but create HBaseValueMetaInterfaceFactory, ColumnFilterFactory and MappingFactory locally as it was before.
Also it has been added unit tests, fixed minor checkstyle issues and using deprecated method Const.isEmpty.