### PR TITLE
[BACKLOG-21243] MQTT Consumer - SSL

### DIFF
--- a/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerDialog.java
+++ b/kettle-plugins/mqtt/src/main/java/org/pentaho/di/trans/step/mqtt/MQTTConsumerDialog.java
@@ -95,6 +95,8 @@ public class MQTTConsumerDialog extends BaseStreamingDialog implements StepDialo
     wQOS.setText( mqttMeta.getQos() );
     wUsername.setText( mqttMeta.getUsername() );
     wUseSSL.setSelection( mqttMeta.isUseSsl() );
+    sslTable.setEnabled( mqttMeta.isUseSsl() );
+    sslTable.table.setEnabled( mqttMeta.isUseSsl() );
     wPassword.setText( mqttMeta.getPassword() );
   }
 


### PR DESCRIPTION
SSL table should needs to be enabled/disabled on dialog open
based on meta (formerly always enabled on open).

https://jira.pentaho.com/browse/BACKLOG-21243