### PR TITLE
[BACKLOG-15780] Add commons-beanutils dependency in big-data-plugin-impl-cluster pom.…

### DIFF
--- a/assemblies/features/src/main/resources/features.xml
+++ b/assemblies/features/src/main/resources/features.xml
@@ -26,6 +26,7 @@
 	<configfile finalname="/etc/pentaho.big.data.impl.cluster.cfg">
       mvn:pentaho/pentaho-osgi-config/${project.version}/cfg/pentaho-big-data-impl-cluster
     </configfile>
+    <bundle>mvn:commons-beanutils/commons-beanutils/1.9.3</bundle>
   </feature>
   <feature name="pentaho-big-data-plugin-api" version="1.0">
     <feature>pentaho-big-data-plugin-base</feature>

--- a/impl/cluster/pom.xml
+++ b/impl/cluster/pom.xml
@@ -36,6 +36,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.3</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${dependency.junit.revision}</version>


### PR DESCRIPTION
…xml, and bundle in big-data-plugin features.xml

Imports to **beanutils** classes were included in big-data-plugin/impl/cluster/.../**NamedClusterImpl** (https://github.com/pentaho/big-data-plugin/pull/848/files#diff-51416d6a7f7f43b6baac50f5ed6a8559R35) and beanutils is a transitive dependency from **kettle-core**:
>[INFO] — maven-dependency-plugin:2.10:tree (default-cli) @ pentaho-big-data-impl-cluster — 
>[INFO] pentaho:pentaho-big-data-impl-cluster:bundle:7.1-SNAPSHOT 
>[INFO] - pentaho-kettle:kettle-core:jar:7.1-SNAPSHOT:provided 
>[INFO]     - commons-beanutils:commons-beanutils:jar:1.9.3:provided

**kettle-core** wills stop having this dependency as transient, so we need to call it directly in this project's **pom.xml**.

**feature.xml** needs to include the dependency too to make it available in product