### PR TITLE
[BAD-1034]-remove emr56, cdh511 shims

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -156,19 +156,6 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-cdh511-package</artifactId>
-      <version>${dependency.hadoop-shims-cdh511.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh512-package</artifactId>
       <version>${hadoop-shims-cdh512.version}</version>
       <type>zip</type>
@@ -197,19 +184,6 @@
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-mapr520-package</artifactId>
       <version>${dependency.hadoop-shims-mapr520.revision}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-emr56-package</artifactId>
-      <version>${hadoop-shims-emr56.version}</version>
       <type>zip</type>
       <scope>provided</scope>
       <exclusions>
@@ -271,12 +245,6 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-cdh511-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-cdh512-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
@@ -290,12 +258,6 @@
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-mapr520-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-emr56-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
     <dependency.simple-jndi.revision>1.0.0</dependency.simple-jndi.revision>
     <dependency.xpp3.revision>1.1.4c</dependency.xpp3.revision>
     <dependency.slf4j.revision>1.7.7</dependency.slf4j.revision>
-    <dependency.hadoop-shims-cdh511.revision>8.0-SNAPSHOT</dependency.hadoop-shims-cdh511.revision>
     <hadoop-shims-cdh512.version>8.0-SNAPSHOT</hadoop-shims-cdh512.version>
     <dependency.jets3t.revision>0.9.3</dependency.jets3t.revision>
     <dependency.xstream.revision>1.4.9</dependency.xstream.revision>
@@ -86,7 +85,6 @@
     <dependency.avro.revision>1.6.2</dependency.avro.revision>
     <dependency.cxf.revision>2.6.15</dependency.cxf.revision>
     <dependency.aws-java-sdk.revision>1.0.008</dependency.aws-java-sdk.revision>
-    <hadoop-shims-emr56.version>8.0-SNAPSHOT</hadoop-shims-emr56.version>
     <hadoop-shims-emr58.version>8.0-SNAPSHOT</hadoop-shims-emr58.version>
     <dependency.osgi.revision>4.3.1</dependency.osgi.revision>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>


### PR DESCRIPTION
In big-data-plugin we should have only one latest shim for each vendor. As emr58 was added before, so emr56 has been removed. Also cdh511 has been removed.

See this pull request along with:
 - https://github.com/pentaho/pentaho-hadoop-shims/pull/559
 - https://github.com/pentaho/build-resources/pull/143