### PR TITLE
[PPP-3892] - Use of vulnerable component org.codehaus.jackson : jacks…

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -75,16 +75,6 @@
       <version>${dependency.avro.revision}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>${dependency.jackson.revision}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>${dependency.jackson.revision}</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.core</groupId>
       <artifactId>commands</artifactId>
       <version>${dependency.commands.revision}</version>

--- a/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
+++ b/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
@@ -53,7 +53,6 @@
                 <include>org.apache.httpcomponents:httpclient</include>
                 <include>org.apache.httpcomponents:httpcore</include>
                 <include>org.codehaus.jackson:jackson-core-asl</include>
-                <include>org.codehaus.jackson:jackson-mapper-asl</include>
                 <include>net.java.dev.jets3t:jets3t</include>
                 <include>jline:jline</include>
                 <include>com.googlecode.json-simple:json-simple</include>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -542,20 +542,10 @@
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
       <version>2.4.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.2</version>
-    </dependency>
+    </dependency>    
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-jaxrs</artifactId>
-      <version>1.9.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
       <version>1.9.2</version>
     </dependency>
     <dependency>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -145,7 +145,6 @@
         <include>org.codehaus.groovy:groovy</include>
         <include>org.codehaus.jackson:jackson-core-asl</include>
         <include>org.codehaus.jackson:jackson-jaxrs</include>
-        <include>org.codehaus.jackson:jackson-mapper-asl</include>
         <include>org.drools:knowledge-api</include>
         <include>org.drools:drools-compiler</include>
         <include>org.drools:drools-core</include>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -98,16 +98,6 @@
       <version>${avro.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.core</groupId>
       <artifactId>commands</artifactId>
       <version>${commands.version}</version>


### PR DESCRIPTION
…on-mapper-asl : 1.5.2, org.codehaus.jackson : jackson-mapper-asl : 1.9.12, org.codehaus.jackson : jackson-mapper-asl 1.9.13,org.codehaus.jackson:jackson-mapper-asl-1.8.8.jar CVE-2017-7525