### PR TITLE
[BACKLOG-17900] - Implement read/write Parquet format functionality in PDI steps via Shim API - resolve Hadoop cluster file paths

### DIFF
--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/nc/NamedClusterFileObject.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/nc/NamedClusterFileObject.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.big.data.impl.vfs.hdfs.nc;
+
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.pentaho.big.data.impl.vfs.hdfs.HDFSFileObject;
+import org.pentaho.di.core.vfs.AliasedFileObject;
+
+public class NamedClusterFileObject extends HDFSFileObject implements AliasedFileObject {
+
+  private final String realFileSystemURI;
+
+  public NamedClusterFileObject( final AbstractFileName name, final NamedClusterFileSystem fileSystem ) throws FileSystemException {
+    super( name, fileSystem );
+    realFileSystemURI = fileSystem.getRealFileSystemURI().toString();
+  }
+
+  @Override
+  public String getOriginalURIString() {
+    return realFileSystemURI + getName().getPath();
+  }
+}

--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/nc/NamedClusterFileSystem.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/nc/NamedClusterFileSystem.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.big.data.impl.vfs.hdfs.nc;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.pentaho.big.data.impl.vfs.hdfs.HDFSFileSystem;
+import org.pentaho.bigdata.api.hdfs.HadoopFileSystem;
+
+import java.net.URI;
+
+
+public class NamedClusterFileSystem extends HDFSFileSystem {
+
+  private final URI realFileSystemURI;
+
+  public NamedClusterFileSystem( final FileName rootName, final URI realFileSystemURI, final FileSystemOptions fileSystemOptions,
+                                 HadoopFileSystem hdfs ) {
+    super( rootName, fileSystemOptions, hdfs );
+    this.realFileSystemURI = realFileSystemURI;
+  }
+
+  @Override protected FileObject createFile( AbstractFileName name ) throws Exception {
+    return new NamedClusterFileObject( name, this );
+  }
+
+  public URI getRealFileSystemURI() {
+    return realFileSystemURI;
+  }
+
+}

--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/nc/NamedClusterProvider.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/nc/NamedClusterProvider.java
@@ -35,7 +35,6 @@ import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
 import org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider;
-import org.pentaho.big.data.impl.vfs.hdfs.HDFSFileSystem;
 import org.pentaho.bigdata.api.hdfs.HadoopFileSystemLocator;
 import org.pentaho.di.core.osgi.api.MetastoreLocatorOsgi;
 import org.pentaho.di.core.osgi.api.VfsEmbeddedFileSystemCloser;
@@ -109,7 +108,7 @@ public class NamedClusterProvider extends HDFSFileProvider implements VfsEmbedde
           getMetastore( clusterName, fileSystemOptions ), new Variables() );
       URI uri = URI.create( generatedUrl );
 
-      return new HDFSFileSystem( name, fileSystemOptions,
+      return new NamedClusterFileSystem( name, uri, fileSystemOptions,
         hadoopFileSystemLocator.getHadoopFilesystem( namedCluster, uri ) );
     } catch ( ClusterInitializationException e ) {
       throw new FileSystemException( e );

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/input/ParquetInput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/input/ParquetInput.java
@@ -30,6 +30,8 @@ import org.pentaho.big.data.kettle.plugins.formats.parquet.input.ParquetInputMet
 import org.pentaho.bigdata.api.format.FormatService;
 import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.vfs.AliasedFileObject;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -98,7 +100,14 @@ public class ParquetInput extends BaseFileInputStep<ParquetInputMeta, ParquetInp
 
     data.input = formatService.createInputFormat( IPentahoParquetInputFormat.class );
     data.input.setSchema( schema );
-    data.input.setInputFile( meta.inputFiles.fileName[0] );
+
+    String inputFileName = meta.inputFiles.fileName[0];
+    FileObject inputFileObject = KettleVFS.getFileObject( inputFileName );
+    if ( AliasedFileObject.isAliasedFile( inputFileObject ) ) {
+      inputFileName = ( (AliasedFileObject) inputFileObject ).getOriginalURIString();
+    }
+
+    data.input.setInputFile( inputFileName );
     data.input.setSplitSize( SPLIT_SIZE );
 
     data.splits = data.input.getSplits();

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutput.java
@@ -24,6 +24,7 @@ package org.pentaho.big.data.kettle.plugins.formats.impl.parquet.output;
 
 import java.io.IOException;
 
+import org.apache.commons.vfs2.FileObject;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.api.initializer.ClusterInitializationException;
 import org.pentaho.big.data.kettle.plugins.formats.FormatInputField;
@@ -33,6 +34,8 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.vfs.AliasedFileObject;
+import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStep;
@@ -98,7 +101,14 @@ public class ParquetOutput extends BaseStep implements StepInterface {
     }
 
     data.output = formatService.createOutputFormat( IPentahoParquetOutputFormat.class );
-    data.output.setOutputFile( meta.getFilename() );
+
+    String outputFileName = meta.getFilename();
+    FileObject outputFileObject = KettleVFS.getFileObject( outputFileName );
+    if ( AliasedFileObject.isAliasedFile( outputFileObject ) ) {
+      outputFileName = ( (AliasedFileObject) outputFileObject ).getOriginalURIString();
+    }
+
+    data.output.setOutputFile( outputFileName );
     data.output.setSchema( createSchema( rowMeta ) );
 
     IPentahoParquetOutputFormat.COMPRESSION compression;


### PR DESCRIPTION
!Review and merge this PR first: https://github.com/pentaho/pentaho-kettle/pull/4403
@bmorrise please review.

