### PR TITLE
[BAD-673]: Pack HDP 2.6 in big-data-plugin on Pentaho 8.0 (master) branch by default

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -168,8 +168,8 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-hdp25-package</artifactId>
-      <version>${dependency.hadoop-shims-hdp25.revision}</version>
+      <artifactId>pentaho-hadoop-shims-hdp26-package</artifactId>
+      <version>${dependency.hadoop-shims-hdp26.revision}</version>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
@@ -232,7 +232,7 @@
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-hdp25-package</artifactId>
+                  <artifactId>pentaho-hadoop-shims-hdp26-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency.mockito.revision>1.9.5</dependency.mockito.revision>
     <dependency.joda-time.revision>2.9.4</dependency.joda-time.revision>
     <dependency.json.revision>8.0-SNAPSHOT</dependency.json.revision>
-    <dependency.hadoop-shims-hdp25.revision>8.0-SNAPSHOT</dependency.hadoop-shims-hdp25.revision>
+    <dependency.hadoop-shims-hdp26.revision>8.0-SNAPSHOT</dependency.hadoop-shims-hdp26.revision>
     <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
     <plugin.org.codehaus.mojo.build-helper-maven-plugin.version>1.5</plugin.org.codehaus.mojo.build-helper-maven-plugin.version>
     <dependency.pentaho-registry.revision>8.0-SNAPSHOT</dependency.pentaho-registry.revision>


### PR DESCRIPTION
What has been done:
Add HDP 2.6 shim into Big Data Plugin.
Delete HDP 2.5 shim from Big Data Plugin.