### PR TITLE
[ENGOPS-2897] Use assembly plugin 3.0 descriptors pom definition

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -266,7 +266,9 @@
           </execution>
         </executions>
         <configuration>
-          <descriptor>${basedir}/src/main/assembly/descriptors/plugin.xml</descriptor>
+          <descriptors>
+            <descriptor>${basedir}/src/main/assembly/descriptors/plugin.xml</descriptor>
+          </descriptors>
           <appendAssemblyId>false</appendAssemblyId>
         </configuration>
       </plugin>

--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -42,7 +42,9 @@
         </executions>
         <configuration>
           <appendAssemblyId>false</appendAssemblyId>
-          <descriptor>${basedir}/src/main/assembly/descriptors/samples.xml</descriptor>
+          <descriptors>
+            <descriptor>${basedir}/src/main/assembly/descriptors/samples.xml</descriptor>
+          </descriptors>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
When targeting the 7.1-SNAPSHOT parent poms, the Maven assembly plugin (v3.0+) requires the `<descriptors>` pom definition to wrap the `<descriptor>` definition.

This should fix the build failure on Cerberus:

http://cerberus.pentaho.com/job/master-snapshot/view/failing/job/big-data-plugin-assembly/529/consoleFull
