### PR TITLE
[BACKLOG-18998] - Pentaho MapReduce with Hbase Row Decoder is failing in hdp26 secure due to org.apache.hadoop.hbase.UnknownScannerException

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -1047,6 +1047,16 @@
       <type>zip</type>
       <classifier>pmr</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka-clients.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-metaverse-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -235,6 +235,8 @@
         <include>xml-apis:xml-apis-ext</include>
         <include>xmlpull:xmlpull</include>
         <include>xpp3:xpp3_min</include>
+        <include>org.apache.kafka:kafka-clients</include>
+        <include>pentaho:pentaho-metaverse-api</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
@VasilinaTerehova please take a view and merge