### PR TITLE
[BACKLOG-18865]-move getting parameters for parquet step to base meta…

### DIFF
--- a/kettle-plugins/formats-meta/src/main/resources/org/pentaho/big/data/kettle/plugins/formats/parquet/output/messages/messages_en_US.properties
+++ b/kettle-plugins/formats-meta/src/main/resources/org/pentaho/big/data/kettle/plugins/formats/parquet/output/messages/messages_en_US.properties
@@ -1,0 +1,7 @@
+ParquetOutput.EncodingType.PLAIN=Plain
+ParquetOutput.EncodingType.DICTIONARY=Dictionary
+ParquetOutput.EncodingType.BIT_PACKED=Bit packed
+ParquetOutput.EncodingType.RLE=RLE
+
+ParquetOutput.CompressionType.NONE=None
+

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutputMeta.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutputMeta.java
@@ -22,17 +22,11 @@
 
 package org.pentaho.big.data.kettle.plugins.formats.impl.parquet.output;
 
-import java.util.function.Function;
-
 import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.big.data.api.cluster.service.locator.NamedClusterServiceLocator;
 import org.pentaho.big.data.kettle.plugins.formats.parquet.output.ParquetOutputMetaBase;
 import org.pentaho.di.core.annotations.Step;
-import org.pentaho.di.core.util.StringUtil;
-import org.pentaho.di.core.util.Utils;
-import org.pentaho.di.core.variables.VariableSpace;
-import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -40,25 +34,23 @@ import org.pentaho.di.trans.step.StepInterface;
 import org.pentaho.di.trans.step.StepMeta;
 
 @Step( id = "ParquetOutput", image = "PO.svg", name = "ParquetOutput.Name", description = "ParquetOutput.Description",
-    categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.BigData",
-    documentationUrl = "http://wiki.pentaho.com/display/EAI/Parquet+output",
-    i18nPackageName = "org.pentaho.di.trans.steps.parquet" )
+  categoryDescription = "i18n:org.pentaho.di.trans.step:BaseStep.Category.BigData",
+  documentationUrl = "http://wiki.pentaho.com/display/EAI/Parquet+output",
+  i18nPackageName = "org.pentaho.di.trans.steps.parquet" )
 public class ParquetOutputMeta extends ParquetOutputMetaBase {
-
-  private static final Class<?> PKG = ParquetOutputMeta.class;
 
   private final NamedClusterServiceLocator namedClusterServiceLocator;
   private final NamedClusterService namedClusterService;
 
   public ParquetOutputMeta( NamedClusterServiceLocator namedClusterServiceLocator,
-      NamedClusterService namedClusterService ) {
+                            NamedClusterService namedClusterService ) {
     this.namedClusterServiceLocator = namedClusterServiceLocator;
     this.namedClusterService = namedClusterService;
   }
 
   @Override
   public StepInterface getStep( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-      Trans trans ) {
+                                Trans trans ) {
     return new ParquetOutput( stepMeta, stepDataInterface, copyNr, transMeta, trans, namedClusterServiceLocator );
   }
 
@@ -71,176 +63,4 @@ public class ParquetOutputMeta extends ParquetOutputMetaBase {
     return new ParquetOutputData();
   }
 
-  public EncodingType getEncodingType( VariableSpace vspace ) {
-    return enableDictionary ? EncodingType.DICTIONARY : EncodingType.PLAIN;
-  }
-
-  public void setEncodingType( String encoding ) {
-    enableDictionary = encoding != null ? encoding.startsWith( "D" ) : false;
-  }
-
-  public String getEncodingType() {
-    return enableDictionary ? EncodingType.DICTIONARY.uiName : EncodingType.PLAIN.uiName;
-  }
-
-  public int getRowGroupSize( VariableSpace vspace ) {
-    return parseReplace( rowGroupSize, vspace, str -> Integer.parseInt( str ), 0 );
-  }
-
-  public String getRowGroupSize() {
-    return rowGroupSize;
-  }
-
-  public void setRowGroupSize( String value ) {
-    rowGroupSize = value;
-  }
-
-  public String getCompressionType() {
-    return StringUtil.isVariable( compressionType ) ? compressionType : getCompressionType( null ).toString();
-  }
-
-  public void setCompressionType( String value ) {
-    compressionType =
-        StringUtil.isVariable( value ) ? value : parseFromToString( value, CompressionType.values(), null ).name();
-  }
-
-  public CompressionType getCompressionType( VariableSpace vspace ) {
-    return parseReplace( compressionType, vspace, str -> CompressionType.valueOf( str ), CompressionType.NONE );
-  }
-
-  public String getParquetVersion() {
-    return StringUtil.isVariable( parquetVersion ) ? parquetVersion : getParquetVersion( null ).toString();
-  }
-
-  public void setParquetVersion( String value ) {
-    parquetVersion =
-        StringUtil.isVariable( value ) ? value : parseFromToString( value, ParquetVersion.values(), null ).name();
-  }
-
-  public ParquetVersion getParquetVersion( VariableSpace vspace ) {
-    return parseReplace( parquetVersion, vspace, str -> ParquetVersion.valueOf( str ), ParquetVersion.PARQUET_1 );
-  }
-
-  public int getDataPageSize( VariableSpace vspace ) {
-    return parseReplace( dataPageSize, vspace, s -> Integer.parseInt( s ), 0 );
-  }
-
-  public String getDataPageSize() {
-    return dataPageSize;
-  }
-
-  public void setDataPageSize( String dataPageSize ) {
-    this.dataPageSize = dataPageSize;
-  }
-
-  public int getDictPageSize( VariableSpace vspace ) {
-    if ( getEncodingType( vspace ).equals( EncodingType.DICTIONARY ) ) {
-      return parseReplace( dictPageSize, vspace, s -> Integer.parseInt( s ), 0 );
-    } else {
-      return 0;
-    }
-  }
-
-  public String getDictPageSize() {
-    return dictPageSize;
-  }
-
-  public void setDictPageSize( String dictPageSize ) {
-    this.dictPageSize = dictPageSize;
-  }
-
-  private <T> T parseReplace( String value, VariableSpace vspace, Function<String, T> parser, T defaultValue ) {
-    String replaced = vspace != null ? vspace.environmentSubstitute( value ) : value;
-    if ( !Utils.isEmpty( replaced ) ) {
-      try {
-        return parser.apply( replaced );
-      } catch ( Exception e ) {
-        // ignored
-      }
-    }
-    return defaultValue;
-  }
-
-  public String[] getEncodingTypes() {
-    return getStrings( EncodingType.values() );
-  }
-
-  public String[] getCompressionTypes() {
-    return getStrings( CompressionType.values() );
-  }
-
-  public String[] getVersionTypes() {
-    return getStrings( ParquetVersion.values() );
-  }
-
-  public static enum CompressionType {
-    NONE( getMsg( "ParquetOutput.CompressionType.NONE" ) ), SNAPPY( "Snappy" ), GZIP( "GZIP" ), LZO( "LZO" );
-
-    private final String uiName;
-
-    private CompressionType( String name ) {
-      this.uiName = name;
-    }
-
-    @Override
-    public String toString() {
-      return uiName;
-    }
-  }
-
-  public static enum EncodingType {
-    PLAIN( getMsg( "ParquetOutput.EncodingType.PLAIN" ) ), DICTIONARY( getMsg(
-        "ParquetOutput.EncodingType.DICTIONARY" ) ), BIT_PACKED( getMsg(
-            "ParquetOutput.EncodingType.BIT_PACKED" ) ), RLE( getMsg( "ParquetOutput.EncodingType.RLE" ) );
-
-    private final String uiName;
-
-    private EncodingType( String name ) {
-      this.uiName = name;
-    }
-
-    @Override
-    public String toString() {
-      return uiName;
-    }
-  }
-
-  public static enum ParquetVersion {
-    PARQUET_1( "Parquet 1.0" ), PARQUET_2( "Parquet 2.0" );
-
-    private final String uiName;
-
-    private ParquetVersion( String name ) {
-      this.uiName = name;
-    }
-
-    @Override
-    public String toString() {
-      return uiName;
-    }
-  }
-
-  protected static <T> String[] getStrings( T[] objects ) {
-    String[] names = new String[objects.length];
-    int i = 0;
-    for ( T obj : objects ) {
-      names[i++] = obj.toString();
-    }
-    return names;
-  }
-
-  protected static <T> T parseFromToString( String str, T[] values, T defaultValue ) {
-    if ( !Utils.isEmpty( str ) ) {
-      for ( T type : values ) {
-        if ( str.equals( type.toString() ) ) {
-          return type;
-        }
-      }
-    }
-    return defaultValue;
-  }
-
-  private static String getMsg( String key ) {
-    return BaseMessages.getString( PKG, key );
-  }
 }

--- a/kettle-plugins/formats/src/main/resources/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/messages/messages_en_US.properties
+++ b/kettle-plugins/formats/src/main/resources/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/messages/messages_en_US.properties
@@ -18,10 +18,3 @@ ParquetOutputDialog.Options.RowSize=Row group size (MB):
 ParquetOutputDialog.Options.PageSize=Data page size (KB):
 ParquetOutputDialog.Options.Encoding=Encoding:
 ParquetOutputDialog.Options.DictPageSize=Dictionary page size (KB):
-
-ParquetOutput.EncodingType.PLAIN=Plain
-ParquetOutput.EncodingType.DICTIONARY=Dictionary
-ParquetOutput.EncodingType.BIT_PACKED=Bit packed
-ParquetOutput.EncodingType.RLE=RLE
-
-ParquetOutput.CompressionType.NONE=None


### PR DESCRIPTION
…, to receive them in spark in the same way - environment substitute, variable space, parse integers
should come together with
pentaho/pentaho-karaf-assembly#373
https://github.com/pentaho/pentaho-ee/pull/634