### PR TITLE
[SP-4140] Backport of PDI-16627 - Hadoop File Output: 'date time form…

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialog.java
@@ -613,9 +613,7 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
     fdDateTimeFormat.right = new FormAttachment( 100, 0 );
     wDateTimeFormat.setLayoutData( fdDateTimeFormat );
     String[] dates = Const.getDateFormats();
-    for ( int x = 0; x < dates.length; x++ ) {
-      wDateTimeFormat.add( dates[x] );
-    }
+    fillWithSupportedDateFormats( wDateTimeFormat, dates );
     wbShowFiles = new Button( wFileComp, SWT.PUSH | SWT.CENTER );
     props.setLook( wbShowFiles );
     wbShowFiles.setText( BaseMessages.getString( BASE_PKG, "TextFileOutputDialog.ShowFiles.Button" ) );
@@ -1319,6 +1317,15 @@ public class HadoopFileOutputDialog extends BaseStepDialog implements StepDialog
       }
     }
     return stepname;
+  }
+
+  protected void fillWithSupportedDateFormats( CCombo combo, String[] dates ) {
+    for ( String s : dates ) {
+      // ':' is not supported in filenames by hadoop file system, add other characters if needed to the regex below
+      if ( s.matches( "[^:]+" ) ) {
+        combo.add( s );
+      }
+    }
   }
 
   private void activeFileNameField() {

--- a/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialogTest.java
+++ b/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileOutputDialogTest.java
@@ -22,9 +22,16 @@
 
 package org.pentaho.big.data.kettle.plugins.hdfs.trans;
 
+import org.eclipse.swt.custom.CCombo;
 import org.junit.Test;
+import org.pentaho.di.core.Const;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 /**
  * Created by bryan on 11/23/15.
@@ -71,5 +78,22 @@ public class HadoopFileOutputDialogTest {
   @Test
   public void testGetUrlPathRootPathWithoutSlash() {
     assertEquals( "/", HadoopFileOutputDialog.getUrlPath( "hdfs://myhost:8020" ) );
+  }
+
+  @Test
+  public void testFillWithSupportedDateFormats() {
+    HadoopFileOutputDialog dialog = mock( HadoopFileOutputDialog.class );
+    CCombo combo = mock( CCombo.class );
+
+    String[] dates = Const.getDateFormats();
+    assertEquals( 19, dates.length );
+
+    // currently there are 19 date formats, 9 of which contain ':' characters which are illegal in hadoop filenames
+    // if the formats returned change, the numbers on this test should be adjusted
+
+    doCallRealMethod().when( dialog ).fillWithSupportedDateFormats( any(), any() );
+    dialog.fillWithSupportedDateFormats( combo, dates );
+
+    verify( combo, times( 10 ) ).add( any() );
   }
 }


### PR DESCRIPTION
…at' dropdown: if using templates with colons, HDFS-output cannot be created (7.1 Suite)

@duarteteixeira @pamval @mchen-len-son 