### PR TITLE
[SP-4367] Backport of PPP-4108 - Use of vulnerable component jackson-…

### DIFF
--- a/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
+++ b/assemblies/legacy-plugin/src/main/assembly/descriptors/plugin.xml
@@ -58,6 +58,7 @@
                 <include>org.apache.httpcomponents:httpclient</include>
                 <include>org.apache.httpcomponents:httpcore</include>
                 <include>org.codehaus.jackson:jackson-core-asl</include>
+                <include>org.codehaus.jackson:jackson-mapper-asl</include>
                 <include>net.java.dev.jets3t:jets3t</include>
                 <include>jline:jline</include>
                 <include>com.googlecode.json-simple:json-simple</include>


### PR DESCRIPTION
…databind-2.8.8.jar, jackson-databind-2.9.2.jar, jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095 (8.1 Suite)

Adding missing dependency in assembly. This was added in master in master and never added in 8.1.

@ricardosilva88 @cravobranco 