### PR TITLE
[BACKLOG-19044] Kafka: Move consumer Options to be stored as attributes

### DIFF
--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputMeta.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputMeta.java
@@ -96,6 +96,9 @@ public class KafkaConsumerInputMeta extends StepWithMappingMeta implements StepM
   public static final String CONNECTION_TYPE = "connectionType";
   public static final String DIRECT_BOOTSTRAP_SERVERS = "directBootstrapServers";
   public static final String ADVANCED_CONFIG = "advancedConfig";
+  public static final String CONFIG_OPTION = "option";
+  public static final String OPTION_PROPERTY = "property";
+  public static final String OPTION_VALUE = "value";
   public static final String TOPIC_FIELD_NAME = TOPIC;
   public static final String OFFSET_FIELD_NAME = "offset";
   public static final String PARTITION_FIELD_NAME = "partition";
@@ -241,7 +244,14 @@ public class KafkaConsumerInputMeta extends StepWithMappingMeta implements StepM
     Optional.ofNullable( XMLHandler.getSubNode( stepnode, ADVANCED_CONFIG ) ).map( node -> node.getChildNodes() )
         .ifPresent( nodes -> IntStream.range( 0, nodes.getLength() ).mapToObj( nodes::item )
             .filter( node -> node.getNodeType() == Node.ELEMENT_NODE )
-            .forEach( node -> config.put( node.getNodeName(), node.getTextContent() ) ) );
+            .forEach( node -> {
+              if ( CONFIG_OPTION.equals( node.getNodeName() ) ) {
+                config.put( node.getAttributes().getNamedItem( OPTION_PROPERTY ).getTextContent(),
+                            node.getAttributes().getNamedItem( OPTION_VALUE ).getTextContent() );
+              } else {
+                config.put( node.getNodeName(), node.getTextContent() );
+              }
+            } ) );
   }
 
   protected void setField( KafkaConsumerField field ) {
@@ -529,7 +539,8 @@ public class KafkaConsumerInputMeta extends StepWithMappingMeta implements StepM
 
     retval.append( "    " ).append( XMLHandler.openTag( ADVANCED_CONFIG ) ).append( Const.CR );
     getConfig().forEach( ( key, value ) -> retval.append( "        " )
-        .append( XMLHandler.addTagValue( (String) key, (String) value ) ) );
+        .append( XMLHandler.addTagValue( CONFIG_OPTION, "", true,
+                              OPTION_PROPERTY, (String) key, OPTION_VALUE, (String) value ) ) );
     retval.append( "    " ).append( XMLHandler.closeTag( ADVANCED_CONFIG ) ).append( Const.CR );
 
     return retval.toString();

--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaProducerOutputMeta.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaProducerOutputMeta.java
@@ -79,6 +79,9 @@ public class KafkaProducerOutputMeta extends BaseStepMeta implements StepMetaInt
   public static final String KEY_FIELD = "keyField";
   public static final String MESSAGE_FIELD = "messageField";
   public static final String ADVANCED_CONFIG = "advancedConfig";
+  public static final String CONFIG_OPTION = "option";
+  public static final String OPTION_PROPERTY = "property";
+  public static final String OPTION_VALUE = "value";
 
   private static Class<?> PKG = KafkaProducerOutput.class; // for i18n purposes, needed by Translator2!!   $NON-NLS-1$
 
@@ -144,7 +147,14 @@ public class KafkaProducerOutputMeta extends BaseStepMeta implements StepMetaInt
     Optional.ofNullable( XMLHandler.getSubNode( stepnode, ADVANCED_CONFIG ) ).map( node -> node.getChildNodes() )
         .ifPresent( nodes -> IntStream.range( 0, nodes.getLength() ).mapToObj( nodes::item )
             .filter( node -> node.getNodeType() == Node.ELEMENT_NODE )
-            .forEach( node -> config.put( node.getNodeName(), node.getTextContent() ) ) );
+            .forEach( node -> {
+              if ( CONFIG_OPTION.equals( node.getNodeName() ) ) {
+                config.put( node.getAttributes().getNamedItem( OPTION_PROPERTY ).getTextContent(),
+                  node.getAttributes().getNamedItem( OPTION_VALUE ).getTextContent() );
+              } else {
+                config.put( node.getNodeName(), node.getTextContent() );
+              }
+            } ) );
   }
 
   @Override public void setDefault() {
@@ -267,7 +277,8 @@ public class KafkaProducerOutputMeta extends BaseStepMeta implements StepMetaInt
     retval.append( "    " ).append( XMLHandler.addTagValue( MESSAGE_FIELD, messageField ) );
     retval.append( "    " ).append( XMLHandler.openTag( ADVANCED_CONFIG ) ).append( Const.CR );
     getConfig().forEach( ( key, value ) -> retval.append( "        " )
-        .append( XMLHandler.addTagValue( (String) key, (String) value ) ) );
+      .append( XMLHandler.addTagValue( CONFIG_OPTION, "", true,
+        OPTION_PROPERTY, (String) key, OPTION_VALUE, (String) value ) ) );
     retval.append( "    " ).append( XMLHandler.closeTag( ADVANCED_CONFIG ) ).append( Const.CR );
 
     return retval.toString();

--- a/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputMetaTest.java
+++ b/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputMetaTest.java
@@ -111,8 +111,8 @@ public class KafkaConsumerInputMetaTest {
         + "    <OutputField kafkaName=\"offset\" type=\"Integer\">seven</OutputField>\n"
         + "    <OutputField kafkaName=\"timestamp\" type=\"Integer\">eight</OutputField>\n"
         + "    <advancedConfig>\n"
-        + "        <advanced.property1>advancedPropertyValue1</advanced.property1>\n"
-        + "        <advanced.property2>advancedPropertyValue2</advanced.property2>\n"
+        + "        <option property=\"advanced.property1\" value=\"advancedPropertyValue1\"></option>\n"
+        + "        <option property=\"advanced.property2\" value=\"advancedPropertyValue2\"></option>\n"
         + "    </advancedConfig>\n"
         + "    <cluster_schema />\n"
         + "    <remotesteps>\n"
@@ -224,8 +224,8 @@ public class KafkaConsumerInputMetaTest {
       + "    <OutputField kafkaName=\"offset\"  type=\"Integer\" >off</OutputField>" + Const.CR
       + "    <OutputField kafkaName=\"timestamp\"  type=\"Integer\" >time</OutputField>" + Const.CR
       + "    <advancedConfig>" + Const.CR
-      + "        <advanced.property1>advancedPropertyValue1</advanced.property1>" + Const.CR
-      + "        <advanced.property2>advancedPropertyValue2</advanced.property2>" + Const.CR
+      + "        <option property=\"advanced.property1\"  value=\"advancedPropertyValue1\" />" + Const.CR
+      + "        <option property=\"advanced.property2\"  value=\"advancedPropertyValue2\" />" + Const.CR
       + "    </advancedConfig>" + Const.CR,
       meta.getXML() );
 

--- a/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaProducerOutputMetaTest.java
+++ b/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaProducerOutputMetaTest.java
@@ -98,8 +98,8 @@ public class KafkaProducerOutputMetaTest {
         + "    <keyField>three</keyField>\n"
         + "    <messageField>four</messageField>\n"
         + "    <advancedConfig>\n"
-        + "        <advanced.property1>advancedPropertyValue1</advanced.property1>\n"
-        + "        <advanced.property2>advancedPropertyValue2</advanced.property2>\n"
+        + "        <option property=\"advanced.property1\" value=\"advancedPropertyValue1\" />\n"
+        + "        <option property=\"advanced.property2\" value=\"advancedPropertyValue2\" />\n"
         + "    </advancedConfig>\n"
         + "    <cluster_schema />\n"
         + "    <remotesteps>\n"
@@ -154,8 +154,8 @@ public class KafkaProducerOutputMetaTest {
         + "    <keyField>fieldOne</keyField>" + Const.CR
         + "    <messageField>message</messageField>" + Const.CR
         + "    <advancedConfig>" + Const.CR
-        + "        <advanced.property1>advancedPropertyValue1</advanced.property1>" + Const.CR
-        + "        <advanced.property2>advancedPropertyValue2</advanced.property2>" + Const.CR
+        + "        <option property=\"advanced.property1\"  value=\"advancedPropertyValue1\" />" + Const.CR
+        + "        <option property=\"advanced.property2\"  value=\"advancedPropertyValue2\" />" + Const.CR
         + "    </advancedConfig>" + Const.CR, meta.getXML()
     );
   }

--- a/kettle-plugins/kafka/src/test/resources/abortParent.ktr
+++ b/kettle-plugins/kafka/src/test/resources/abortParent.ktr
@@ -463,8 +463,8 @@
     <OutputField kafkaName="offset" type="Integer">Offset</OutputField>
     <OutputField kafkaName="timestamp" type="Integer">Timestamp</OutputField>
     <advancedConfig>
-      <auto.offset.reset>latest</auto.offset.reset>
-      <security.protocol>PLAINTEXT</security.protocol>
+      <option property="auto.offset.reset" value="latest" />
+      <option property="security.protocol" value="PLAINTEXT" />
     </advancedConfig>
     <cluster_schema />
     <remotesteps>


### PR DESCRIPTION
If a user entered a string with a space for the property the saving of
the KTR would break since the property is used as a tag. Moving property
to an attribute