### PR TITLE
[BACKLOG-13633]-Create and Dev validate the MapR 5.2 shim against Pentaho master / 7.1

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -182,8 +182,8 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
-      <version>${dependency.hadoop-shims-mapr510.revision}</version>
+      <artifactId>pentaho-hadoop-shims-mapr520-package</artifactId>
+      <version>${dependency.hadoop-shims-mapr520.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -251,7 +251,7 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-mapr510-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-mapr520-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <dependency.xerces.version>2.9.1</dependency.xerces.version>
     <dependency.mockito.revision>1.9.5</dependency.mockito.revision>
-    <dependency.hadoop-shims-mapr510.revision>7.1-SNAPSHOT</dependency.hadoop-shims-mapr510.revision>
+    <dependency.hadoop-shims-mapr520.revision>7.1-SNAPSHOT</dependency.hadoop-shims-mapr520.revision>
     <dependency.json.revision>7.1-SNAPSHOT</dependency.json.revision>
     <dependency.hadoop-shims-cdh58.revision>7.1-SNAPSHOT</dependency.hadoop-shims-cdh58.revision>
     <dependency.httpcomponents-client.revision>4.5.2</dependency.httpcomponents-client.revision>


### PR DESCRIPTION
Removed mapr510 and added mapr520 to the following pom files:

 - assemblies/legacy-plugin/pom.xml;
 - pom.xml.

Also created:

 - mapr520 ce version of the shim (pentaho/pentaho-hadoop-shims#439);
 - added mapr520 property to the global version properties file for 7.1-qat (pentaho/build-resources#104).