### PR TITLE
[BAD-1423]-Parquet Output step: NPE appears if a user use in "Compression" dropdown values with different letter case or another value

### DIFF
--- a/kettle-plugins/formats-meta/src/main/java/org/pentaho/big/data/kettle/plugins/formats/parquet/output/ParquetOutputMetaBase.java
+++ b/kettle-plugins/formats-meta/src/main/java/org/pentaho/big/data/kettle/plugins/formats/parquet/output/ParquetOutputMetaBase.java
@@ -448,7 +448,7 @@ public abstract class ParquetOutputMetaBase extends BaseStepMeta implements Step
 
   public void setCompressionType( String value ) {
     compressionType =
-      StringUtil.isVariable( value ) ? value : parseFromToString( value, CompressionType.values(), null ).name();
+      StringUtil.isVariable( value ) ? value : parseFromToString( value, CompressionType.values(), CompressionType.NONE ).name();
   }
 
   public CompressionType getCompressionType( VariableSpace vspace ) {
@@ -542,7 +542,7 @@ public abstract class ParquetOutputMetaBase extends BaseStepMeta implements Step
   protected static <T> T parseFromToString( String str, T[] values, T defaultValue ) {
     if ( !Utils.isEmpty( str ) ) {
       for ( T type : values ) {
-        if ( str.equals( type.toString() ) ) {
+        if ( str.equalsIgnoreCase( type.toString() ) ) {
           return type;
         }
       }

--- a/kettle-plugins/formats-meta/src/test/java/org/pentaho/big/data/kettle/plugins/formats/parquet/output/ParquetOutputMetaBaseTest.java
+++ b/kettle-plugins/formats-meta/src/test/java/org/pentaho/big/data/kettle/plugins/formats/parquet/output/ParquetOutputMetaBaseTest.java
@@ -21,6 +21,7 @@
  ******************************************************************************/
 package org.pentaho.big.data.kettle.plugins.formats.parquet.output;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,5 +72,13 @@ public class ParquetOutputMetaBaseTest {
 
     metaBase.getXML();
     verify( namedClusterEmbedManager ).registerUrl( eq( "hc://HC/fileName" ) );
+  }
+
+  @Test
+  public void setCompressionType() {
+    metaBase.setCompressionType( "gzip" );
+    Assert.assertTrue( metaBase.compressionType.equals( "GZIP" ) );
+    metaBase.setCompressionType( "abc" );
+    Assert.assertTrue( metaBase.compressionType.equals( "NONE" ) );
   }
 }


### PR DESCRIPTION
 - fixed: change compare from equals to equalsIgnoreCase and use "None" as default value