### PR TITLE
[BACKLOG-21076] Update the AvroOutput Dialog to support BigDecimal precision and scale.

### DIFF
--- a/kettle-plugins/formats-meta/src/main/java/org/pentaho/big/data/kettle/plugins/formats/avro/output/AvroOutputField.java
+++ b/kettle-plugins/formats-meta/src/main/java/org/pentaho/big/data/kettle/plugins/formats/avro/output/AvroOutputField.java
@@ -143,9 +143,13 @@ public class AvroOutputField implements IAvroOutputField {
   }
 
   public void setPrecision( String precision ) {
-    this.precision = Integer.valueOf( precision );
-    if ( this.precision <= 0 ) {
+    if ( precision == null ) {
       this.precision = AvroSpec.DEFAULT_DECIMAL_PRECISION;
+    } else {
+      this.precision = Integer.valueOf( precision );
+      if ( this.precision <= 0 ) {
+        this.precision = AvroSpec.DEFAULT_DECIMAL_PRECISION;
+      }
     }
   }
 
@@ -154,9 +158,13 @@ public class AvroOutputField implements IAvroOutputField {
   }
 
   public void setScale( String scale ) {
-    this.scale = Integer.valueOf( scale );
-    if ( this.scale < 0 ) {
+    if ( scale == null ) {
       this.scale = AvroSpec.DEFAULT_DECIMAL_SCALE;
+    } else {
+      this.scale = Integer.valueOf( scale );
+      if ( this.scale < 0 ) {
+        this.scale = AvroSpec.DEFAULT_DECIMAL_SCALE;
+      }
     }
   }
 }


### PR DESCRIPTION
@pentaho/moseisley Please review.

Fixes an issue with opening 8.0 transformations with an AvroOutput step.