### PR TITLE
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnera…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -12,6 +12,7 @@
   <packaging>pom</packaging>
   <properties>
     <publish-sonar-phase>site</publish-sonar-phase>
+    <apache-xmlgraphics.revision>1.7.1</apache-xmlgraphics.revision>
   </properties>
   <dependencies>
     <dependency>
@@ -452,77 +453,77 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-anim</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-awt-util</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-bridge</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-codec</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-css</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-dom</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-ext</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-gui-util</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-gvt</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-parser</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-script</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-svg-dom</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-transcoder</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-util</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-xml</artifactId>
-      <version>1.7</version>
+      <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.beanshell</groupId>


### PR DESCRIPTION
[SP-3097] Backport of PPP-3581 - CVE-2015-0250 - Batik 1.7 is vulnerable to XXE in SVG to PNG and SVG to JPG conversion classes (6.1 Suite)