### PR TITLE
[PPP-4226] Use of vulnerable component commons-compress  CVE-2018-11771

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -436,7 +436,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
This is a series of PRs, please see https://github.com/pentaho/maven-parent-poms/pull/82 for full list.

@ssamora 