### PR TITLE
BACKLOG-18712 - fixed 3 UI defects.  'Avro path' and 'Get fields' should have both been sentence case.  Put in correct values for Compression type drop down

### DIFF
--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/avro/output/AvroOutputMeta.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/avro/output/AvroOutputMeta.java
@@ -189,9 +189,8 @@ public class AvroOutputMeta extends AvroOutputMetaBase {
 
   public static enum CompressionType {
     NONE( getMsg( "AvroOutput.CompressionType.NONE" ) ),
-    SNAPPY( "Snappy" ),
-    GZIP( "GZIP" ),
-    LZO( "LZO" );
+    DEFLATE( "Deflate" ),
+    SNAPPY( "Snappy" );
 
     private final String name;
 

--- a/kettle-plugins/formats/src/main/resources/org/pentaho/big/data/kettle/plugins/formats/avro/output/messages/messages_en_US.properties
+++ b/kettle-plugins/formats/src/main/resources/org/pentaho/big/data/kettle/plugins/formats/avro/output/messages/messages_en_US.properties
@@ -5,11 +5,11 @@ AvroOutputDialog.Shell.Title=Avro Output
 
 AvroOutputDialog.FieldsTab.TabTitle=Fields
 AvroOutputDialog.Fields.column.Name=Name
-AvroOutputDialog.Fields.column.Path=Avro Path
+AvroOutputDialog.Fields.column.Path=Avro path
 AvroOutputDialog.Fields.column.Type=Type
 AvroOutputDialog.Fields.column.Default=Default value
 AvroOutputDialog.Fields.column.Null=Null
-AvroOutputDialog.Fields.Get=Get Fields
+AvroOutputDialog.Fields.Get=Get fields
 
 AvroOutputDialog.Schema.TabTitle=Schema
 AvroOutputDialog.Schema.SourceTitle=Source


### PR DESCRIPTION
@rmansoor @tkafalas  please check out the small pull request.  It fixes UI defects logged here:  http://jira.pentaho.com/browse/BACKLOG-18712