### PR TITLE
[SP-4824] Backport of PPP-4226 - Use of vulnerable component commons-…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -435,7 +435,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
…compress  CVE-2018-11771 (8.2 Suite)

Cherry-pick of #1595 into 8.2 branch.

@RPAraujo @ppatricio 