### PR TITLE
[BACKLOG-30592] Add Shim/driver to Cluster Configuration

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/hadoopcluster/hadoopcluster.component.js
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/hadoopcluster/hadoopcluster.component.js
@@ -60,9 +60,15 @@ define([
 
       vm.importLabel = i18n.get('cluster.hadoop.import.label');
       vm.versionLabel = i18n.get('cluster.hadoop.version.label');
-      dataService.getShimIdentifiers().then(function(res) {
+      dataService.getShimIdentifiers().then(function (res) {
         vm.shimVersionJson = res.data;
-        vm.shimNames = Array.from(new Set(res.data.map(item => item.vendor))).sort();
+        var shimNames = [];
+        for (var i = 0; i < res.data.length; i++) {
+          if (!contains(shimNames, res.data[i].vendor)) {
+            shimNames.push(res.data[i].vendor);
+          }
+        }
+        vm.shimNames = shimNames;
         vm.shimName = vm.shimNames[0];
       });
 
@@ -89,6 +95,15 @@ define([
       vm.buttons = getButtons();
     }
 
+    function contains(arr, item) {
+      for (var i = 0; i < arr.length; i++) {
+        if (arr[i] === item) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     function resetErrorMsg() {
       if (!vm.data.isSaved) {
         vm.data.state = "new";
@@ -101,11 +116,11 @@ define([
     function onSelect(option) {
       vm.data.model.configurationType = option;
 
-      if (i18n.get('cluster.hadoop.import.ccfg') === option ) {
+      if (i18n.get('cluster.hadoop.import.ccfg') === option) {
         vm.configurationPathPlaceholder = i18n.get('cluster.hadoop.no.ccfg.selected.placeholder');
         vm.selectConfigPathButtonLabel = i18n.get('cluster.hadoop.selectCcfgFileButtonLabel');
         vm.data.model.currentPath = vm.data.model.ccfgFilePath;
-      } else if (i18n.get('cluster.hadoop.provide.site.xml') === option ) {
+      } else if (i18n.get('cluster.hadoop.provide.site.xml') === option) {
         vm.configurationPathPlaceholder = i18n.get('cluster.hadoop.no.config.placeholder');
         vm.selectConfigPathButtonLabel = i18n.get('cluster.hadoop.config.folder.button.label');
         vm.data.model.currentPath = vm.data.model.hadoopConfigFolderPath;
@@ -114,27 +129,31 @@ define([
 
     function onSelectShim(option) {
       vm.data.model.shimName = option;
-      vm.shimVersions = vm.shimVersionJson
-          .filter(item => item.vendor === option)
-          .map(item => item.version);
-      vm.shimVersion = vm.shimVersions[0]
+      var versions = [];
+      for (var i = 0; i < vm.shimVersionJson.length; i++) {
+        if (vm.shimVersionJson[i].vendor === option) {
+          versions.push(vm.shimVersionJson[i].version);
+        }
+      }
+      vm.shimVersions = versions;
+      vm.shimVersion = vm.shimVersions[0];
     }
 
     function onSelectShimVersion(option) {
-      vm.data.model.shimVersion= option;
+      vm.data.model.shimVersion = option;
     }
 
     function onBrowse() {
       try {
         var path;
-        if (i18n.get('cluster.hadoop.provide.site.xml') === vm.data.model.configurationType ) {
-          path = browse( "folder", vm.data.model.hadoopConfigFolderPath);
+        if (i18n.get('cluster.hadoop.provide.site.xml') === vm.data.model.configurationType) {
+          path = browse("folder", vm.data.model.hadoopConfigFolderPath);
           if (path) {
             vm.data.model.hadoopConfigFolderPath = path;
             vm.data.model.currentPath = path;
           }
         } else {
-          path = browse( "file", vm.data.model.ccfgFilePath);
+          path = browse("file", vm.data.model.ccfgFilePath);
           if (path) {
             vm.data.model.ccfgFilePath = path;
             vm.data.model.currentPath = path;
@@ -153,7 +172,7 @@ define([
 
     function checkConfigurationPath() {
       //Sync the paths for the different types with the current path
-      if (i18n.get('cluster.hadoop.provide.site.xml') === vm.data.model.configurationType ) {
+      if (i18n.get('cluster.hadoop.provide.site.xml') === vm.data.model.configurationType) {
         vm.data.model.hadoopConfigFolderPath = vm.data.model.currentPath;
       } else {
         vm.data.model.ccfgFilePath = vm.data.model.currentPath;


### PR DESCRIPTION
Apparently javascript lambdas don't work with the SWT browser
on Windows and Ubuntu, but do on Mac.
Removing lambdas.

https://jira.pentaho.com/browse/BACKLOG-30592