### PR TITLE
[SP-4853] Backport of PDI-17767 - 8.2: Blank "File/Folder" path in Ha…

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
@@ -105,7 +105,7 @@ public class HadoopFileInputMeta extends TextFileInputMeta implements HadoopFile
     String source_filefolder = XMLHandler.getNodeValue( filenamenode );
     Node sourceNode = XMLHandler.getSubNodeByNr( filenode, SOURCE_CONFIGURATION_NAME, i );
     String source = XMLHandler.getNodeValue( sourceNode );
-    return loadUrl( encryptDecryptPassword( source_filefolder, EncryptDirection.DECRYPT ), source, metaStore, namedClusterURLMapping );
+    return source_filefolder == null ? null : loadUrl( encryptDecryptPassword( source_filefolder, EncryptDirection.DECRYPT ), source, metaStore, namedClusterURLMapping );
   }
 
   @Override


### PR DESCRIPTION
…doop File Input step corrupts KTR and prevents it from being opened (8.2 Suite)

@ssamora 