### PR TITLE
[BACKLOG-26480] - Fix an unresolved OSGI reference when running Pentaho MapReduce with Hive

### DIFF
--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -240,6 +240,7 @@
         <include>xmlpull:xmlpull</include>
         <include>xpp3:xpp3_min</include>
         <include>org.apache.kafka:kafka-clients</include>
+        <include>org.mortbay.jetty:servlet-api</include>
         <include>pentaho:pentaho-metaverse-api</include>
       </includes>
     </dependencySet>


### PR DESCRIPTION
@tkafalas @lucboudreau Please review.