### PR TITLE
[BACKLOG-27577] Centralize karaf dependencies management

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -439,7 +439,6 @@
     <dependency>
       <groupId>org.apache.karaf</groupId>
       <artifactId>org.apache.karaf.main</artifactId>
-      <version>${dependency.karaf.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -1047,7 +1046,6 @@
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.boot</artifactId>
-      <version>2.4.2</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/osgi-jaas/pom.xml
+++ b/osgi-jaas/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.apache.karaf.jaas</groupId>
       <artifactId>org.apache.karaf.jaas.config</artifactId>
-      <version>${dependency.karaf.revision}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <pentaho-json.version>8.3.0.0-SNAPSHOT</pentaho-json.version>
     <pentaho-hadoop-shims-hdp26.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-hdp26.version>
     <pentaho-hadoop-shims-hdp30.version>8.3.0.0-SNAPSHOT</pentaho-hadoop-shims-hdp30.version>
-    <dependency.karaf.revision>3.0.3</dependency.karaf.revision>
     <pentaho-registry.version>8.3.0.0-SNAPSHOT</pentaho-registry.version>
     <dependency.guava.revision>17.0</dependency.guava.revision>
     <dependency.maven-resources-plugin.revision>2.7</dependency.maven-resources-plugin.revision>


### PR DESCRIPTION
@graimundo and @Pancho7 please review.

We are effectively upgrading org.apache.karaf.jaas from 2.4.2 to 3.0.3. Not sure why we had that old version and if it will have any impact...

Note that this targets pentaho:karaf_update, so wingman will not run. Our build pipeline will, when all related PRs are merged.

Needs [pentaho/maven-parent-poms#107](https://github.com/pentaho/maven-parent-poms/pull/107).