### PR TITLE
[BAD-599] - fix for SPNEGO download shared-object.xml

### DIFF
--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <common.version>3.3.0-v20070426</common.version>
     <httpcomponents-core.version>4.4</httpcomponents-core.version>
-    <httpcomponents-client.version>4.5.2</httpcomponents-client.version>
+    <httpcomponents-client.version>4.5.3</httpcomponents-client.version>
     <xstream.version>1.4.9</xstream.version>
     <xmlpull.revision>1.1.3.1</xmlpull.revision>
     <pig.version>0.8.1</pig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dependency.hadoop-shims-mapr520.revision>7.1-SNAPSHOT</dependency.hadoop-shims-mapr520.revision>
     <dependency.json.revision>7.1-SNAPSHOT</dependency.json.revision>
     <dependency.hadoop-shims-cdh58.revision>7.1-SNAPSHOT</dependency.hadoop-shims-cdh58.revision>
-    <dependency.httpcomponents-client.revision>4.5.2</dependency.httpcomponents-client.revision>
+    <dependency.httpcomponents-client.revision>4.5.3</dependency.httpcomponents-client.revision>
     <dependency.httpcomponents-core.revision>4.4</dependency.httpcomponents-core.revision>
     <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
     <plugin.org.codehaus.mojo.build-helper-maven-plugin.version>1.5</plugin.org.codehaus.mojo.build-helper-maven-plugin.version>


### PR DESCRIPTION
the reason is that https://svn.apache.org/repos/asf/httpcomponents/httpclient/tags/4.5.2/httpclient/src/main/java/org/apache/http/impl/auth/GGSSchemeBase.java -
final GSSName serverName = manager.createName(service + "@" + authServer, GSSName.NT_HOSTBASED_SERVICE); where service = host.getSchemeName().toUpperCase(Locale.ROOT); takes into consideration our url with https which is wrong
while in 4.5.3 new version the logic has been fixed(in 4.5 it's ok too)
https://svn.apache.org/repos/asf/httpcomponents/httpclient/tags/4.5.3/httpclient/src/main/java/org/apache/http/impl/auth/GGSSchemeBase.java - final GSSName serverName = manager.createName("HTTP@" + authServer, GSSName.NT_HOSTBASED_SERVICE);
where http is used