### PR TITLE
[BAD-615]-Spark on Windows: PDI doesn't receive response from Resource Manager when "Blocking" is disabled in Spark submit step

### DIFF
--- a/kettle-plugins/spark/pom.xml
+++ b/kettle-plugins/spark/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>pentaho</groupId>
@@ -16,8 +17,31 @@
   <properties>
     <publish-sonar-phase>site</publish-sonar-phase>
     <dependency.commons-validator.version>1.3.1</dependency.commons-validator.version>
+    <net.java.dev.jna.version>4.4.0</net.java.dev.jna.version>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${net.java.dev.jna.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>${net.java.dev.jna.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-core</artifactId>
@@ -83,7 +107,8 @@
               org.pentaho.ui.xul*;resolution:=optional,
               org.pentaho.di.osgi,
               org.pentaho.di.core.plugins,
-              *</Import-Package>
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/kettle-plugins/spark/src/main/java/org/pentaho/di/job/entries/spark/JobEntrySparkSubmit.java
+++ b/kettle-plugins/spark/src/main/java/org/pentaho/di/job/entries/spark/JobEntrySparkSubmit.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -24,6 +24,7 @@ package org.pentaho.di.job.entries.spark;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StreamTokenizer;
@@ -33,6 +34,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.sun.jna.Platform;
 import org.pentaho.di.cluster.SlaveServer;
 import org.pentaho.di.core.CheckResultInterface;
 import org.pentaho.di.core.Const;
@@ -64,19 +67,18 @@ import static org.pentaho.di.job.entry.validator.JobEntryValidatorUtils.notBlank
 /**
  * This job entry submits a JAR to Spark and executes a class. It uses the spark-submit script to submit a command like
  * this: spark-submit --class org.pentaho.spark.SparkExecTest --master yarn-cluster my-spark-job.jar arg1 arg2
- *
+ * <p>
  * More information on the options is here: http://spark.apache.org/docs/1.2.0/submitting-applications.html
  *
  * @author jdixon
  * @since Dec 3 2014
- *
  */
 
 @JobEntry( image = "org/pentaho/di/ui/job/entries/spark/img/spark.svg", id = "SparkSubmit",
-    name = "JobEntrySparkSubmit.Title", description = "JobEntrySparkSubmit.Description",
-    categoryDescription = "i18n:org.pentaho.di.job:JobCategory.Category.BigData",
-    i18nPackageName = "org.pentaho.di.job.entries.spark",
-    documentationUrl = "0L0/0Y0/0L0/Spark_Submit" )
+  name = "JobEntrySparkSubmit.Title", description = "JobEntrySparkSubmit.Description",
+  categoryDescription = "i18n:org.pentaho.di.job:JobCategory.Category.BigData",
+  i18nPackageName = "org.pentaho.di.job.entries.spark",
+  documentationUrl = "0L0/0Y0/0L0/Spark_Submit" )
 public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobEntryInterface, JobEntryListener {
   public static final String JOB_TYPE_JAVA_SCALA = "Java or Scala";
   public static final String JOB_TYPE_PYTHON = "Python";
@@ -148,10 +150,9 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
 
   /**
    * Parses XML and recreates the state
-   *
    */
   public void loadXML( Node entrynode, List<DatabaseMeta> databases, List<SlaveServer> slaveServers, Repository rep,
-      IMetaStore metaStore ) throws KettleXMLException {
+                       IMetaStore metaStore ) throws KettleXMLException {
     try {
       super.loadXML( entrynode, databases, slaveServers );
 
@@ -190,7 +191,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
    * Reads the state from the repository
    */
   public void loadRep( Repository rep, IMetaStore metaStore, ObjectId id_jobentry, List<DatabaseMeta> databases,
-      List<SlaveServer> slaveServers ) throws KettleException {
+                       List<SlaveServer> slaveServers ) throws KettleException {
     try {
       scriptPath = rep.getJobEntryAttributeString( id_jobentry, "scriptPath" );
       master = rep.getJobEntryAttributeString( id_jobentry, "master" );
@@ -207,14 +208,14 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
       }
       for ( int i = 0; i < rep.countNrJobEntryAttributes( id_jobentry, "libsEnv" ); i++ ) {
         libs.put( rep.getJobEntryAttributeString( id_jobentry, i, "libsPath" ),
-            rep.getJobEntryAttributeString( id_jobentry, i, "libsEnv" ) );
+          rep.getJobEntryAttributeString( id_jobentry, i, "libsEnv" ) );
       }
       driverMemory = rep.getJobEntryAttributeString( id_jobentry, "driverMemory" );
       executorMemory = rep.getJobEntryAttributeString( id_jobentry, "executorMemory" );
       blockExecution = rep.getJobEntryAttributeBoolean( id_jobentry, "blockExecution" );
     } catch ( KettleException dbe ) {
       throw new KettleException( "Unable to load job entry of type 'SparkSubmit' from the repository for id_jobentry="
-          + id_jobentry, dbe );
+        + id_jobentry, dbe );
     }
   }
 
@@ -244,7 +245,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
       rep.saveJobEntryAttribute( id_job, getObjectId(), "blockExecution", blockExecution );
     } catch ( KettleDatabaseException dbe ) {
       throw new KettleException( "Unable to save job entry of type 'SparkSubmit' to the repository for id_job="
-          + id_job, dbe );
+        + id_job, dbe );
     }
   }
 
@@ -260,8 +261,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets the path for the spark-submit utility
    *
-   * @param scriptPath
-   *          path to spark-submit utility
+   * @param scriptPath path to spark-submit utility
    */
   public void setScriptPath( String scriptPath ) {
     this.scriptPath = scriptPath;
@@ -279,8 +279,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets the URL for the Spark master node
    *
-   * @param master
-   *          URL for the Spark master node
+   * @param master URL for the Spark master node
    */
   public void setMaster( String master ) {
     this.master = master;
@@ -330,8 +329,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets the path for the jar containing the Spark code to execute
    *
-   * @param jar
-   *          path for the jar
+   * @param jar path for the jar
    */
   public void setJar( String jar ) {
     this.jar = jar;
@@ -349,8 +347,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets the name of the class containing the Spark code to execute
    *
-   * @param className
-   *          name of the class
+   * @param className name of the class
    */
   public void setClassName( String className ) {
     this.className = className;
@@ -368,8 +365,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets the arguments for the Spark class. This is a space-separated list of strings, e.g. "http.log 1000"
    *
-   * @param args
-   *          arguments
+   * @param args arguments
    */
   public void setArgs( String args ) {
     this.args = args;
@@ -387,8 +383,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets executor memory config param's value
    *
-   * @param executorMemory
-   *          amount of memory executor process is allowed to consume
+   * @param executorMemory amount of memory executor process is allowed to consume
    */
   public void setExecutorMemory( String executorMemory ) {
     this.executorMemory = executorMemory;
@@ -406,8 +401,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets driver memory config param's value
    *
-   * @param driverMemory
-   *          amount of memory driver process is allowed to consume
+   * @param driverMemory amount of memory driver process is allowed to consume
    */
   public void setDriverMemory( String driverMemory ) {
     this.driverMemory = driverMemory;
@@ -425,8 +419,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Sets if the job entry will wait for job execution to complete
    *
-   * @param blockExecution
-   *          blocking mode
+   * @param blockExecution blocking mode
    */
   public void setBlockExecution( boolean blockExecution ) {
     this.blockExecution = blockExecution;
@@ -537,7 +530,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   }
 
   @VisibleForTesting
-  protected boolean validate( ) {
+  protected boolean validate() {
     boolean valid = true;
     if ( Const.isEmpty( scriptPath ) || !new File( environmentSubstitute( scriptPath ) ).exists() ) {
       logError( BaseMessages.getString( PKG, "JobEntrySparkSubmit.Error.SparkSubmitPathInvalid" ) );
@@ -563,6 +556,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
 
     return valid;
   }
+
 
   /**
    * Executes the spark-submit command and returns a Result
@@ -599,11 +593,11 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
 
       // any error message?
       PatternMatchingStreamLogger errorLogger =
-          new PatternMatchingStreamLogger( log, proc.getErrorStream(), jobSubmittedPatterns, jobSubmitted );
+        new PatternMatchingStreamLogger( log, proc.getErrorStream(), jobSubmittedPatterns, jobSubmitted );
 
       // any output?
       PatternMatchingStreamLogger outputLogger =
-          new PatternMatchingStreamLogger( log, proc.getInputStream(), jobSubmittedPatterns, jobSubmitted );
+        new PatternMatchingStreamLogger( log, proc.getInputStream(), jobSubmittedPatterns, jobSubmitted );
 
       if ( !blockExecution ) {
         PatternMatchingStreamLogger.PatternMatchedListener cb =
@@ -642,20 +636,14 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
       } ).start();
 
       proc.waitFor();
+
       processFinished.set( true );
+
+      prepareProcessThreadsToStop( proc, errorLoggerThread, outputLoggerThread );
 
       if ( log.isDetailed() ) {
         logDetailed( "Spark submit finished" );
       }
-
-      // wait until loggers read all data from stdout and stderr
-      errorLoggerThread.join();
-      outputLoggerThread.join();
-
-      // close the streams
-      // otherwise you get "Too many open files, java.io.IOException" after a lot of iterations
-      proc.getErrorStream().close();
-      proc.getOutputStream().close();
 
       // What's the exit status?
       int exitCode;
@@ -685,6 +673,41 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
     return result;
   }
 
+  private void waitForThreadsFinishToRead( Thread errorLoggerThread, Thread outputLoggerThread )
+    throws InterruptedException {
+    // wait until loggers read all data from stdout and stderr
+    errorLoggerThread.join();
+    outputLoggerThread.join();
+  }
+
+  private void prepareProcessThreadsToStop( Process proc, Thread errorLoggerThread, Thread outputLoggerThread )
+    throws Exception {
+    if ( blockExecution ) {
+      waitForThreadsFinishToRead( errorLoggerThread, outputLoggerThread );
+    } else {
+      killChildProcesses();
+    }
+    // close the streams
+    // otherwise you get "Too many open files, java.io.IOException" after a lot of iterations
+    proc.getErrorStream().close();
+    proc.getOutputStream().close();
+  }
+
+  @VisibleForTesting
+  void killChildProcesses() {
+    if ( Platform.isWindows() ) {
+      try {
+        WinProcess process = new WinProcess( WinProcess.getPID( proc ) );
+        process.killChildProcesses();
+      } catch ( IOException e ) {
+        if ( log.isDetailed() ) {
+          logDetailed(
+            ( BaseMessages.getString( PKG, "JobEntrySparkSubmit.Error.KillWindowsChildProcess", e.getMessage() ) ) );
+        }
+      }
+    }
+  }
+
   public boolean evaluates() {
     return true;
   }
@@ -694,7 +717,7 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
    */
   @Override
   public void check( List<CheckResultInterface> remarks, JobMeta jobMeta, VariableSpace space, Repository repository,
-      IMetaStore metaStore ) {
+                     IMetaStore metaStore ) {
     andValidator().validate( this, "scriptPath", remarks, putValidators( notBlankValidator() ) );
     andValidator().validate( this, "scriptPath", remarks, putValidators( fileExistsValidator() ) );
     andValidator().validate( this, "master", remarks, putValidators( notBlankValidator() ) );
@@ -708,11 +731,9 @@ public class JobEntrySparkSubmit extends JobEntryBase implements Cloneable, JobE
   /**
    * Parse a string into arguments as if it were provided on the command line.
    *
-   * @param commandLineString
-   *          A command line string.
+   * @param commandLineString A command line string.
    * @return List of parsed arguments
-   * @throws IOException
-   *           when the command line could not be parsed
+   * @throws IOException when the command line could not be parsed
    */
   public List<String> parseCommandLine( String commandLineString ) throws IOException {
     List<String> args = new ArrayList<String>();

--- a/kettle-plugins/spark/src/main/resources/org/pentaho/di/job/entries/spark/messages/messages_en_US.properties
+++ b/kettle-plugins/spark/src/main/resources/org/pentaho/di/job/entries/spark/messages/messages_en_US.properties
@@ -38,3 +38,4 @@ JobEntrySparkSubmit.Error.SparkSubmitPathInvalid=Path to spark-submit is invalid
 JobEntrySparkSubmit.Error.MasterURLEmpty=Master URL is empty.
 JobEntrySparkSubmit.Error.JarPathEmpty=Path to application jar is empty.
 JobEntrySparkSubmit.Error.PyFilePathEmpty=Path to python file is empty.
+JobEntrySparkSubmit.Error.KillWindowsChildProcess=Could not kill child process

--- a/kettle-plugins/spark/src/test/java/org/pentaho/di/job/entries/spark/WinProcessTest.java
+++ b/kettle-plugins/spark/src/test/java/org/pentaho/di/job/entries/spark/WinProcessTest.java
@@ -1,0 +1,291 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.job.entries.spark;
+
+import com.sun.jna.Platform;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+public class WinProcessTest {
+
+  private static String processCmdResource;
+  private static String javaFileResource;
+  private static String classPath;
+  private static String childProcessClassName = "ChildProcessTester";
+
+  @BeforeClass
+  public static void setUp() {
+    Assume.assumeTrue( Platform.isWindows() );
+
+    processCmdResource =
+      Thread.currentThread().getContextClassLoader().getResource( "process.cmd" ).getPath().toString().substring( 1 );
+    javaFileResource =
+      Thread.currentThread().getContextClassLoader().getResource( childProcessClassName + ".java" ).getPath().toString()
+        .substring( 1 );
+    int index = javaFileResource.lastIndexOf( '/' );
+    classPath = javaFileResource.substring( 0, index );
+  }
+
+  @Test
+  public void getPIDWhenProcessIsNull() {
+    int pid = WinProcess.getPID( null );
+    Assert.assertEquals( -1, pid );
+  }
+
+  @Test
+  public void getPIDWhenProcessExists() {
+    int pid = -1;
+    Process process = null;
+    List<String> cmds = new ArrayList<>();
+    cmds.add( "cmd.exe" );
+    ProcessBuilder processBuilder = new ProcessBuilder( cmds );
+    try {
+      process = processBuilder.start();
+      pid = WinProcess.getPID( process );
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    } finally {
+      process.destroy();
+    }
+
+    Assert.assertTrue( pid > 0 );
+    Assert.assertFalse( process.isAlive() );
+  }
+
+  @Test
+  public void createWinProcessWrapperAndKillProcess() {
+    int pid;
+    Process process = null;
+    WinProcess winProcess = null;
+    List<String> cmds = new ArrayList<>();
+    cmds.add( "cmd.exe" );
+    ProcessBuilder processBuilder = new ProcessBuilder( cmds );
+    try {
+      process = processBuilder.start();
+      winProcess = new WinProcess( WinProcess.getPID( process ) );
+      pid = winProcess.getWinProcessPID();
+
+      Assert.assertNotNull( winProcess );
+      Assert.assertTrue( pid > 0 );
+
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    } finally {
+      winProcess.terminate();
+    }
+
+    Assert.assertFalse( process.isAlive() );
+  }
+
+  @Test
+  public void tryToKillChildProcessIfItNotExists() {
+    String childProcessPIDs = " ";
+    Process process = null;
+    WinProcess winProcess = null;
+    List<String> cmds = new ArrayList<>();
+    cmds.add( "cmd.exe" );
+    ProcessBuilder processBuilder = new ProcessBuilder( cmds );
+    try {
+      process = processBuilder.start();
+      winProcess = new WinProcess( WinProcess.getPID( process ) );
+      childProcessPIDs = winProcess.killChildProcesses();
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    } finally {
+      process.destroy();
+    }
+    Assert.assertEquals( childProcessPIDs, "" );
+    Assert.assertTrue( childProcessPIDs.isEmpty() );
+    Assert.assertFalse( process.isAlive() );
+  }
+
+  @Test
+  public void killExistingChildProcess() {
+
+    int parentPID;
+    boolean isChildProcessExists;
+    WinProcess winProcess;
+    String childProcessPIDs = " ";
+    String pattern = "child process started";
+
+    List<String> cmds = new ArrayList<>();
+
+    cmds.add( "cmd.exe" );
+    cmds.add( "/c" );
+    cmds.add( processCmdResource );
+    cmds.add( javaFileResource );
+    cmds.add( classPath );
+    cmds.add( childProcessClassName );
+
+    ProcessBuilder builder = new ProcessBuilder( cmds );
+    try {
+      Process proc = builder.start();
+
+      InputStream inStream = proc.getInputStream();
+      InputStream errStream = proc.getErrorStream();
+
+      Thread inStreamReader = new Thread(
+        () -> {
+          try {
+            String line = null;
+            BufferedReader in = new BufferedReader( new InputStreamReader( inStream ) );
+            while ( ( line = in.readLine() ) != null ) {
+              System.out.println( line );
+              if ( line.contains( pattern ) ) {
+                proc.destroy();
+              }
+            }
+          } catch ( IOException e ) {
+            e.printStackTrace();
+          }
+        } );
+
+      inStreamReader.start();
+
+      Thread errStreamReader = new Thread(
+        () -> {
+          try {
+            String line = null;
+            BufferedReader in = new BufferedReader( new InputStreamReader( errStream ) );
+            while ( ( line = in.readLine() ) != null ) {
+              System.out.println( line );
+              if ( line.contains( pattern ) ) {
+                proc.destroy();
+              }
+            }
+          } catch ( IOException e ) {
+            e.printStackTrace();
+          }
+        } );
+
+      errStreamReader.start();
+
+      proc.waitFor();
+
+      parentPID = WinProcess.getPID( proc );
+      winProcess = new WinProcess( parentPID );
+      childProcessPIDs = winProcess.killChildProcesses();
+      isChildProcessExists = isChildProcessAlive( parentPID, childProcessPIDs );
+
+      if ( isChildProcessExists ) {
+        winProcess = new WinProcess( new Integer( childProcessPIDs ) );
+        winProcess.terminate();
+      }
+
+      Assert.assertNotEquals( childProcessPIDs, "" );
+      Assert.assertTrue( new Integer( childProcessPIDs ) > 0 );
+      Assert.assertFalse( childProcessPIDs.isEmpty() );
+      Assert.assertFalse( isChildProcessExists );
+
+      proc.getErrorStream().close();
+      proc.getInputStream().close();
+
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    } catch ( InterruptedException e ) {
+      e.printStackTrace();
+    }
+  }
+
+  private static boolean isChildProcessAlive( Integer parentPID, String childPID ) {
+
+    List<String> cmds = new ArrayList<>();
+    final AtomicBoolean childProcessExists = new AtomicBoolean( false );
+
+    cmds.add( "wmic.exe" );
+    cmds.add( "process" );
+    cmds.add( "where" );
+    cmds.add( "parentProcessId=" + parentPID );
+    cmds.add( "get" );
+    cmds.add( "processId" );
+
+    ProcessBuilder builder = new ProcessBuilder( cmds );
+
+    try {
+      Process proc = builder.start();
+
+      InputStream inStream = proc.getInputStream();
+      InputStream errStream = proc.getErrorStream();
+
+      Thread inStreamReader = new Thread(
+        () -> {
+          try {
+            String line = null;
+            BufferedReader in = new BufferedReader( new InputStreamReader( inStream ) );
+            while ( ( line = in.readLine() ) != null ) {
+              System.out.println( line );
+              if ( line.contains( childPID ) ) {
+                childProcessExists.set( true );
+                proc.destroy();
+              }
+            }
+          } catch ( IOException e ) {
+            e.printStackTrace();
+          }
+        } );
+
+      inStreamReader.start();
+
+      Thread errStreamReader = new Thread(
+        () -> {
+          try {
+            String line = null;
+            BufferedReader in = new BufferedReader( new InputStreamReader( errStream ) );
+            while ( ( line = in.readLine() ) != null ) {
+              System.out.println( line );
+              if ( line.contains( childPID ) ) {
+                childProcessExists.set( true );
+                proc.destroy();
+              }
+            }
+          } catch ( IOException e ) {
+            e.printStackTrace();
+          }
+        } );
+
+      errStreamReader.start();
+
+      proc.waitFor();
+
+      proc.getErrorStream().close();
+      proc.getInputStream().close();
+
+    } catch ( IOException e ) {
+      e.printStackTrace();
+    } catch ( InterruptedException e ) {
+      e.printStackTrace();
+    }
+    return childProcessExists.get();
+  }
+}

--- a/kettle-plugins/spark/src/test/resources/ChildProcessTester.java
+++ b/kettle-plugins/spark/src/test/resources/ChildProcessTester.java
@@ -1,0 +1,43 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+public class ChildProcessTester implements Runnable {
+
+    private String pattern = "child process started";
+
+    @Override public void run() {
+        for ( int i = 0; i < 1000; i++ ) {
+            System.out.println( Thread.currentThread().getName() + " " + i );
+            System.out.println( pattern );
+            try {
+                Thread.sleep( 10000 );
+            } catch ( Exception e ) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static void main( String[] args ) {
+        Thread thread = new Thread( new ChildProcessTester() );
+        thread.start();
+    }
+}

--- a/kettle-plugins/spark/src/test/resources/process.cmd
+++ b/kettle-plugins/spark/src/test/resources/process.cmd
@@ -1,0 +1,2 @@
+javac %1
+java -cp %2 %3


### PR DESCRIPTION
Kill the child win process by pid and remove join operation for threads in case when blocking is enabled.
Added WinProcess class to kill child win processes.

See this pull request along with https://github.com/pentaho/pentaho-karaf-assembly/pull/363