### PR TITLE
[PDI-17441] Feature: Add support for ADL as an Hadoop FS

### DIFF
--- a/impl/cluster/src/main/java/org/pentaho/big/data/impl/cluster/NamedClusterImpl.java
+++ b/impl/cluster/src/main/java/org/pentaho/big/data/impl/cluster/NamedClusterImpl.java
@@ -34,6 +34,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.beanutils.BeanMap;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.vfs2.FileName;
@@ -68,6 +69,8 @@ public class NamedClusterImpl implements NamedCluster, NamedClusterOsgi {
   public static final String HDFS_SCHEME = "hdfs";
   public static final String MAPRFS_SCHEME = "maprfs";
   public static final String WASB_SCHEME = "wasb";
+  public static final String WASBS_SCHEME = "wasbs";
+  public static final String ADLS_SCHEME = "adl";
   public static final String NC_SCHEME = "hc";
   public static final String INDENT = "  ";
   public static final String ROOT_INDENT = "    ";
@@ -311,8 +314,8 @@ public class NamedClusterImpl implements NamedCluster, NamedClusterOsgi {
         if ( variableSpace != null ) {
           String filePath = variableSpace.environmentSubstitute( path );
           StringBuilder pattern = new StringBuilder();
-          pattern.append( "^(" ).append( HDFS_SCHEME ).append( "|" ).append( WASB_SCHEME ).append( "|" ).append(
-              MAPRFS_SCHEME ).append( "|" ).append( NC_SCHEME ).append( "):\\/\\/" );
+
+          pattern.append( "^(" ).append(String.join("|", HDFS_SCHEME, WASB_SCHEME, WASBS_SCHEME, MAPRFS_SCHEME, NC_SCHEME, ADLS_SCHEME)).append( "):\\/\\/" );
           Pattern r = Pattern.compile( pattern.toString() );
           Matcher m = r.matcher( filePath );
           prependCluster = !m.find();

--- a/impl/cluster/src/test/java/org/pentaho/big/data/impl/cluster/NamedClusterImplTest.java
+++ b/impl/cluster/src/test/java/org/pentaho/big/data/impl/cluster/NamedClusterImplTest.java
@@ -374,6 +374,24 @@ public class NamedClusterImplTest {
   }
 
   @Test
+  public void testProcessURLWASBSFullSubstitution() throws MetaStoreException {
+    namedCluster.setHdfsHost( "hostname" );
+    namedCluster.setHdfsPort( "12340" );
+    namedCluster.setStorageScheme( "wasbs" );
+    String incomingURL = "wasbs://namedClusterHdfsUsername:namedClusterHdfsPassword@hostname:12340/tmp/hdsfDemo.txt";
+    assertEquals( incomingURL, namedCluster.processURLsubstitution( incomingURL, metaStore, null ) );
+  }
+
+  @Test
+  public void testProcessURLADLFullSubstitution() throws MetaStoreException {
+    namedCluster.setHdfsHost( "hostname" );
+    namedCluster.setHdfsPort( "12340" );
+    namedCluster.setStorageScheme( "adl" );
+    String incomingURL = "adl://namedClusterHdfsUsername:namedClusterHdfsPassword@hostname:12340/tmp/hdsfDemo.txt";
+    assertEquals( incomingURL, namedCluster.processURLsubstitution( incomingURL, metaStore, null ) );
+  }
+
+  @Test
   public void testProcessURLHostVariableNull() throws MetaStoreException {
     namedCluster.setHdfsHost( "${hostUrl}" );
     namedCluster.setStorageScheme( "hdfs" );

--- a/impl/vfs/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/impl/vfs/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -39,6 +39,13 @@
     <argument value="wasbs" type="java.lang.String"/>
   </bean>
 
+  <bean id="adlprovider" class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider" scope="singleton">
+    <argument ref="hadoopFileSystemService"/>
+    <argument ref="namedClusterService"/>
+    <argument ref="maprfsFileNameParser" />
+    <argument value="adl" type="java.lang.String"/>
+  </bean>
+
   <bean class="org.pentaho.big.data.impl.vfs.hdfs.nc.NamedClusterProvider" scope="singleton">
     <argument ref="hadoopFileSystemService"/>
     <argument ref="namedClusterService"/>

--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/vfs/HadoopVfsFileChooserDialog.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/vfs/HadoopVfsFileChooserDialog.java
@@ -22,6 +22,7 @@
 
 package org.pentaho.big.data.kettle.plugins.hdfs.vfs;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
@@ -181,7 +182,11 @@ public class HadoopVfsFileChooserDialog extends CustomVfsUiPanel {
     NamedCluster nc = getNamedClusterWidget().getSelectedNamedCluster();
     // The Named Cluster may be hdfs, maprfs or wasb.  We need to detect it here since the named
     // cluster was just selected.
-    schemeName = "wasb".equals( nc.getStorageScheme() ) ? "wasb" : "hdfs";
+    if(!Lists.newArrayList("wasb", "wasbs", "adl").contains(nc.getStorageScheme())) {
+      schemeName = "hdfs";
+    } else {
+      schemeName = nc.getStorageScheme();
+    }
 
     FileObject root = rootFile;
     try {


### PR DESCRIPTION
There is support for the adl scheme in current hadoop. This PR adds support for Azure DataLake storage in PDI. This is part of PRs against the `big-data-shims`, `pentaho-karaf-assembly`, and `pentaho-big-data-plugins` repositories.