### PR TITLE
[BACKLOG-18434]-PMR jobs are failed with ClassNotFoundException: org.…

### DIFF
--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -60,6 +60,7 @@
         <include>commons-discovery:commons-discovery</include>
         <include>commons-fileupload:commons-fileupload</include>
         <include>org.apache.httpcomponents:httpclient</include>
+        <include>org.apache.httpcomponents:httpcore</include>
         <include>commons-io:commons-io</include>
         <include>commons-lang:commons-lang</include>
         <include>commons-logging:commons-logging</include>


### PR DESCRIPTION
…apache.http.protocol.HttpCoreContext, add jar org.apache.httpcomponents:httpcore to pmr archive