### PR TITLE
[SP-4476] Backport of PDI-16888 - Title bar of several steps doesn't …

### DIFF
--- a/legacy/src/main/resources/org/pentaho/di/trans/steps/avroinput/messages/messages_en_US.properties
+++ b/legacy/src/main/resources/org/pentaho/di/trans/steps/avroinput/messages/messages_en_US.properties
@@ -1,7 +1,7 @@
-AvroInput.Name=Avro input
+AvroInput.Name=Avro input (deprecated)
 AvroInput.Description=Reads data from an Avro file
 
-AvroInputDialog.Shell.Title=Avro input
+AvroInputDialog.Shell.Title=Avro input (deprecated)
 AvroInputDialog.StepName.Label=Step name
 
 AvroInputDialog.SourceTab.Title=Source


### PR DESCRIPTION
…have the correspondent name of the step (8.1 Suite)
@pentaho-lmartins 

This is part of a series of pull requests. for details see: https://github.com/pentaho/pentaho-kettle/pull/5651