### PR TITLE
[BACKLOG-31075] Add the ability for a user to specify a metastore

### DIFF
--- a/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
+++ b/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
@@ -7,6 +7,10 @@ active.hadoop.configuration=
 # Path to the directory that contains the available Hadoop configurations
 hadoop.configurations.path=hadoop-configurations
 
+# Path to metastore to use when running on a Pentaho slave server
+# To use an existing PDI metastore, for example, the directory is /home/user/.pentaho
+big.data.slave.metastore.dir=
+
 # Version of Kettle to use from the Kettle HDFS installation directory. This can be set globally here or overridden per job
 # as a User Defined property. If not set we will use the version of Kettle that is used to submit the Pentaho MapReduce job.
 pmr.kettle.installation.id=

--- a/impl/cluster/src/test/resources/plugin.properties
+++ b/impl/cluster/src/test/resources/plugin.properties
@@ -1,0 +1,1 @@
+big.data.slave.metastore.dir=


### PR DESCRIPTION
location in the big-data-plugin plugin.properties file when running on a
pentaho slave server.