### PR TITLE
[BAD-1420]-remove cdh512 and emr58 from big-data-plugin

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -156,19 +156,6 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-cdh512-package</artifactId>
-      <version>${pentaho-hadoop-shims-cdh512.version}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-cdh513-package</artifactId>
       <version>${pentaho-hadoop-shims-cdh513.version}</version>
       <type>zip</type>
@@ -210,19 +197,6 @@
       <groupId>org.pentaho</groupId>
       <artifactId>pentaho-hadoop-shims-mapr60-package</artifactId>
       <version>${pentaho-hadoop-shims-mapr60.version}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.pentaho</groupId>
-      <artifactId>pentaho-hadoop-shims-emr58-package</artifactId>
-      <version>${pentaho-hadoop-shims-emr58.version}</version>
       <type>zip</type>
       <scope>provided</scope>
       <exclusions>
@@ -291,12 +265,6 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-cdh512-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-cdh513-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
@@ -316,12 +284,6 @@
                 <artifactItem>
                   <groupId>org.pentaho</groupId>
                   <artifactId>pentaho-hadoop-shims-mapr60-package</artifactId>
-                  <type>zip</type>
-                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.pentaho</groupId>
-                  <artifactId>pentaho-hadoop-shims-emr58-package</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     <dependency.simple-jndi.revision>1.0.0</dependency.simple-jndi.revision>
     <dependency.xpp3.revision>1.1.4c</dependency.xpp3.revision>
     <dependency.slf4j.revision>1.7.7</dependency.slf4j.revision>
-    <pentaho-hadoop-shims-cdh512.version>8.1.0.0-SNAPSHOT</pentaho-hadoop-shims-cdh512.version>
     <pentaho-hadoop-shims-cdh513.version>8.1.0.0-SNAPSHOT</pentaho-hadoop-shims-cdh513.version>
     <dependency.jets3t.revision>0.9.4</dependency.jets3t.revision>
     <dependency.xstream.revision>1.4.10</dependency.xstream.revision>
@@ -88,7 +87,6 @@
     <dependency.avro.revision>1.6.2</dependency.avro.revision>
     <dependency.cxf.revision>3.0.13</dependency.cxf.revision>
     <dependency.aws-java-sdk.revision>1.7.4</dependency.aws-java-sdk.revision>
-    <pentaho-hadoop-shims-emr58.version>8.1.0.0-SNAPSHOT</pentaho-hadoop-shims-emr58.version>
     <pentaho-hadoop-shims-emr59.version>8.1.0.0-SNAPSHOT</pentaho-hadoop-shims-emr59.version>
     <dependency.osgi.revision>4.3.1</dependency.osgi.revision>
     <kafka-clients.version>0.10.2.1</kafka-clients.version>


### PR DESCRIPTION
Update Big Data Plugin in order to include only the last shim version of CDH and EMR vendors.