### PR TITLE
[BAD-1224]-Amazon EMR Job Executor and Amazon EMR Hive Executor steps fail to run (disable Connect button when jobFlowId is set)

### DIFF
--- a/legacy/src/test/java/org/pentaho/amazon/AbstractAmazonJobExecutorControllerTest.java
+++ b/legacy/src/test/java/org/pentaho/amazon/AbstractAmazonJobExecutorControllerTest.java
@@ -471,4 +471,61 @@ public class AbstractAmazonJobExecutorControllerTest {
     verify( hiveJobExecutorController, never() ).showErrorDialog( anyString(), anyString() );
   }
 
+  @Test
+  public void testHideFields_fieldsArrayIsNull() {
+
+    boolean hideFields = jobExecutorController.hideFields();
+
+    assertEquals( false, hideFields );
+  }
+
+  @Test
+  public void testHideFields_firstFieldInArrayIsNotEmpty() {
+
+    String[] fieldsValues = { "accessKey", "", "" };
+
+    boolean hideFields = jobExecutorController.hideFields( fieldsValues );
+
+    assertEquals( true, hideFields );
+  }
+
+  @Test
+  public void testHideFields_secondFieldInArrayIsNotEmpty() {
+
+    String[] fieldsValues = { "", "secretKey", "" };
+
+    boolean hideFields = jobExecutorController.hideFields( fieldsValues );
+
+    assertEquals( true, hideFields );
+  }
+
+  @Test
+  public void testHideFields_lastFieldInArrayIsNotEmpty() {
+
+    String[] fieldsValues = { "", "", "jobFlowId" };
+
+    boolean hideFields = jobExecutorController.hideFields( fieldsValues );
+
+    assertEquals( true, hideFields );
+  }
+
+  @Test
+  public void testHideFields_lastFieldInArrayIsEmptyAndOtherFieldsIsNotEmpty() {
+
+    String[] fieldsValues = { "accessKey", "secretKey", "" };
+
+    boolean hideFields = jobExecutorController.hideFields( fieldsValues );
+
+    assertEquals( false, hideFields );
+  }
+
+  @Test
+  public void testHideFields_fieldArrayIsFull() {
+
+    String[] fieldsValues = { "accessKey", "secretKey", "jobFlowId" };
+
+    boolean hideFields = jobExecutorController.hideFields( fieldsValues );
+
+    assertEquals( true, hideFields );
+  }
 }


### PR DESCRIPTION
Set Connect button and Emr settings fields disabled when Job Flow Id field is not empty.