### PR TITLE
[BACKLOG-23135]-Amazon Hive Job Executor and Amazon EMR Job Executor: label of entry should be changed from "Step name" to "Entry name", update icon for EMR

### DIFF
--- a/legacy/src/main/resources/org/pentaho/amazon/emr/job/messages/messages_en_US.properties
+++ b/legacy/src/main/resources/org/pentaho/amazon/emr/job/messages/messages_en_US.properties
@@ -3,7 +3,7 @@ EMRJobExecutorPlugin.Description=Execute MapReduce jobs in Amazon EMR
 
 
 JobEntryDialog.Title=Amazon EMR Job Executor
-JobEntry.Name.Label=Step name:
+JobEntry.Name.Label=Entry name:
 
 AmazonElasticMapReduceJobExecutor.Name.Label=EMR job flow name:
 AmazonElasticMapReduceJobExecutor.AWSAccessKey.Label=Access key:

--- a/legacy/src/main/resources/org/pentaho/amazon/emr/ui/AmazonElasticMapReduceJobExecutorDialog.xul
+++ b/legacy/src/main/resources/org/pentaho/amazon/emr/ui/AmazonElasticMapReduceJobExecutorDialog.xul
@@ -12,7 +12,7 @@
           width="452"
           linuxHeight="674"
           linuxWidth="517"
-          appicon="AWS-HIVE.png"
+          appicon="EMR.png"
           buttons="">
 
     <vbox>
@@ -31,7 +31,7 @@
             </vbox>
             <hbox flex="1">
               <spacer flex="1"/>
-              <image src="AWS-HIVE.png"/>
+              <image src="EMR.png"/>
             </hbox>
           </row>
         </rows>

--- a/legacy/src/main/resources/org/pentaho/amazon/hive/job/messages/messages_en_US.properties
+++ b/legacy/src/main/resources/org/pentaho/amazon/hive/job/messages/messages_en_US.properties
@@ -3,7 +3,7 @@ HiveJobExecutorPlugin.Description=Execute Hive jobs in Amazon EMR
 
 
 JobEntryDialog.Title=Amazon Hive Job Executor
-JobEntry.Name.Label=Step name:
+JobEntry.Name.Label=Entry name:
 
 
 AmazonHiveJobExecutor.Name.Label=Hive job flow name:


### PR DESCRIPTION
In scope of this pull request [BACKLOG-23136](https://jira.pentaho.com/browse/BACKLOG-23136) is also fixed (update icon for Amazon EMR step)