### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/assemblies/features/src/main/feature/feature.xml
+++ b/assemblies/features/src/main/feature/feature.xml
@@ -13,9 +13,7 @@
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/1.1</bundle>
     <bundle>wrap:mvn:org.pentaho.di.plugins/kettle-log4j-core/${pdi.version}</bundle>
     <bundle>wrap:mvn:libthrift/libthrift/0.6</bundle>
-    <bundle>wrap:mvn:xmlpull/xmlpull/1.1.3.1</bundle>
-    <bundle>wrap:mvn:xpp3/xpp3_min/1.1.4c</bundle>
-    <bundle>mvn:com.thoughtworks.xstream/xstream/1.4.10</bundle>
+    <bundle>mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>
   </feature>
 
   <feature name="pentaho-big-data-plugin-osgi" version="1.0">

--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -202,7 +202,6 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>${dependency.xstream.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.pentaho</groupId>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -230,7 +230,6 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>${dependency.xstream.revision}</version>
     </dependency>
     <dependency>
       <groupId>org.dom4j</groupId>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -20,7 +20,6 @@
   </licenses>
   <properties>
     <common.version>3.3.0-v20070426</common.version>
-    <xmlpull.revision>1.1.3.1</xmlpull.revision>
     <pig.version>0.8.1</pig.version>
     <httpcomponents-core.version>4.4</httpcomponents-core.version>
     <h2.version>1.3.166</h2.version>
@@ -35,7 +34,6 @@
     <publish-sonar-phase>site</publish-sonar-phase>
     <oozie.version>3.1.3-incubating</oozie.version>
     <high-scale-lib.version>1.1.2</high-scale-lib.version>
-    <xpp3.revision>1.1.4c</xpp3.revision>
     <jline.version>0.9.94</jline.version>
     <easymock.version>3.0</easymock.version>
     <org.powermock.version>1.6.2</org.powermock.version>
@@ -187,21 +185,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xmlpull</groupId>
-      <artifactId>xmlpull</artifactId>
-      <version>${xmlpull.revision}</version>
-    </dependency>
-    <dependency>
-      <groupId>xpp3</groupId>
-      <artifactId>xpp3_min</artifactId>
-      <version>${xpp3.revision}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>${dependency.xstream.revision}</version>
     </dependency>
     <dependency>
       <groupId>pentaho-kettle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
     <dependency.simple-jndi.revision>1.0.2</dependency.simple-jndi.revision>
     <dependency.xpp3.revision>1.1.4c</dependency.xpp3.revision>
     <dependency.jets3t.revision>0.9.4</dependency.jets3t.revision>
-    <dependency.xstream.revision>1.4.10</dependency.xstream.revision>
     <dependency.oozie.revision>3.1.3-incubating</dependency.oozie.revision>
     <pentaho-metadata.version>${project.version}</pentaho-metadata.version>
     <dependency.maven-clean-plugin.revision>2.5</dependency.maven-clean-plugin.revision>


### PR DESCRIPTION
This is part of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/170 for details.

**Don't merge before the PR above.**

Removing unnecessary dependencies from `legacy` module. Changes to `feature.xml` don't cause any differences in the final assembly.