### PR TITLE
[BACKLOG-25185] Avro Input Step - Backport Get Fields Functionality from the 7.1 Avro Input Step (NON-AEL)

### DIFF
--- a/assemblies/features/src/main/resources/features.xml
+++ b/assemblies/features/src/main/resources/features.xml
@@ -78,14 +78,14 @@
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-hive/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-spark/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-kafka/${project.version}</bundle>
-    <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-formats-meta/${project.version}</bundle>
-    <feature>pentaho-big-data-formats-avro</feature>
+    <feature>pentaho-big-data-kettle-plugins-formats</feature>
   </feature>
-  <feature name="pentaho-big-data-formats-avro" version="1.0">
+  <feature name="pentaho-big-data-kettle-plugins-formats" version="1.0">
+    <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-formats-meta/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-big-data-kettle-plugins-formats/${project.version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.apache.avro/avro/${apache-avro.version}</bundle>
-    <bundle dependency='true'>wrap:mvn:com.thoughtworks.paranamer/paranamer/${thoughtworks.paranamer.version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.codehaus.jackson/jackson-core-asl/${codehaus.jackson.version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus.jackson.version}</bundle>
+    <bundle>wrap:mvn:org.apache.avro/avro/${apache-avro.version}</bundle>
+    <bundle>wrap:mvn:com.thoughtworks.paranamer/paranamer/${thoughtworks.paranamer.version}</bundle>
+    <bundle>wrap:mvn:org.codehaus.jackson/jackson-core-asl/${codehaus.jackson.version}</bundle>
+    <bundle>wrap:mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus.jackson.version}</bundle>
   </feature>
 </features>


### PR DESCRIPTION
- Created a feature for pentaho-big-data-kettle-plugins-formats
- Added Avro dependencies to the pentaho-big-data-kettle-plugins-formats 
feature