### PR TITLE
[BACKLOG-21243] MQTT Consumer - SSL

### DIFF
--- a/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilder.java
+++ b/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTClientBuilder.java
@@ -36,6 +36,7 @@ import org.pentaho.di.trans.step.StepInterface;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -155,6 +156,7 @@ final class MQTTClientBuilder {
     client.setCallback( callback );
 
     step.getLogChannel().logDebug( "Subscribing to topics with a quality of service level of " + qos );
+    step.getLogChannel().logDebug( loggableOptions().toString() );
 
     client.connect( getOptions() );
     if ( topics != null && topics.size() > 0 ) {
@@ -206,6 +208,20 @@ final class MQTTClientBuilder {
       options.setPassword( step.environmentSubstitute( password ).toCharArray() );
     }
     return options;
+  }
+
+  /**
+   * Returns a copy of loggable options with sensitive data stripped.
+   */
+  private MqttConnectOptions loggableOptions() {
+    MqttConnectOptions loggableOptions = getOptions();
+
+    Optional.ofNullable( loggableOptions.getSSLProperties() )
+      .orElseGet( () -> new Properties() )
+      .keySet().stream()
+      .filter( key -> key.toString().toUpperCase().contains( "PASSWORD" ) )
+      .forEach( key -> loggableOptions.getSSLProperties().put( key, "*****" ) );
+    return loggableOptions;
   }
 
   private void setSSLProps( MqttConnectOptions options ) {

--- a/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerDialog.java
+++ b/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerDialog.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
@@ -77,12 +78,13 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
   private Label wlPassword;
   private PasswordTextVar wPassword;
   private Button wUseSSL;
-  private Label wlUseSSL;
   private Label wlSSLProperties;
   private TableView sslTable;
+  private final Point startingDimensions = new Point( 527, 612 );
 
   public MQTTConsumerDialog( Shell parent, Object in, TransMeta tr, String sname ) {
     super( parent, in, tr, sname );
+
     mqttMeta = (MQTTConsumerMeta) in;
   }
 
@@ -109,6 +111,13 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
 
   @Override protected String getDialogTitle() {
     return BaseMessages.getString( PKG, "MQTTConsumerDialog.Shell.Title" );
+  }
+
+  @Override
+  public void setSize() {
+    setSize( shell );  // sets shell location and preferred size
+    shell.setMinimumSize( startingDimensions );
+    shell.setSize( startingDimensions ); // override the preferred size
   }
 
   @Override protected void buildSetup( Composite wSetupComp ) {
@@ -222,7 +231,7 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
   }
 
   private void buildSecurityTab() {
-    wSecurityTab = new CTabItem( wTabFolder, SWT.NONE );
+    wSecurityTab = new CTabItem( wTabFolder, SWT.NONE, 1 );
     wSecurityTab.setText( BaseMessages.getString( PKG, "MQTTDialog.Security.Tab" ) );
 
     wSecurityComp = new Composite( wTabFolder, SWT.NONE );
@@ -285,6 +294,7 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
     wPassword.setLayoutData( fdPassword );
 
     wUseSSL = new Button( wSecurityComp, SWT.CHECK );
+    wUseSSL.setText( BaseMessages.getString( PKG, "MQTTDialog.Security.UseSSL" ) );
     props.setLook( wUseSSL );
     FormData fdUseSSL = new FormData();
     fdUseSSL.top = new FormAttachment( wAuthenticationGroup, 15 );
@@ -294,6 +304,7 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
       @Override public void widgetSelected( SelectionEvent selectionEvent ) {
         boolean selection = ( (Button) selectionEvent.getSource() ).getSelection();
         sslTable.setEnabled( selection );
+        sslTable.table.setEnabled( selection );
       }
 
       @Override public void widgetDefaultSelected( SelectionEvent selectionEvent ) {
@@ -301,14 +312,6 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
         sslTable.setEnabled( selection );
       }
     } );
-
-    wlUseSSL = new Label( wSecurityComp, SWT.LEFT );
-    props.setLook( wlUseSSL );
-    wlUseSSL.setText( BaseMessages.getString( PKG, "MQTTDialog.Security.UseSSL" ) );
-    FormData fdlUseSSL = new FormData();
-    fdlUseSSL.left = new FormAttachment( wUseSSL, 0 );
-    fdlUseSSL.top = new FormAttachment( wAuthenticationGroup, 15 );
-    wlUseSSL.setLayoutData( fdlUseSSL );
 
     wlSSLProperties = new Label( wSecurityComp, SWT.LEFT );
     wlSSLProperties.setText( BaseMessages.getString( PKG, "MQTTDialog.Security.SSLProperties" ) );


### PR DESCRIPTION
1) Moving security tab to before batch,
2) debug logging of connection options.
3) Dialog height set to match ux
4) SSL table shows 4 rows
5) SSL table now greys out when disabled.
6) Attached "Use secure protocol" to the checkbox for even spacing
across platforms (formerly bunched up on Windows)

https://jira.pentaho.com/browse/BACKLOG-21243