### PR TITLE
[PDI-16816] Hadoop File Input misses Environment field in ETL Metadata Injection

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -95,6 +95,7 @@ import org.pentaho.di.core.util.StringUtil;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.vfs.KettleVFS;
 import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.job.entries.copyfiles.JobEntryCopyFiles;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.TransPreviewFactory;
@@ -371,9 +372,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
   private Button wAddResult;
 
-  private TextFileInputMeta input;
-
-  private HadoopFileInputMeta hadoopFileInputMeta;
+  private HadoopFileInputMeta input;
 
   private ToolBar tb;
 
@@ -395,10 +394,9 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
   public HadoopFileInputDialog( Shell parent, Object in, TransMeta transMeta, String sname ) {
     super( parent, (BaseStepMeta) in, transMeta, sname );
-    input = (TextFileInputMeta) in;
-    hadoopFileInputMeta = (HadoopFileInputMeta) input;
-    namedClusterService = hadoopFileInputMeta.getNamedClusterService();
-    hadoopFileInputMeta.setVariableSpace( variables );
+    input = (HadoopFileInputMeta) in;
+    namedClusterService = input.getNamedClusterService();
+    input.setVariableSpace( variables );
     firstClickOnDateLocale = true;
   }
 
@@ -627,7 +625,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
   }
 
   private void showFiles() {
-    TextFileInputMeta tfii = new TextFileInputMeta();
+    HadoopFileInputMeta tfii = new HadoopFileInputMeta();
     getInfo( tfii );
     String[] files = tfii.getFilePaths( transMeta );
     if ( files != null && files.length > 0 ) {
@@ -679,7 +677,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
     ToolItem deleteToolItem = new ToolItem( tb, SWT.PUSH );
     deleteToolItem.setImage( GUIResource.getInstance().getImageDelete() );
-    deleteToolItem.setToolTipText( BaseMessages.getString( PKG, "JobCopyFiles.FilenameDelete.Tooltip" ) );
+    deleteToolItem.setToolTipText( BaseMessages.getString( JobEntryCopyFiles.class, "JobCopyFiles.FilenameDelete.Tooltip" ) );
     deleteToolItem.addSelectionListener( new SelectionAdapter() {
       @Override
       public void widgetSelected( SelectionEvent arg0 ) {
@@ -2038,13 +2036,13 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
   }
 
   /**
-   * Read the data from the TextFileInputMeta object and show it in this dialog.
+   * Read the data from the HadoopFileInputMeta object and show it in this dialog.
    *
    * @param meta
-   *          The TextFileInputMeta object to obtain the data from.
+   *          The HadoopFileInputMeta object to obtain the data from.
    */
-  public void getData( TextFileInputMeta meta ) {
-    final TextFileInputMeta in = meta;
+  public void getData( HadoopFileInputMeta meta ) {
+    final HadoopFileInputMeta in = meta;
 
     wAccFilenames.setSelection( in.isAcceptingFilenames() );
     wPassThruFields.setSelection( in.inputFiles.passingThruFields );
@@ -2059,8 +2057,11 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
       for ( int i = 0; i < in.getFileName().length; i++ ) {
         String sourceUrl = in.getFileName()[i];
-        String clusterName = hadoopFileInputMeta.getClusterNameBy( sourceUrl );
+        String clusterName = input.getClusterNameBy( sourceUrl );
         String environment = STATIC_ENVIRONMENT;
+        if ( in.environment != null && i < in.environment.length && in.environment[i] != null ) {
+          environment = in.environment[i];
+        }
         if ( clusterName != null ) {
           clusterName =
               clusterName.startsWith( HadoopFileInputMeta.LOCAL_SOURCE_FILE ) ? LOCAL_ENVIRONMENT : clusterName;
@@ -2068,7 +2069,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
               clusterName.startsWith( HadoopFileInputMeta.STATIC_SOURCE_FILE ) ? STATIC_ENVIRONMENT : clusterName;
           clusterName = clusterName.startsWith( HadoopFileInputMeta.S3_SOURCE_FILE ) ? S3_ENVIRONMENT : clusterName;
           sourceUrl = clusterName.equals( LOCAL_ENVIRONMENT ) || clusterName.equals( STATIC_ENVIRONMENT )
-            || clusterName.equals( S3_ENVIRONMENT ) ? sourceUrl : hadoopFileInputMeta.getUrlPath( sourceUrl );
+            || clusterName.equals( S3_ENVIRONMENT ) ? sourceUrl : input.getUrlPath( sourceUrl );
           environment = clusterName;
         }
 
@@ -2192,7 +2193,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
     wStepname.selectAll();
   }
 
-  private void getFieldsData( TextFileInputMeta in, boolean insertAtTop ) {
+  private void getFieldsData( HadoopFileInputMeta in, boolean insertAtTop ) {
     for ( int i = 0; i < in.inputFields.length; i++ ) {
       BaseFileField field = in.inputFields[i];
 
@@ -2299,10 +2300,10 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
     dispose();
   }
 
-  private void getInfo( TextFileInputMeta meta ) {
+  private void getInfo( HadoopFileInputMeta meta ) {
     stepname = wStepname.getText(); // return value
 
-    // copy info to TextFileInputMeta class (input)
+    // copy info to HadoopFileInputMeta class (input)
     meta.inputFiles.acceptingFilenames = wAccFilenames.getSelection();
     meta.inputFiles.passingThruFields = wPassThruFields.getSelection();
     meta.inputFiles.acceptingField = wAccField.getText();
@@ -2343,16 +2344,16 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
     Map<String, String> namedClusterURLMappings = new HashMap<String, String>();
     String[] fileNames = new String[wFilenameList.getItems( 1 ).length];
-    String[] nameClusterList = wFilenameList.getItems( 0 );
+    meta.environment = wFilenameList.getItems( 0 );
 
-    for ( int i = 0; i < nameClusterList.length; i++ ) {
-      String sourceNc = nameClusterList[i];
+    for ( int i = 0; i < meta.environment.length; i++ ) {
+      String sourceNc = meta.environment[i];
       sourceNc = sourceNc.equals( LOCAL_ENVIRONMENT ) ? HadoopFileInputMeta.LOCAL_SOURCE_FILE + i : sourceNc;
       sourceNc = sourceNc.equals( STATIC_ENVIRONMENT ) ? HadoopFileInputMeta.STATIC_SOURCE_FILE + i : sourceNc;
       sourceNc = sourceNc.equals( S3_ENVIRONMENT ) ? HadoopFileInputMeta.S3_SOURCE_FILE + i : sourceNc;
       String source = wFilenameList.getItems( 1 )[i];
       if ( !Const.isEmpty( source ) ) {
-        fileNames[i] = hadoopFileInputMeta.loadUrl( source, sourceNc, getMetaStore(), namedClusterURLMappings );
+        fileNames[i] = input.loadUrl( source, sourceNc, getMetaStore(), namedClusterURLMappings );
       } else {
         fileNames[i] = "";
       }
@@ -2363,7 +2364,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
     meta.inputFiles.setFileRequired( wFilenameList.getItems( 3 ) );
     meta.inputFiles.setIncludeSubFolders( wFilenameList.getItems( 4 ) );
 
-    hadoopFileInputMeta.setNamedClusterURLMapping( namedClusterURLMappings );
+    input.setNamedClusterURLMapping( namedClusterURLMappings );
 
     for ( int i = 0; i < nrfields; i++ ) {
       BaseFileField field = new BaseFileField();
@@ -2431,9 +2432,9 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
   // Get the data layout
   private void getCSV() {
-    TextFileInputMeta meta = new TextFileInputMeta();
+    HadoopFileInputMeta meta = new HadoopFileInputMeta();
     getInfo( meta );
-    TextFileInputMeta previousMeta = (TextFileInputMeta) meta.clone();
+    HadoopFileInputMeta previousMeta = (HadoopFileInputMeta) meta.clone();
     FileInputList textFileList = meta.getTextFileList( transMeta );
     InputStream fileInputStream = null;
     InputStream inputStream = null;
@@ -2623,7 +2624,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
   // Preview the data
   private void preview() {
     // Create the XML input step
-    TextFileInputMeta oneMeta = new TextFileInputMeta();
+    HadoopFileInputMeta oneMeta = new HadoopFileInputMeta();
     getInfo( oneMeta );
 
     if ( oneMeta.isAcceptingFilenames() ) {
@@ -2674,7 +2675,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
   // Get the first x lines
   private void first( boolean skipHeaders ) {
-    TextFileInputMeta info = new TextFileInputMeta();
+    HadoopFileInputMeta info = new HadoopFileInputMeta();
     getInfo( info );
 
     try {
@@ -2720,7 +2721,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
 
   // Get the first x lines
   private List<String> getFirst( int nrlines, boolean skipHeaders ) throws KettleException {
-    TextFileInputMeta meta = new TextFileInputMeta();
+    HadoopFileInputMeta meta = new HadoopFileInputMeta();
     getInfo( meta );
     FileInputList textFileList = meta.getTextFileList( transMeta );
 
@@ -2794,7 +2795,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
   }
 
   private void getFixed() {
-    TextFileInputMeta info = new TextFileInputMeta();
+    HadoopFileInputMeta info = new HadoopFileInputMeta();
     getInfo( info );
 
     Shell sh = new Shell( shell, SWT.DIALOG_TRIM | SWT.RESIZE | SWT.MAX | SWT.MIN );
@@ -2864,7 +2865,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
     }
   }
 
-  private Vector<TextFileInputFieldInterface> getFields( TextFileInputMeta info, List<String> rows ) {
+  private Vector<TextFileInputFieldInterface> getFields( HadoopFileInputMeta info, List<String> rows ) {
     Vector<TextFileInputFieldInterface> fields = new Vector<TextFileInputFieldInterface>();
 
     int maxsize = 0;
@@ -3070,7 +3071,7 @@ public class HadoopFileInputDialog extends BaseStepDialog implements StepDialogI
             } else if ( currentPanel.getVfsSchemeDisplayText().equals( S3_ENVIRONMENT ) ) {
               wFilenameList.getActiveTableItem().setText( wFilenameList.getActiveTableColumn() - 1, S3_ENVIRONMENT );
             } else if ( isCluster ) {
-              url = hadoopFileInputMeta.getUrlPath( url );
+              url = input.getUrlPath( url );
               wFilenameList.getActiveTableItem().setText( wFilenameList.getActiveTableColumn() - 1,
                   clusterName );
             }

--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -31,6 +31,7 @@ import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.core.variables.VariableSpace;
@@ -66,6 +67,14 @@ public class HadoopFileInputMeta extends TextFileInputMeta {
   public static final String S3_SOURCE_FILE = "S3-SOURCE-FILE-";
   public static final String S3_DEST_FILE = "S3-DEST-FILE-";
   private final NamedClusterService namedClusterService;
+
+  /** The environment of the selected file/folder */
+  @Injection( name = "ENVIRONMENT", group = "FILENAME_LINES" )
+  public String[] environment = {};
+
+  public HadoopFileInputMeta() {
+    this( null, null, null );
+  }
 
   public HadoopFileInputMeta( NamedClusterService namedClusterService,
                               RuntimeTestActionService runtimeTestActionService, RuntimeTester runtimeTester ) {

--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -201,7 +201,7 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
   private TableView wFields;
   private FormData fdFields;
 
-  private TextFileOutputMeta input;
+  private HadoopFileOutputMeta input;
 
   private Button wMinWidth;
   private Listener lsMinWidth;
@@ -240,11 +240,10 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
 
   public HadoopFileOutputDialog( Shell parent, Object in, TransMeta transMeta, String sname ) {
     super( parent, (BaseStepMeta) in, transMeta, sname );
-    input = (TextFileOutputMeta) in;
-    HadoopFileOutputMeta hadoopFileOutputMeta = (HadoopFileOutputMeta) in;
-    namedClusterService = hadoopFileOutputMeta.getNamedClusterService();
-    runtimeTestActionService = hadoopFileOutputMeta.getRuntimeTestActionService();
-    runtimeTester = hadoopFileOutputMeta.getRuntimeTester();
+    input = (HadoopFileOutputMeta) in;
+    namedClusterService = input.getNamedClusterService();
+    runtimeTestActionService = input.getRuntimeTestActionService();
+    runtimeTester = input.getRuntimeTester();
     inputFields = new HashMap<String, Integer>();
   }
 
@@ -844,9 +843,9 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     wFormat.setText( BaseMessages.getString( BASE_PKG, "TextFileOutputDialog.Format.Label" ) );
     props.setLook( wFormat );
 
-    for ( int i = 0; i < TextFileOutputMeta.formatMapperLineTerminator.length; i++ ) {
+    for ( int i = 0; i < HadoopFileOutputMeta.formatMapperLineTerminator.length; i++ ) {
       wFormat.add( BaseMessages.getString( BASE_PKG, "TextFileOutputDialog.Format."
-        + TextFileOutputMeta.formatMapperLineTerminator[i] ) );
+        + HadoopFileOutputMeta.formatMapperLineTerminator[i] ) );
     }
     wFormat.select( 0 );
     wFormat.addModifyListener( lsMod );
@@ -1465,8 +1464,8 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     }
     if ( input.getFileFormat() != null ) {
       wFormat.select( 0 ); // default if not found: CR+LF
-      for ( int i = 0; i < TextFileOutputMeta.formatMapperLineTerminator.length; i++ ) {
-        if ( input.getFileFormat().equalsIgnoreCase( TextFileOutputMeta.formatMapperLineTerminator[i] ) ) {
+      for ( int i = 0; i < HadoopFileOutputMeta.formatMapperLineTerminator.length; i++ ) {
+        if ( input.getFileFormat().equalsIgnoreCase( HadoopFileOutputMeta.formatMapperLineTerminator[i] ) ) {
           wFormat.select( i );
         }
       }
@@ -1552,7 +1551,7 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     dispose();
   }
 
-  private void getInfo( TextFileOutputMeta tfoi ) {
+  private void getInfo( HadoopFileOutputMeta tfoi ) {
     String ncName = ( (HadoopFileOutputMeta) tfoi ).getSourceConfigurationName();
     String fileName = wFilename.getText();
 
@@ -1565,7 +1564,7 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     tfoi.setFileName( fileName );
     tfoi.setDoNotOpenNewFileInit( wDoNotOpenNewFileInit.getSelection() );
     tfoi.setCreateParentFolder( wCreateParentFolder.getSelection() );
-    tfoi.setFileFormat( TextFileOutputMeta.formatMapperLineTerminator[wFormat.getSelectionIndex()] );
+    tfoi.setFileFormat( HadoopFileOutputMeta.formatMapperLineTerminator[wFormat.getSelectionIndex()] );
     tfoi.setFileCompression( wCompression.getText() );
     tfoi.setEncoding( wEncoding.getText() );
     tfoi.setSeparator( wSeparator.getText() );

--- a/kettle-plugins/hdfs/src/main/resources/org/pentaho/big/data/kettle/plugins/hdfs/trans/messages/messages_en_US.properties
+++ b/kettle-plugins/hdfs/src/main/resources/org/pentaho/big/data/kettle/plugins/hdfs/trans/messages/messages_en_US.properties
@@ -19,6 +19,7 @@ HadoopFileInputDialog.Connection.Error.title=Unable to Connect
 HadoopFileInputDialog.Connection.error=You don''t seem to be getting a connection to the Hadoop Cluster.  Check the cluster configuration you''re using.
 
 #File Tab
+HadoopFileInput.Injection.ENVIRONMENT=The environment of the selected file/folder.
 HadoopFileOutput.Injection.FILENAME=The name of the file to write to.
 HadoopFileOutput.Injection.CREATE_PARENT_FOLDER=This option indicates whether a parent folder should be created for the file when it''s created.
 HadoopFileOutput.Injection.DO_NOT_CREATE_FILE_AT_STARTUP=This option will not write empty files if no rows are processed.


### PR DESCRIPTION
- injectable "Environment" field was added
- new HadoopFileInputMeta constructor was added
- new message string was added