### PR TITLE
[PPP-3692] - Use of vulnerable component commons-beanutils: 1.8.0 - C…

### DIFF
--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -49,7 +49,6 @@
         <include>com.lowagie:itext</include>
         <include>com.lowagie:itext-rtf</include>
         <include>commons-beanutils:commons-beanutils</include>
-        <include>commons-beanutils:commons-beanutils-core</include>
         <include>commons-cli:commons-cli</include>
         <include>commons-collections:commons-collections</include>
         <include>commons-dbcp:commons-dbcp</include>


### PR DESCRIPTION
…VE-2014-0114

- remove redundant dependency commons-collections-core

@mbatchelor, @pamval, last mention of commons-beanutils-core. 
Note: It is not the reason of http://jira.pentaho.com/browse/BACKLOG-15780 error.
Thanks.