### PR TITLE
[SP-4828] - Backport of PPP-4266 - Use of Vulnerable Component: commons-fileupload-1.3.2.jar (CVE-2016-1000031 | sonatype-2014-01730) (7.1 Suite)

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -182,7 +182,6 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
This is a series of PRs, please see: https://github.com/pentaho/maven-parent-poms/pull/85