### PR TITLE
[PPP-4266] Use of Vulnerable Component commons-fileupload CVE-2016-1000031

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -182,7 +182,6 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
* [PPP-4266] Removing the version reference in the pmr libraries, it will rely on the version written in the maven-parent-poms project instead.

This is a series of PRs, please see pentaho/maven-parent-poms#83