### PR TITLE
[PPP-4283] Use of Vulnerable Components: commons-httpclient-3.0.1.jar…

### DIFF
--- a/api/runtimeTest/pom.xml
+++ b/api/runtimeTest/pom.xml
@@ -42,8 +42,11 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/assemblies/features/src/main/feature/feature.xml
+++ b/assemblies/features/src/main/feature/feature.xml
@@ -5,8 +5,6 @@
     <bundle>wrap:mvn:com.amazonaws/aws-java-sdk/1.11.275</bundle>
     <bundle>mvn:commons-cli/commons-cli/1.2</bundle>
     <bundle>wrap:mvn:com.github.stephenc.high-scale-lib/high-scale-lib/1.1.2</bundle>
-    <bundle>wrap:mvn:org.apache.httpcomponents/httpclient/4.5.3</bundle>
-    <bundle>wrap:mvn:org.apache.httpcomponents/httpcore/4.4</bundle>
     <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.5.2</bundle>
     <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.5.2</bundle>
     <bundle>wrap:mvn:net.java.dev.jets3t/jets3t/0.9.4</bundle>

--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -162,12 +162,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>${dependency.httpcomponents-client.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>${dependency.httpcomponents-core.revision}</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jets3t</groupId>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -917,7 +917,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/kettle-plugins/hdfs/pom.xml
+++ b/kettle-plugins/hdfs/pom.xml
@@ -88,6 +88,7 @@
       <version>${pentaho-metaverse.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- Needed for tests -->
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -21,7 +21,6 @@
   <properties>
     <common.version>3.3.0-v20070426</common.version>
     <pig.version>0.8.1</pig.version>
-    <httpcomponents-core.version>4.4</httpcomponents-core.version>
     <h2.version>1.3.166</h2.version>
     <jets3t.version>0.9.4</jets3t.version>
     <hadoop.version>0.20.2</hadoop.version>
@@ -29,7 +28,6 @@
     <xml-apis.version>2.0.2</xml-apis.version>
     <commands.version>3.3.0-I20070605-0010</commands.version>
     <avro.version>1.6.2</avro.version>
-    <httpcomponents-client.version>4.5.3</httpcomponents-client.version>
     <libthrift.version>0.6</libthrift.version>
     <publish-sonar-phase>site</publish-sonar-phase>
     <oozie.version>3.1.3-incubating</oozie.version>
@@ -154,12 +152,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>${httpcomponents-client.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>${httpcomponents-core.version}</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jets3t</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,7 @@
     <dependency.oozie.revision>3.1.3-incubating</dependency.oozie.revision>
     <pentaho-metadata.version>${project.version}</pentaho-metadata.version>
     <dependency.maven-clean-plugin.revision>2.5</dependency.maven-clean-plugin.revision>
-    <dependency.httpcomponents-core.revision>4.4</dependency.httpcomponents-core.revision>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <dependency.httpcomponents-client.revision>4.5.3</dependency.httpcomponents-client.revision>
     <commons-database.version>${project.version}</commons-database.version>
     <dependency.jackson.revision>1.5.2</dependency.jackson.revision>
     <pentaho-reporting.version>${project.version}</pentaho-reporting.version>


### PR DESCRIPTION
… and httpclient-4.0.1.jar (sonatype-2007-0004 | CVE-2011-1498 | CVE-2012-6153 | CVE-2012-5783)

The bundles:

- wrap:mvn:org.apache.httpcomponents/httpclient/4.5.3
- wrap:mvn:org.apache.httpcomponents/httpcore/4.4

were removed from feature.xml file since they are provided via system bundle. This is now ensured by these PRs:
pentaho/pentaho-karaf-ee-assembly#266
pentaho/pentaho-karaf-assembly#566