### PR TITLE
[PDI-16816] Hadoop File Input misses Environment field in ETL Metadata Injection

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
@@ -29,8 +29,10 @@ import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemException;
 import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
+import org.pentaho.di.core.Const;
 import org.pentaho.di.core.annotations.Step;
 import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.fileinput.FileInputList;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.util.Utils;
@@ -45,6 +47,10 @@ import org.pentaho.metastore.api.IMetaStore;
 import org.pentaho.runtime.test.RuntimeTester;
 import org.pentaho.runtime.test.action.RuntimeTestActionService;
 import org.w3c.dom.Node;
+
+import static org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileInputDialog.LOCAL_ENVIRONMENT;
+import static org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileInputDialog.S3_ENVIRONMENT;
+import static org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileInputDialog.STATIC_ENVIRONMENT;
 
 @Step( id = "HadoopFileInputPlugin", image = "HDI.svg", name = "HadoopFileInputPlugin.Name",
     description = "HadoopFileInputPlugin.Description",
@@ -121,7 +127,7 @@ public class HadoopFileInputMeta extends TextFileInputMeta {
     if ( c != null ) {
       url = c.processURLsubstitution( url, metastore, new Variables() );
     }
-    if ( !Utils.isEmpty( ncName ) && !Utils.isEmpty( url ) ) {
+    if ( !Utils.isEmpty( ncName ) && !Utils.isEmpty( url ) && mappings != null ) {
       mappings.put( url, ncName );
     }
     return url;
@@ -158,5 +164,34 @@ public class HadoopFileInputMeta extends TextFileInputMeta {
 
   public NamedClusterService getNamedClusterService() {
     return namedClusterService;
+  }
+
+  @Override
+  public FileInputList getFileInputList( VariableSpace space ) {
+    inputFiles.normalizeAllocation( inputFiles.fileName.length );
+    for ( int i = 0; i < environment.length; i++ ) {
+      if ( inputFiles.fileName[i].contains( "://" ) ) {
+        continue;
+      }
+      String sourceNc = environment[i];
+      sourceNc = sourceNc.equals( LOCAL_ENVIRONMENT ) ? HadoopFileInputMeta.LOCAL_SOURCE_FILE + i : sourceNc;
+      sourceNc = sourceNc.equals( STATIC_ENVIRONMENT ) ? HadoopFileInputMeta.STATIC_SOURCE_FILE + i : sourceNc;
+      sourceNc = sourceNc.equals( S3_ENVIRONMENT ) ? HadoopFileInputMeta.S3_SOURCE_FILE + i : sourceNc;
+      String source = inputFiles.fileName[i];
+      if ( !Const.isEmpty( source ) ) {
+        inputFiles.fileName[i] = loadUrl( source, sourceNc, getParentStepMeta().getParentTransMeta().getMetaStore(), null );
+      } else {
+        inputFiles.fileName[i] = "";
+      }
+    }
+    return createFileList( space );
+  }
+
+  /**
+   * Created for test purposes
+   */
+  FileInputList createFileList( VariableSpace space ) {
+    return FileInputList.createFileList( space, inputFiles.fileName, inputFiles.fileMask, inputFiles.excludeFileMask,
+      inputFiles.fileRequired, inputFiles.includeSubFolderBoolean() );
   }
 }

--- a/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMetaTest.java
+++ b/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMetaTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p/>
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  * <p/>
  * ******************************************************************************
  * <p/>
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.pentaho.big.data.api.cluster.NamedCluster;
 import org.pentaho.big.data.api.cluster.NamedClusterService;
+import org.pentaho.di.core.fileinput.FileInputList;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.core.xml.XMLHandler;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.trans.TransMeta;
@@ -49,7 +52,12 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.anyInt;
 
 /**
  * @author Vasilina Terehova
@@ -157,6 +165,26 @@ public class HadoopFileInputMetaTest {
     when( mockRep.getStepAttributeString( anyObject(), eq( 0 ), eq( "file_name" ) ) ).thenReturn( URL_FROM_CLUSTER );
 
     assertEquals( URL_FROM_CLUSTER, hadoopFileInputMeta.loadSourceRep( mockRep, null, 0, mockMetaStore ) );
+  }
+
+  @Test
+  public void testGetFileInputList() {
+    final String URL_FROM_CLUSTER = "urlFromCluster";
+    StepMeta parentStepMeta = mock( StepMeta.class );
+    IMetaStore mockMetaStore = mock( IMetaStore.class );
+    NamedCluster mockNamedCluster = mock( NamedCluster.class );
+    TransMeta parentTransMeta = mock( TransMeta.class );
+    when( parentStepMeta.getParentTransMeta() ).thenReturn( parentTransMeta );
+    when( parentTransMeta.getMetaStore() ).thenReturn( mockMetaStore );
+    when( mockNamedCluster.processURLsubstitution( any(), eq( mockMetaStore ), any() ) ).thenReturn( URL_FROM_CLUSTER );
+    when( namedClusterService.getNamedClusterByName( TEST_CLUSTER_NAME, mockMetaStore ) ).thenReturn( mockNamedCluster );
+    HadoopFileInputMeta hadoopFileInputMetaSpy =  initHadoopMetaInput( new HadoopFileInputMeta( namedClusterService, runtimeTestActionService, runtimeTester ) );
+    hadoopFileInputMetaSpy.environment = new String[] { TEST_CLUSTER_NAME };
+    hadoopFileInputMetaSpy.setParentStepMeta( parentStepMeta );
+    doReturn( new FileInputList() ).when( hadoopFileInputMetaSpy ).createFileList( any( VariableSpace.class ) );
+    hadoopFileInputMetaSpy.getFileInputList( new Variables() );
+
+    assertEquals( "urlFromCluster", hadoopFileInputMetaSpy.inputFiles.fileName[0] );
   }
 
 }


### PR DESCRIPTION
- fix incompleteness was fixed
- BaseFileInputMeta getFileInputList was overridden
- test was added