### PR TITLE
[BACKLOG-17587] - Removed explicit declaration of maven-assembly-plug…

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -333,7 +333,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>${maven-assembly-plugin.version}</version>
         <executions>
           <execution>
             <id>pkg</id>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -1113,7 +1113,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>${maven-assembly-plugin.version}</version>
         <executions>
           <execution>
             <id>assembly</id>

--- a/assemblies/samples/pom.xml
+++ b/assemblies/samples/pom.xml
@@ -30,7 +30,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>${maven-assembly-plugin.version}</version>
         <executions>
           <execution>
             <id>pkg</id>


### PR DESCRIPTION
…in to use the version declared in the dependency management.

@nantunes please review