### PR TITLE
[BISERVER-14068] Remove Apache Axis axis-1.4.jar and axis-saaj-1.4.jar

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -434,16 +434,6 @@
       <version>1.7.1</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.axis</groupId>
-      <artifactId>axis</artifactId>
-      <version>1.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.axis</groupId>
-      <artifactId>axis-saaj</artifactId>
-      <version>1.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>1.4.1</version>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -118,8 +118,6 @@
         <include>org.antlr:antlr-complete</include>
         <include>org.apache.ant:ant</include>
         <include>org.apache.ant:ant-launcher</include>
-        <include>org.apache.axis:axis</include>
-        <include>org.apache.axis:axis-saaj</include>
         <include>org.apache.commons:commons-compress</include>
         <include>org.apache.felix:org.apache.felix.main</include>
         <include>org.apache.felix:org.apache.felix.framework</include>


### PR DESCRIPTION
@pedrofvteixeira please review.

Merge with: https://github.com/pentaho/pentaho-platform/pull/4305