### PR TITLE
[PPP-4182] Use of vulnerable component dom4j-1.6.1.jar  CVE-2018-1000632

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -224,9 +224,8 @@
       <version>${dependency.xstream.revision}</version>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>1.6.1</version>
     </dependency>
     <dependency>
       <groupId>eigenbase</groupId>
@@ -321,7 +320,6 @@
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>jcifs</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -76,7 +76,7 @@
         <include>xmlpull:xmlpull</include>
         <include>xpp3:xpp3_min</include>
         <include>com.thoughtworks.xstream:xstream</include>
-        <include>dom4j:dom4j</include>
+        <include>org.dom4j:dom4j</include>
         <include>eigenbase:eigenbase-properties</include>
         <include>eigenbase:eigenbase-resgen</include>
         <include>eigenbase:eigenbase-xom</include>

--- a/kettle-plugins/mapreduce/pom.xml
+++ b/kettle-plugins/mapreduce/pom.xml
@@ -73,6 +73,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>


### PR DESCRIPTION
This is one of a series of PRs. See pentaho/maven-parent-poms#70 for the complete list and more details. **Do not merge until further notice!**

@graimundo