### PR TITLE
[PDI-17036] 8.0 AVRO step not able to read result of AVRO output from…

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -119,6 +119,16 @@
       <version>${dependency.avro.revision}</version>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>${dependency.jackson.revision}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>${dependency.jackson.revision}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.core</groupId>
       <artifactId>commands</artifactId>
       <version>${dependency.commands.revision}</version>

--- a/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
+++ b/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
@@ -58,6 +58,7 @@
                 <include>org.apache.httpcomponents:httpclient</include>
                 <include>org.apache.httpcomponents:httpcore</include>
                 <include>org.codehaus.jackson:jackson-core-asl</include>
+                <include>org.codehaus.jackson:jackson-mapper-asl</include>
                 <include>net.java.dev.jets3t:jets3t</include>
                 <include>jline:jline</include>
                 <include>com.googlecode.json-simple:json-simple</include>


### PR DESCRIPTION
… 7.1

- Added jackson mapper back, since avro has a compile time dependency on it.

This is a partial revert of #1344.