### PR TITLE
[BACKLOG-12886]-Create EMR 5.2 shim against Pentaho 7.1/master

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -189,8 +189,8 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-emr46-package</artifactId>
-      <version>${dependency.hadoop-shims-emr46.revision}</version>
+      <artifactId>pentaho-hadoop-shims-emr52-package</artifactId>
+      <version>${dependency.hadoop-shims-emr52.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -257,7 +257,7 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-emr46-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-emr52-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency.commons-configuration.revision>1.9</dependency.commons-configuration.revision>
     <dependency.high-scale-lib.revision>1.1.2</dependency.high-scale-lib.revision>
     <dependency.mondrian.revision>3.14-SNAPSHOT</dependency.mondrian.revision>
-    <dependency.hadoop-shims-emr46.revision>7.1-SNAPSHOT</dependency.hadoop-shims-emr46.revision>
+    <dependency.hadoop-shims-emr52.revision>7.1-SNAPSHOT</dependency.hadoop-shims-emr52.revision>
     <dependency.kettle.revision>7.1-SNAPSHOT</dependency.kettle.revision>
     <dependency.pentaho-reporting.revision>7.1-SNAPSHOT</dependency.pentaho-reporting.revision>
     <dependency.xpp3.revision>1.1.4c</dependency.xpp3.revision>


### PR DESCRIPTION
Removed emr46 and Added emr52 to the following pom files:

assemblies/legacy-plugin/pom.xml;
pom.xml.