### PR TITLE
[BACKLOG-24465] Unsecure: Pig Script Executor fails with the "java.la…

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -123,6 +123,7 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>kettle-log4j-core</artifactId>
       <version>${pdi.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>libthrift</groupId>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -183,6 +183,7 @@
       <groupId>org.pentaho.di.plugins</groupId>
       <artifactId>kettle-log4j-core</artifactId>
       <version>${pdi.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>libthrift</groupId>


### PR DESCRIPTION
…ng.VerifyError: Bad type on operand stack"