### PR TITLE
[BACKLOG-24118] - Parquet Input fails on Secured shims moved to OSGI (EE specific)

### DIFF
--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/input/AvroInput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/input/AvroInput.java
@@ -79,7 +79,7 @@ public class AvroInput extends BaseFileInputStep<AvroInputMeta, AvroInputData> {
             throw new KettleException( "No input files defined" );
           }
 
-          data.input = formatService.createInputFormat( IPentahoAvroInputFormat.class );
+          data.input = formatService.createInputFormat( IPentahoAvroInputFormat.class, meta.getNamedCluster() );
           data.input
             .setInputFile( meta.getParentStepMeta().getParentTransMeta().environmentSubstitute( meta.getFilename() ) );
           data.input.setInputSchemaFile(
@@ -151,7 +151,7 @@ public class AvroInput extends BaseFileInputStep<AvroInputMeta, AvroInputData> {
   public static List<? extends IAvroInputField> getDefaultFields( NamedClusterServiceLocator namedClusterServiceLocator,
                                                                    NamedCluster namedCluster, String schemaPath, String dataPath ) throws Exception {
     FormatService formatService = namedClusterServiceLocator.getService( namedCluster, FormatService.class );
-    IPentahoAvroInputFormat in = formatService.createInputFormat( IPentahoAvroInputFormat.class );
+    IPentahoAvroInputFormat in = formatService.createInputFormat( IPentahoAvroInputFormat.class, namedCluster );
     in.setInputSchemaFile( schemaPath );
     in.setInputFile( dataPath );
     return in.getFields();

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/orc/input/OrcInput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/orc/input/OrcInput.java
@@ -72,7 +72,7 @@ public class OrcInput extends BaseFileInputStep<OrcInputMeta, OrcInputData> {
         if ( meta.inputFiles == null || meta.getFilename() == null || meta.getFilename().length() == 0 ) {
           throw new KettleException( "No input files defined" );
         }
-        data.input = formatService.createInputFormat( IPentahoOrcInputFormat.class );
+        data.input = formatService.createInputFormat( IPentahoOrcInputFormat.class, meta.getNamedCluster() );
 
         String inputFileName = getKettleVFSFileName(
                 meta.getParentStepMeta().getParentTransMeta().environmentSubstitute( meta.getFilename() ) );
@@ -115,7 +115,7 @@ public class OrcInput extends BaseFileInputStep<OrcInputMeta, OrcInputData> {
   public static List<? extends IOrcInputField> retrieveSchema( NamedClusterServiceLocator namedClusterServiceLocator,
                                                                NamedCluster namedCluster, String dataPath ) throws Exception {
     FormatService formatService = namedClusterServiceLocator.getService( namedCluster, FormatService.class );
-    IPentahoOrcInputFormat in = formatService.createInputFormat( IPentahoOrcInputFormat.class );
+    IPentahoOrcInputFormat in = formatService.createInputFormat( IPentahoOrcInputFormat.class, namedCluster );
 
     in.setInputFile( getKettleVFSFileName( dataPath ) );
     return in.readSchema( );

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/input/ParquetInput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/input/ParquetInput.java
@@ -112,7 +112,7 @@ public class ParquetInput extends BaseFileInputStep<ParquetInputMeta, ParquetInp
       inputFileName = ( (AliasedFileObject) inputFileObject ).getOriginalURIString();
     }
 
-    data.input = formatService.createInputFormat( IPentahoParquetInputFormat.class );
+    data.input = formatService.createInputFormat( IPentahoParquetInputFormat.class, meta.getNamedCluster() );
 
     // Pentaho 8.0 transformations will have the formatType set to 0. Get the fields from the schema and set the
     // formatType to the formatType retrieved from the schema.
@@ -162,7 +162,7 @@ public class ParquetInput extends BaseFileInputStep<ParquetInputMeta, ParquetInp
   public static List<? extends IParquetInputField> retrieveSchema( NamedClusterServiceLocator namedClusterServiceLocator,
                                                                    NamedCluster namedCluster, String path ) throws Exception {
     FormatService formatService = namedClusterServiceLocator.getService( namedCluster, FormatService.class );
-    IPentahoParquetInputFormat in = formatService.createInputFormat( IPentahoParquetInputFormat.class );
+    IPentahoParquetInputFormat in = formatService.createInputFormat( IPentahoParquetInputFormat.class, namedCluster );
     FileObject inputFileObject = KettleVFS.getFileObject( path );
     if ( AliasedFileObject.isAliasedFile( inputFileObject ) ) {
       path = ( (AliasedFileObject) inputFileObject ).getOriginalURIString();

--- a/kettle-plugins/formats/src/test/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/input/AvroInputTest.java
+++ b/kettle-plugins/formats/src/test/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/input/AvroInputTest.java
@@ -134,7 +134,7 @@ public class AvroInputTest {
       e.printStackTrace();
     }
 
-    when( mockFormatService.createInputFormat( IPentahoAvroInputFormat.class ) )
+    when( mockFormatService.createInputFormat( IPentahoAvroInputFormat.class, avroInputMeta.getNamedCluster() ) )
       .thenReturn( mockPentahoAvroInputFormat );
     when( mockNamedClusterServiceLocator.getService( any( NamedCluster.class ), any( Class.class ) ) )
       .thenReturn( mockFormatService );


### PR DESCRIPTION
@pentaho/moseisley Please review.
https://github.com/pentaho/pentaho-hadoop-shims/pull/808