### PR TITLE
[BACKLOG-27573] -  Adding OSGi core artifact to pmr lib to substitute…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -811,6 +811,11 @@
       <version>${dependency.pdi-osgi-bridge-core.revision}</version>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>simple-jndi</artifactId>
       <version>${dependency.simple-jndi.revision}</version>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -207,6 +207,7 @@
         <include>org.pentaho.reporting.library:libswing</include>
         <include>org.pentaho.reporting.library:libxml</include>
         <include>pentaho:pdi-osgi-bridge-core</include>
+        <include>org.osgi:org.osgi.core</include>
         <include>pentaho:pentaho-platform-api</include>
         <include>pentaho:pentaho-platform-core</include>
         <include>pentaho:pentaho-platform-extensions</include>


### PR DESCRIPTION
… felix framework. Required for PDI OSGi bridge.