### PR TITLE
[BACKLOG-21243] MQTT Consumer - Implement Secure Protocol Support

### DIFF
--- a/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilder.java
+++ b/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilder.java
@@ -1,0 +1,198 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.step.mqtt;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.pentaho.di.trans.step.StepInterface;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.pentaho.di.i18n.BaseMessages.getString;
+
+final class MQTTClientBuilder {
+  private static final Class<?> PKG = MQTTClientBuilder.class;
+
+  private static final String UNSECURE_PROTOCOL = "tcp://";
+  private static final String SECURE_PROTOCOL = "ssl://";
+  // the paho library specifies ssl prop names as com.ibm, though not necessarily using the ibm implementations
+  private static final String SSL_PROP_PREFIX = "com.ibm.";
+
+
+  private String broker;
+  private List<String> topics;
+  private String qos = "0";
+  private boolean isSecure;
+  private String username;
+  private String password;
+  private Map<String, String> sslConfig;
+  private MqttCallback callback;
+  private String clientId = MqttAsyncClient.generateClientId();  // default
+  private StepInterface step;
+
+
+  @VisibleForTesting @FunctionalInterface interface ClientFactory {
+    MqttClient getClient( String broker, String clientId, MqttClientPersistence persistence )
+      throws MqttException;
+  }
+
+  @VisibleForTesting ClientFactory clientFactory = MqttClient::new;
+
+  private MQTTClientBuilder() {
+  }
+
+  static MQTTClientBuilder builder() {
+    return new MQTTClientBuilder();
+  }
+
+  MQTTClientBuilder withCallback( MqttCallback callback ) {
+    this.callback = callback;
+    return this;
+  }
+
+  MQTTClientBuilder withBroker( String broker ) {
+    this.broker = broker;
+    return this;
+  }
+
+  MQTTClientBuilder withTopics( List<String> topics ) {
+    this.topics = topics;
+    return this;
+  }
+
+  MQTTClientBuilder withQos( String qos ) {
+    this.qos = qos;
+    return this;
+  }
+
+  MQTTClientBuilder withIsSecure( boolean isSecure ) {
+    this.isSecure = isSecure;
+    return this;
+  }
+
+  MQTTClientBuilder withClientId( String clientId ) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  MQTTClientBuilder withUsername( String username ) {
+    this.username = username;
+    return this;
+  }
+
+  MQTTClientBuilder withPassword( String password ) {
+    this.password = password;
+    return this;
+  }
+
+  MQTTClientBuilder withStep( StepInterface step ) {
+    this.step = step;
+    return this;
+  }
+
+
+  MQTTClientBuilder withSslConfig( Map<String, String> sslConfig ) {
+    this.sslConfig = sslConfig;
+    return this;
+  }
+
+  MqttClient buildAndConnect() throws MqttException {
+    validateArgs();
+
+    String broker = UNSECURE_PROTOCOL + getBroker();
+    MqttClient client = clientFactory.getClient( broker, clientId,
+      new MemoryPersistence() );
+
+    client.setCallback( callback );
+
+    step.getLogChannel().logDebug( "Subscribing to topics with a quality of service level of " + qos );
+
+    client.connect( getOptions() );
+    if ( topics != null && topics.size() > 0 ) {
+      client.subscribe(
+        step.environmentSubstitute( topics.toArray( new String[ 0 ] ) ),
+        initializedIntAray( Integer.parseInt( step.environmentSubstitute( this.qos ) ) )
+      );
+    }
+    return client;
+  }
+
+  private String getBroker() {
+    return step.environmentSubstitute( this.broker );
+  }
+
+
+  private void validateArgs() {
+    // expectation that the broker will contain the server:port.
+    checkArgument( getBroker().matches( "^[^ :/]+:\\d+" ),
+      getString( PKG, "MQTTInput.Error.ConnectionURL" ) );
+    try {
+      int qosVal = Integer.parseInt( step.environmentSubstitute( this.qos ) );
+      checkArgument( qosVal >= 0 && qosVal <= 2 );
+    } catch ( Exception e ) {
+      String errorMsg = getString( PKG, "MQTTClientBuilder.Error.QOS",
+         step.getStepMeta().getName(), step.environmentSubstitute( qos ) );
+      step.getLogChannel().logError( errorMsg );
+      throw new IllegalArgumentException( errorMsg );
+    }
+  }
+
+  private int[] initializedIntAray( int val ) {
+    return IntStream.range( 0, topics.size() ).map( i -> val ).toArray();
+  }
+
+  private MqttConnectOptions getOptions() {
+    MqttConnectOptions options = new MqttConnectOptions();
+
+    if ( isSecure ) {
+      setSSLProps( options );
+    }
+    if ( username != null ) {
+      options.setUserName( username );
+    }
+    if ( password != null ) {
+      options.setPassword( password.toCharArray() );
+    }
+    return options;
+  }
+
+  private void setSSLProps( MqttConnectOptions options ) {
+    Properties props = new Properties();
+    props.putAll(
+      sslConfig.entrySet().stream()
+        .collect( Collectors.toMap( e -> SSL_PROP_PREFIX + e.getKey(),
+          Map.Entry::getValue ) ) );
+    options.setSSLProperties( props );
+  }
+}

--- a/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumer.java
+++ b/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumer.java
@@ -25,7 +25,6 @@ package org.pentaho.di.trans.step.mqtt;
 import com.google.common.base.Preconditions;
 import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -66,19 +65,7 @@ public class MQTTConsumer extends BaseStreamStep implements StepInterface {
       logger.error( getString( PKG, "MQTTInput.Error.FailureGettingFields" ), e );
     }
     window = new FixedTimeStreamWindow<>( subtransExecutor, rowMeta, getDuration(), getBatchSize() );
-    try {
-      source = MQTTStreamSource.builder()
-        .withBroker( mqttConsumerMeta.getMqttServer() )
-        .withTopics( mqttConsumerMeta.getTopics() )
-        .withQos( mqttConsumerMeta.getQos() )
-        .withVariables( this )
-        .withBaseStep( this )
-        .build();
-    } catch ( NumberFormatException e ) {
-      log.logError(
-        BaseMessages.getString( PKG, "MQTTConsumer.Error.QOS", environmentSubstitute( mqttConsumerMeta.getQos() ) ) );
-      return false;
-    }
+    source = new MQTTStreamSource( mqttConsumerMeta, this );
     return init;
   }
 

--- a/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSource.java
+++ b/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTStreamSource.java
@@ -23,30 +23,20 @@
 package org.pentaho.di.trans.step.mqtt;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
-import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttClient;
-import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
-import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.pentaho.di.core.variables.VariableSpace;
-import org.pentaho.di.core.variables.Variables;
-import org.pentaho.di.trans.streaming.common.BaseStreamStep;
 import org.pentaho.di.trans.streaming.common.BlockingQueueStreamSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.IntStream;
 
+import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Collections.singletonList;
-import static org.pentaho.di.i18n.BaseMessages.getString;
 
 /**
  * StreamSource implementation which supplies a blocking iterable of MQTT messages based on the specified topics,
@@ -55,18 +45,8 @@ import static org.pentaho.di.i18n.BaseMessages.getString;
 public class MQTTStreamSource extends BlockingQueueStreamSource<List<Object>> {
   private final Logger logger = LoggerFactory.getLogger( this.getClass() );
   private static final Class<?> PKG = MQTTStreamSource.class;
-  private static final String UNSECURE_PROTOCOL = "tcp://";
-  private static final String SECURE_PROTOCOL = "ssl://";
-
-  private final String broker;
-  private final List<String> topics;
-  private final int qos;
-  private final boolean isSecure;
-  private final String username;
-  private final String password;
-
-  private final Map<String, String> sslConfig;
-
+  private final MQTTConsumerMeta mqttConsumerMeta;
+  private final MQTTConsumer mqttConsumer;
 
   @VisibleForTesting protected MqttClient mqttClient;
 
@@ -76,7 +56,8 @@ public class MQTTStreamSource extends BlockingQueueStreamSource<List<Object>> {
     }
 
     @Override public void messageArrived( String topic, MqttMessage message ) throws Exception {
-      acceptRows( singletonList( ImmutableList.of( new String( message.getPayload() ), topic ) ) );
+      acceptRows( singletonList(
+        ImmutableList.of( new String( message.getPayload(), defaultCharset() ), topic ) ) );
     }
 
     @Override public void deliveryComplete( IMqttDeliveryToken token ) {
@@ -84,46 +65,24 @@ public class MQTTStreamSource extends BlockingQueueStreamSource<List<Object>> {
     }
   };
 
-  public MQTTStreamSource( String broker, List<String> topics, int qualityOfService,
-                           BaseStreamStep mqttConsumer, boolean isSecure, String username,
-                           String password, Map<String, String> sslConfig ) {
+  MQTTStreamSource( MQTTConsumerMeta mqttConsumerMeta, MQTTConsumer mqttConsumer ) {
     super( mqttConsumer );
-    this.broker = broker;
-    this.topics = topics;
-    this.qos = qualityOfService;
-    this.isSecure = isSecure;
-    this.username = username;
-    this.password = password;
-    this.sslConfig = sslConfig;
+    this.mqttConsumer = mqttConsumer;
+    this.mqttConsumerMeta = mqttConsumerMeta;
   }
-
-  //  public MQTTStreamSource( String broker, List<String> topics, int qualityOfService,
-  //                           MQTTConsumer mqttConsumer, Map<String, String> sslConfig ) {
-  //    this( broker, topics, qualityOfService, mqttConsumer );
-  //    this.sslConfig = sslConfig;
-  //  }
 
   @Override public void open() {
     try {
-      Preconditions
-        .checkArgument( broker.matches( "^[^ :/]+:\\d+" ), getString( PKG, "MQTTInput.Error.ConnectionURL" ) );
-      // expectation that the broker will contain the server:port.
-      mqttClient = new MqttClient(
-        UNSECURE_PROTOCOL + broker, MqttAsyncClient.generateClientId(), new MemoryPersistence() );
-
-
-      mqttClient.connect( new MqttConnectOptions() ); // keeping default ops for now
-      mqttClient.setCallback( callback );
-      streamStep.logDebug( "Subscribing to topics with a quality of service level of " + qos );
-      mqttClient.subscribe( topics.toArray( new String[ 0 ] ), initializedIntAray( qos ) );
+      mqttClient = MQTTClientBuilder.builder()
+        .withBroker( mqttConsumerMeta.getMqttServer() )
+        .withTopics( mqttConsumerMeta.getTopics() )
+        .withQos( mqttConsumerMeta.getQos() )
+        .withStep( mqttConsumer )
+        .withCallback( callback )
+        .buildAndConnect();
     } catch ( MqttException e ) {
       logger.error( e.getMessage(), e );
     }
-  }
-
-  // create an int array filled with the same val
-  private int[] initializedIntAray( int val ) {
-    return IntStream.range( 0, topics.size() ).map( i -> val ).toArray();
   }
 
   @Override public void close() {
@@ -137,82 +96,4 @@ public class MQTTStreamSource extends BlockingQueueStreamSource<List<Object>> {
 
   }
 
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  public static final class Builder {
-    private String broker;
-    private List<String> topics;
-    private String qos;
-    private boolean isSecure;
-    private String username;
-    private String password;
-    private Map<String, String> sslConfig;
-    private BaseStreamStep baseStreamStep;
-    private VariableSpace space = new Variables();
-
-    private Builder() {
-    }
-
-    public Builder withBroker( String broker ) {
-      this.broker = broker;
-      return this;
-    }
-
-    public Builder withTopics( List<String> topics ) {
-      this.topics = topics;
-      return this;
-    }
-
-    public Builder withQos( String qos ) {
-      this.qos = qos;
-      return this;
-    }
-
-    public Builder withIsSecure( boolean isSecure ) {
-      this.isSecure = isSecure;
-      return this;
-    }
-
-    public Builder withUsername( String username ) {
-      this.username = username;
-      return this;
-    }
-
-    public Builder withPassword( String password ) {
-      this.password = password;
-      return this;
-    }
-
-    public Builder withSslConfig( Map<String, String> sslConfig ) {
-      this.sslConfig = sslConfig;
-      return this;
-    }
-
-    public Builder withBaseStep( BaseStreamStep step ) {
-      this.baseStreamStep = step;
-      return this;
-    }
-
-    public Builder withVariables( VariableSpace space ) {
-      this.space = space;
-      return this;
-    }
-
-    public MQTTStreamSource build() {
-      MQTTStreamSource streamSource =
-        new MQTTStreamSource(
-          space.environmentSubstitute( broker ),
-          Arrays.asList( space.environmentSubstitute( topics.toArray( new String[ 0 ] ) ) ),
-          Integer.parseInt( space.environmentSubstitute( this.qos ) ),
-          baseStreamStep,
-          isSecure,
-          space.environmentSubstitute( username ),
-          space.environmentSubstitute( password ),
-          sslConfig );
-      // TODO variable subs for ssl stuff.
-      return streamSource;
-    }
-  }
 }

--- a/kettle-plugins/mqtt/src/main/resources/org/pentaho/di/trans/step/mqtt/messages/messages_en_US.properties
+++ b/kettle-plugins/mqtt/src/main/resources/org/pentaho/di/trans/step/mqtt/messages/messages_en_US.properties
@@ -28,6 +28,8 @@ MQTTProducerDialog.Topic=Topic:
 MQTTProducerDialog.QOS=Quality of Service:
 MQTTProducerDialog.MessageField=Message field:
 
+MQTTClientBuilder.Error.QOS={0} - Quality of Service level {1} is invalid. Please set a level of 0, 1, or 2
+
 MQTTProducer.Error.QOS=MQTT Producer - Quality of Service level {0} is invalid. Please set a level of 0, 1, or 2
 
 MQTTProducer.Log.LineNumber=Linenr

--- a/kettle-plugins/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilderTest.java
+++ b/kettle-plugins/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilderTest.java
@@ -1,0 +1,142 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2018 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.step.mqtt;
+
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
+import org.pentaho.di.i18n.BaseMessages;
+import org.pentaho.di.trans.step.StepInterface;
+import org.pentaho.di.trans.step.StepMeta;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith ( MockitoJUnitRunner.class )
+public class MQTTClientBuilderTest {
+
+  @Mock LogChannelInterface logger;
+  @Mock MqttCallback callback;
+  @Mock MQTTClientBuilder.ClientFactory factory;
+  @Mock MqttClient client;
+  @Mock StepInterface step;
+  @Mock StepMeta meta;
+
+  @Captor ArgumentCaptor<MqttConnectOptions> connectOptsCapture;
+
+  VariableSpace space = new Variables();
+  MQTTClientBuilder builder = MQTTClientBuilder.builder();
+
+  @Before
+  public void before() throws MqttException {
+    builder
+      .withBroker( "127.0.0.1:101010" )
+      .withStep( step );
+    builder.clientFactory = factory;
+    when( factory.getClient( any(), any(), any() ) )
+      .thenReturn( client );
+    when( step.getParentVariableSpace() ).thenReturn( space );
+    when( step.getLogChannel() ).thenReturn( logger );
+    when( step.getStepMeta() ).thenReturn( meta );
+    when( step.getStepMeta().getName() ).thenReturn( "Step Name" );
+    when( step.environmentSubstitute( anyString() ) ).thenAnswer( ( answer -> answer.getArguments()[ 0 ] ) );
+    when( step.environmentSubstitute( any( String[].class ) ) )
+      .thenAnswer( ( answer -> answer.getArguments()[ 0 ] ) );
+  }
+
+  @Test
+  public void testValidBuilderParams() throws MqttException {
+    MqttClient client = builder
+      .withQos( "2" )
+      .withUsername( "user" )
+      .withPassword( "pass" )
+      .withIsSecure( true )
+      .withTopics( Collections.singletonList( "SomeTopic" ) )
+      .withSslConfig( ImmutableMap.of( "ssl.trustStore", "/some/path" ) )
+      .withCallback( callback ).
+        buildAndConnect();
+    verify( client ).setCallback( callback );
+    verify( factory ).getClient( anyString(), anyString(), any( MemoryPersistence.class ) );
+    verify( client ).connect( connectOptsCapture.capture() );
+
+    MqttConnectOptions opts = connectOptsCapture.getValue();
+    assertThat( opts.getUserName(), equalTo( "user" ) );
+    assertThat( opts.getPassword(), equalTo( "pass".toCharArray() ) );
+    Properties props = opts.getSSLProperties();
+    assertThat( props.size(), equalTo( 1 ) );
+    assertThat( props.getProperty( "com.ibm.ssl.trustStore" ), equalTo( "/some/path" ) );
+  }
+
+  @Test
+  public void testFailParsingQOSLevelNotInteger() {
+    try {
+      builder
+        .withQos( "hello" )
+        .buildAndConnect();
+      fail( "Should of failed initialization." );
+    } catch ( Exception e ) {
+      // Initialization failed because QOS level isn't 0, 1 or 2
+      assertTrue( e instanceof IllegalArgumentException );
+    }
+    verify( logger )
+      .logError( BaseMessages.getString( MQTTConsumer.class, "MQTTClientBuilder.Error.QOS", "Step Name", "hello" ) );
+  }
+
+  @Test
+  public void testFailParsingQOSLevelNotInRange() {
+    try {
+      builder
+        .withQos( "72" )
+        .buildAndConnect();
+      fail( "Should of failed initialization." );
+    } catch ( Exception e ) {
+      // Initialization failed because QOS level isn't 0, 1 or 2
+      assertTrue( e instanceof IllegalArgumentException );
+    }
+    verify( logger )
+      .logError( BaseMessages.getString( MQTTConsumer.class, "MQTTClientBuilder.Error.QOS", "Step Name", "72" ) );
+  }
+
+}

--- a/kettle-plugins/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerTest.java
+++ b/kettle-plugins/mqtt/src/test/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerTest.java
@@ -36,16 +36,13 @@ import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
 import org.pentaho.di.core.plugins.PluginRegistry;
 import org.pentaho.di.core.plugins.StepPluginType;
-import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith( MockitoJUnitRunner.class )
@@ -93,17 +90,5 @@ public class MQTTConsumerTest {
     }
   }
 
-  @Test
-  public void testFailParsingQOSLevel() {
-    trans.setVariable( "qos", "hello" );
-    try {
-      trans.prepareExecution( new String[] {} );
-      fail( "Should of failed initialization." );
-    } catch ( KettleException e ) {
-      // Initialization failed because QOS level isn't 0, 1 or 2
-      assertTrue( e.getMessage().contains( BaseMessages.getString( Trans.class, "Trans.Log.FailToInitializeAtLeastOneStep" ) ) );
-    }
 
-    verify( logChannel ).logError( BaseMessages.getString( MQTTConsumer.class, "MQTTConsumer.Error.QOS", "hello" ) );
-  }
 }


### PR DESCRIPTION
Splitting MqttClient construction out so it can be reused by producer.

https://jira.pentaho.com/browse/BACKLOG-21243