### PR TITLE
[PDI-17035] AVRO input step from 7.1 not compatible with 8.0

### DIFF
--- a/legacy/src/main/resources/org/pentaho/di/trans/steps/avroinput/messages/messages_en_US.properties
+++ b/legacy/src/main/resources/org/pentaho/di/trans/steps/avroinput/messages/messages_en_US.properties
@@ -1,7 +1,7 @@
-AvroInput.Name=Old Avro Input
+AvroInput.Name=Avro Input-Legacy
 AvroInput.Description=Reads data from an Avro file
 
-AvroInputDialog.Shell.Title=Old Avro input
+AvroInputDialog.Shell.Title=Avro input-Legacy
 AvroInputDialog.StepName.Label=Step name
 
 AvroInputDialog.SourceTab.Title=Source


### PR DESCRIPTION
Changing the name from "Old Avro Input" to "Avro Input-Legacy"

@mbatchelor 