### PR TITLE
[SP-4823] Backport of PPP-4226 - Use of vulnerable component commons-…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -424,7 +424,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
…compress  CVE-2018-11771 (7.1 Suite)

Cherry-pick of #1595 into 7.1 branch.

@RPAraujo @ppatricio 