### PR TITLE
[BACKLOG-19399] AEL Spark - Not getting Step Metrics for Avro and Parquet Output steps

### DIFF
--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/output/AvroOutput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/output/AvroOutput.java
@@ -87,7 +87,9 @@ public class AvroOutput extends BaseStep implements StepInterface {
             outputData[i] = currentRow[inputRowIndex];
           }
         }
-        data.writer.write( new RowMetaAndData( outputRMI, outputData ) );
+        RowMetaAndData row = new RowMetaAndData( outputRMI, outputData );
+        data.writer.write( row );
+        putRow( row.getRowMeta(), row.getData() );
         return true;
       } else {
         // no more input to be expected...


### PR DESCRIPTION
This PR is a cherry-pick from master https://github.com/pentaho/big-data-plugin/pull/1120/commits/97303fb27170c2c51545ca4b3f193df99bf6a9dd