### PR TITLE
[BACKLOG-15075]: Pack CDH 5.10 in big-data-plugin on master branch by default

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -161,15 +161,8 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-cdh58-package</artifactId>
-      <version>${dependency.hadoop-shims-cdh58.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-cdh59-package</artifactId>
-      <version>${dependency.hadoop-shims-cdh59.revision}</version>
+      <artifactId>pentaho-hadoop-shims-cdh510-package</artifactId>
+      <version>${dependency.hadoop-shims-cdh510.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -233,13 +226,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-cdh58-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-cdh59-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-cdh510-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <dependency.mockito.revision>1.9.5</dependency.mockito.revision>
     <dependency.hadoop-shims-mapr520.revision>7.1-SNAPSHOT</dependency.hadoop-shims-mapr520.revision>
     <dependency.json.revision>7.1-SNAPSHOT</dependency.json.revision>
-    <dependency.hadoop-shims-cdh58.revision>7.1-SNAPSHOT</dependency.hadoop-shims-cdh58.revision>
     <dependency.httpcomponents-client.revision>4.5.3</dependency.httpcomponents-client.revision>
     <dependency.httpcomponents-core.revision>4.4</dependency.httpcomponents-core.revision>
     <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
@@ -82,7 +81,7 @@
     <dependency.bean-matchers.revision>0.9</dependency.bean-matchers.revision>
     <dependency.hadoop-shims-api.revision>7.1-SNAPSHOT</dependency.hadoop-shims-api.revision>
     <dependency.avro.revision>1.6.2</dependency.avro.revision>
-    <dependency.hadoop-shims-cdh59.revision>7.1-SNAPSHOT</dependency.hadoop-shims-cdh59.revision>
+    <dependency.hadoop-shims-cdh510.revision>7.1-SNAPSHOT</dependency.hadoop-shims-cdh510.revision>
     <dependency.cxf.revision>2.6.15</dependency.cxf.revision>
     <dependency.hadoop-shims-hdp25.revision>7.1-SNAPSHOT</dependency.hadoop-shims-hdp25.revision>
     <dependency.aws-java-sdk.revision>1.0.008</dependency.aws-java-sdk.revision>


### PR DESCRIPTION
added CDH 5.10 shim in list of the shims supplied by default;
deleted CDH 5.8 and CDH 5.9 from the list.