### PR TITLE
[BACKLOG-26921] - only bring in metaverse test-jar when running ITs.

### DIFF
--- a/kettle-plugins/kafka/pom.xml
+++ b/kettle-plugins/kafka/pom.xml
@@ -111,14 +111,6 @@
     <dependency>
       <groupId>pentaho</groupId>
       <artifactId>pentaho-metaverse-core</artifactId>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-      <version>${pdi.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-metaverse-core</artifactId>
       <version>${pdi.version}</version>
       <scope>test</scope>
     </dependency>
@@ -176,4 +168,24 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>integration-test</id>
+      <activation>
+        <property>
+          <name>runITs</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>pentaho</groupId>
+          <artifactId>pentaho-metaverse-core</artifactId>
+          <classifier>tests</classifier>
+          <type>test-jar</type>
+          <version>${pdi.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -113,56 +113,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-test-source</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/it/java</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-test-resource</id>
-            <phase>generate-test-resources</phase>
-            <goals>
-              <goal>add-test-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>src/it/resources</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.org.apache.maven.plugins.maven-failsafe-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>verify</id>
-            <goals>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>${dependency.maven-bundle-plugin.version}</version>


### PR DESCRIPTION
remove IT config in big-data-plugin because that stuff his handled in
the pentaho parent