### PR TITLE
[BAD-1439] - The MapReduce step creates a metastore folder every time…

### DIFF
--- a/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
+++ b/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -562,17 +562,15 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
     java.nio.file.Path localMetaStoreSnapshotDirPath;
     Path hdfsMetaStoreDirForCurrentJobPath;
     FileObject localMetaStoreSnapshotDirObject;
-    //will create a temp folder on the local fs while hdfs folder name does not exist
-    do {
-      localMetaStoreSnapshotDirPath = Files.createTempDirectory( XmlUtil.META_FOLDER_NAME );
-      localMetaStoreSnapshotDirObject = KettleVFS.getFileObject( localMetaStoreSnapshotDirPath.toString() );
-      hdfsMetaStoreDirForCurrentJobPath = fs.asPath( installPath, localMetaStoreSnapshotDirObject.getName().getBaseName() );
-    } while ( fs.exists( hdfsMetaStoreDirForCurrentJobPath ) );
+
+    localMetaStoreSnapshotDirPath = Files.createTempDirectory( XmlUtil.META_FOLDER_NAME );
+    localMetaStoreSnapshotDirObject = KettleVFS.getFileObject( localMetaStoreSnapshotDirPath.toString() );
+    hdfsMetaStoreDirForCurrentJobPath = fs.asPath( installPath, XmlUtil.META_FOLDER_NAME );
 
     //fill local metastore snapshot by the existing named cluster
     snapshotMetaStore( localMetaStoreSnapshotDirPath.toString() );
 
-    hadoopShim.getDistributedCacheUtil().stageForCache( localMetaStoreSnapshotDirObject, fs, hdfsMetaStoreDirForCurrentJobPath, false, true );
+    hadoopShim.getDistributedCacheUtil().stageForCache( localMetaStoreSnapshotDirObject, fs, hdfsMetaStoreDirForCurrentJobPath, true, true );
     hadoopShim.getDistributedCacheUtil().addCachedFiles( conf, fs, hdfsMetaStoreDirForCurrentJobPath, null );
   }
 


### PR DESCRIPTION
… it is executed

Explanation:
- Before the creation of metadata folder on Big Data Cluster, is being created a local folder in C:\Users\USER\AppData\Local\Temp. This folder is created using NIO API, more concretely Files.createTempDirectory(PREFIX), where PREFIX has the value of "metastore". In every createTempDirectory call, is created a new folder folder with a different suffix, generating folders like metastore123 or metastore345.

- The problem here is that this folder name (metadata+SUFFIX) is also being used to generate metastore folder name in Big Data Cluster, instead of creating/reusing/overriding a existing metadata folder.

- With this PR code change, instead of having a metadata+SUFFIX folder for each execution, it will exists a single metadata folder that is being reused/override by each mapreduce execution in Big data cluster.

- Concerns with conflicting executions: 
- 1) The data being stored in Cluster side is basically connection configurations of that same cluster (is a file representation of cluster configuration setting window of PDI - hdfs password, ozzieURL, jobTrackerHost, zooKeeperHost, etc), even if multiple PDI's access to the same information during mapreduce execution don't seem to be an issue, because it will be the same data settings for all of them. Any new mapreduce execution will override this file just in case of any config changed 

- 2) In case of need, each PDI can configure different mapreduce working folders by using - pmr.kettle.dfs.install.dir=/opt/pentaho/mapreduce (data-integration/plugins/pentaho-big-data-plugin/plugin.properties); 

- 3) Tried with multiple PDI instances and seems to be all fine; 

- 4) The obvious solution of deleting metadata folder after the mapreduce execution seems not to be supported by hadoopShim, there is a method to stage the folder (hadoopShim.getDistributedCacheUtil().stageForCache), but not for unstage it; 

- 5) My only concern is if this file format (cdh513.xml and type.xml) change in the future, if for some reason multiple PDIs with different versions run mapreduces, it might be a problem.


Additional reference (NIO - CreateTempDirectory) - https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createTempDirectory-java.nio.file.Path-java.lang.String-java.nio.file.attribute.FileAttribute...- 


Example of cdh513.xml:
`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<element>
  <id>cdh513</id>
  <value/>
  <type>String</type>
  <children>
    <child>
      <id>hdfsPassword</id>
      <value>cGFzc3dvcmQ=</value>
      <type>String</type>
    </child>
    <child>
      <id>oozieUrl</id>
      <value>http://svqxbdcn6cdh513n3.pentahoqa.com:11000/oozie</value>
      <type>String</type>
    </child>
    <child>
      <id>mapr</id>
      <value>N</value>
      <type>String</type>
    </child>
    <child>
      <id>useGateway</id>
      <value>N</value>
      <type>String</type>
    </child>
    <child>
      <id>lastModifiedDate</id>
      <value>1538412787884</value>
      <type>String</type>
    </child>
    <child>
      <id>jobTrackerHost</id>
      <value>svqxbdcn6cdh513n2.pentahoqa.com</value>
      <type>String</type>
    </child>
    <child>
      <id>zooKeeperHost</id>
      <value>svqxbdcn6cdh513n1.pentahoqa.com</value>
      <type>String</type>
    </child>
    <child>
      <id>shimIdentifier</id>
      <value/>
      <type>String</type>
    </child>
    <child>
      <id>gatewayUrl</id>
      <value/>
      <type>String</type>
    </child>
    <child>
      <id>jobTrackerPort</id>
      <value>8032</value>
      <type>String</type>
    </child>
    <child>
      <id>zooKeeperPort</id>
      <value>2181</value>
      <type>String</type>
    </child>
    <child>
      <id>name</id>
      <value>cdh513</value>
      <type>String</type>
    </child>
    <child>
      <id>hdfsPort</id>
      <value>8020</value>
      <type>String</type>
    </child>
    <child>
      <id>hdfsUsername</id>
      <value>devuser</value>
      <type>String</type>
    </child>
    <child>
      <id>gatewayPassword</id>
      <value/>
      <type>String</type>
    </child>
    <child>
      <id>kafkaBootstrapServers</id>
      <value/>
      <type>String</type>
    </child>
    <child>
      <id>storageScheme</id>
      <value>hdfs</value>
      <type>String</type>
    </child>
    <child>
      <id>hdfsHost</id>
      <value>svqxbdcn6cdh513n2.pentahoqa.com</value>
      <type>String</type>
    </child>
    <child>
      <id>gatewayUsername</id>
      <value/>
      <type>String</type>
    </child>
  </children>
  <name>cdh513</name>
  <security>
    <owner/>
    <owner-permissions-list/>
  </security>
</element>`
Example of type.xml:
`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<data-type>
  <name>NamedCluster</name>
  <description>A NamedCluster</description>
</data-type>`