### PR TITLE
[BACKLOG-30801] - Remove wrong comment reference

### DIFF
--- a/impl/shim/pig/src/main/java/org/pentaho/big/data/impl/shim/pig/WriterAppenderManager.java
+++ b/impl/shim/pig/src/main/java/org/pentaho/big/data/impl/shim/pig/WriterAppenderManager.java
@@ -80,7 +80,7 @@ public class WriterAppenderManager implements Closeable {
   }
 
   private Level getLog4jLevel( LogLevel level ) {
-    // KettleLogChannelAppender does not exists in Kette core, so we'll use it from kettle5-log4j-plugin.
+    // KettleLogChannelAppender does not exists in Kette core, so we'll use it from kettle5-log4j-core.
     Level log4jLevel = KettleLogChannelAppender.LOG_LEVEL_MAP.get( level );
     return log4jLevel != null ? log4jLevel : Level.INFO;
   }


### PR DESCRIPTION
Remove wrong comment with reference to kettle5-log4j-plugin.

Where was kettle5-log4j-plugin should be kettle5-log4j-core