### PR TITLE
BACKLOG-15193: httpclient to 4.5 - Connect to Amazon S3 storage fails

### DIFF
--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <common.version>3.3.0-v20070426</common.version>
     <httpcomponents-core.version>4.4</httpcomponents-core.version>
-    <httpcomponents-client.version>4.5.3</httpcomponents-client.version>
+    <httpcomponents-client.version>4.5</httpcomponents-client.version>
     <xstream.version>1.4.9</xstream.version>
     <xmlpull.revision>1.1.3.1</xmlpull.revision>
     <pig.version>0.8.1</pig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency.mockito.revision>1.9.5</dependency.mockito.revision>
     <dependency.hadoop-shims-mapr520.revision>7.1-SNAPSHOT</dependency.hadoop-shims-mapr520.revision>
     <dependency.json.revision>7.1-SNAPSHOT</dependency.json.revision>
-    <dependency.httpcomponents-client.revision>4.5.3</dependency.httpcomponents-client.revision>
+    <dependency.httpcomponents-client.revision>4.5</dependency.httpcomponents-client.revision>
     <dependency.httpcomponents-core.revision>4.4</dependency.httpcomponents-core.revision>
     <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
     <plugin.org.codehaus.mojo.build-helper-maven-plugin.version>1.5</plugin.org.codehaus.mojo.build-helper-maven-plugin.version>


### PR DESCRIPTION
for s3 httpclient-4.5.3 has logic of switching classloader, which breaks pentaho logic for s3
"So in new code httpclient load Connection manager class using Thread.currentThread().getContextClassLoader();  (which is ApplicationClassloader)
Previously httpclient just uses Class.forName(ClassName) which used Classloader of the calling class. "

According to http://jira.pentaho.com/browse/BAD-599 both httpclient-4.5 and httpclient-4.5.3 works ok with SPENGO, checked with httpclient-4.5 – it doesn’t break s3 and doesn't have switching logic