### PR TITLE
[PDI-17667] Use of vulnerable component jetty 8.1.15, CVE-2017-9735, …

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -929,47 +929,38 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-continuation</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-io</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-xml</artifactId>
-      <version>8.1.15.v20140411</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -143,7 +143,6 @@
         <include>org.apache.xmlgraphics:batik-i18n</include>
         <include>org.beanshell:bsh</include>
         <include>org.codehaus.groovy:groovy</include>
-        <include>org.codehaus.jackson:jackson-core-asl</include>
         <include>org.codehaus.jackson:jackson-jaxrs</include>
         <include>org.drools:knowledge-api</include>
         <include>org.drools:drools-compiler</include>
@@ -156,6 +155,7 @@
         <include>org.eclipse.jetty:jetty-server</include>
         <include>org.eclipse.jetty:jetty-servlet</include>
         <include>org.eclipse.jetty:jetty-util</include>
+        <include>org.eclipse.jetty:jetty-xml</include>
         <include>org.eobjects.sassyreader:SassyReader</include>
         <include>org.fife.ui:rsyntaxtextarea</include>
         <include>org.hibernate:hibernate-c3p0</include>
@@ -209,13 +209,12 @@
         <include>pentaho:pentaho-platform-api</include>
         <include>pentaho:pentaho-platform-core</include>
         <include>pentaho:pentaho-platform-extensions</include>
-        <include>pentaho:pentaho-xul-core</include>
         <include>pentaho:metastore</include>
         <include>pentaho:mondrian</include>
         <include>pentaho:pentaho-capability-manager</include>
         <include>org.pentaho:commons-database-model</include>
         <include>org.pentaho:pentaho-hadoop-shims-api</include>
-        <include>pentaho:pentaho-metadata</include>
+        <include>org.pentaho:pentaho-metadata</include>
         <include>pentaho:pentaho-osgi-utils-api</include>
         <include>org.pentaho:pentaho-registry</include>
         <include>pentaho:simple-jndi</include>
@@ -234,8 +233,6 @@
         <include>wsdl4j:wsdl4j-qname</include>
         <include>xml-apis:xml-apis</include>
         <include>xml-apis:xml-apis-ext</include>
-        <include>xmlpull:xmlpull</include>
-        <include>xpp3:xpp3_min</include>
         <include>org.apache.kafka:kafka-clients</include>
         <include>org.mortbay.jetty:servlet-api</include>
         <include>pentaho:pentaho-metaverse-api</include>


### PR DESCRIPTION
…CVE-2017-7657 CVE-2015-2080

[PPP-4183] Use of Vulnerable Component: Multiple Jetty Components [Listed in Description] (CVE-2017-7656 | CVE-2017-7657 | CVE-2017-7658 | CVE-2015-2080 | CVE-2017-9735 )



Centralized Jetty components: use dependency management.
On the 'assembly.xml':
- Added 'org.eclipse.jetty:jetty-xml' and fixed 'pentaho:pentaho-metadata' to 'org.pentaho:pentaho-metadata' - they're pom dependencies (and already exist in the final installation folder)
- Removed the duplicated entries for 'xmlpull:xmlpull' and 'xpp3:xpp3_min'
- Removed 'org.codehaus.jackson:jackson-core-asl' and 'pentaho:pentaho-xul-core' - they weren't being included on the resulting Zip file


Depends on pentaho/maven-parent-poms#121

@pentaho-lmartins @pentaho/tatooine
@graimundo @nantunes 