### PR TITLE
[BAD-637] Hadoop File Input: TextFileImportWizardPage dlg: Cannot "Ge…

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputDialog.java
@@ -104,7 +104,6 @@ import org.pentaho.di.trans.steps.file.BaseFileField;
 import org.pentaho.di.trans.steps.fileinput.text.TextFileFilter;
 import org.pentaho.di.trans.steps.fileinput.text.TextFileInputMeta;
 import org.pentaho.di.trans.steps.fileinput.text.TextFileInputUtils;
-import org.pentaho.di.trans.steps.textfileinput.TextFileInputField;
 import org.pentaho.di.ui.core.dialog.EnterNumberDialog;
 import org.pentaho.di.ui.core.dialog.EnterSelectionDialog;
 import org.pentaho.di.ui.core.dialog.EnterTextDialog;
@@ -2791,7 +2790,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
           wFields.clearAll( false );
 
           for ( int i = 0; i < fields.size(); i++ ) {
-            TextFileInputField field = (TextFileInputField) fields.get( i );
+            BaseFileField field = (BaseFileField) fields.get( i );
             if ( !field.isIgnored() && field.getLength() > 0 ) {
               TableItem item = new TableItem( wFields.table, SWT.NONE );
               item.setText( 1, field.getName() );
@@ -2861,13 +2860,13 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
       // See if positions are skipped, if this is the case, add dummy fields...
       if ( f.getPosition() != prevEnd ) {
         // gap
-        TextFileInputField field = new TextFileInputField( "Dummy" + dummynr, prevEnd, f.getPosition() - prevEnd );
+        BaseFileField field = new BaseFileField( "Dummy" + dummynr, prevEnd, f.getPosition() - prevEnd );
         field.setIgnored( true ); // don't include in result by default.
         fields.add( field );
         dummynr++;
       }
 
-      TextFileInputField field = new TextFileInputField( f.getName(), f.getPosition(), f.getLength() );
+      BaseFileField field = new BaseFileField( f.getName(), f.getPosition(), f.getLength() );
       field.setType( f.getType() );
       field.setIgnored( false );
       field.setFormat( f.getFormat() );
@@ -2885,7 +2884,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
     }
 
     if ( info.inputFields.length == 0 ) {
-      TextFileInputField field = new TextFileInputField( "Field1", 0, maxsize );
+      BaseFileField field = new BaseFileField( "Field1", 0, maxsize );
       fields.add( field );
     } else {
       // Take the last field and see if it reached until the maximum...
@@ -2895,7 +2894,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
       int len = f.getLength();
       if ( pos + len < maxsize ) {
         // If not, add an extra trailing field!
-        TextFileInputField field = new TextFileInputField( "Dummy" + dummynr, pos + len, maxsize - pos - len );
+        BaseFileField field = new BaseFileField( "Dummy" + dummynr, pos + len, maxsize - pos - len );
         field.setIgnored( true ); // don't include in result by default.
         fields.add( field );
         dummynr++;


### PR DESCRIPTION
…t Fields" if the "Fixed" width file-type selected

 - replaced deprecated TextFileInputField with BaseFileField