### PR TITLE
[BACKLOG-30731] Added S3Details.getProperties

### DIFF
--- a/legacy/src/main/java/org/pentaho/amazon/s3/S3Details.java
+++ b/legacy/src/main/java/org/pentaho/amazon/s3/S3Details.java
@@ -30,7 +30,11 @@ import org.pentaho.metastore.persist.MetaStoreElementType;
 import org.pentaho.s3.vfs.S3FileProvider;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
 
 @MetaStoreElementType(
   name = "Amazon S3 Connection",
@@ -87,6 +91,7 @@ public class S3Details implements VFSConnectionDetails {
     return description;
   }
 
+
   public void setDescription( String description ) {
     this.description = description;
   }
@@ -141,8 +146,8 @@ public class S3Details implements VFSConnectionDetails {
 
   public List<String> getRegions() {
     List<String> names = new ArrayList<>();
-    for ( Regions region : Regions.values() ) {
-      names.add( region.getName() );
+    for ( Regions reg : Regions.values() ) {
+      names.add( reg.getName() );
     }
     return names;
   }
@@ -161,5 +166,20 @@ public class S3Details implements VFSConnectionDetails {
 
   public void setProfileName( String profileName ) {
     this.profileName = profileName;
+  }
+
+  @Override public Map<String, String> getProperties() {
+    Map<String, String> props = new HashMap<>();
+    props.put( "name", getName() );
+    props.put( "description", getDescription() );
+    props.put( "accessKey", getAccessKey() );
+    props.put( "secretKey", getSecretKey() );
+    props.put( "sessionToken", getSessionToken() );
+    props.put( "credentialsFilePath", getCredentialsFilePath() );
+    props.put( "credentialsFile", getCredentialsFile() );
+    props.put( "authType", getAuthType() );
+    props.put( "region", getRegion() );
+    props.put( "profileName", getProfileName() );
+    return unmodifiableMap( props );
   }
 }

--- a/legacy/src/test/java/org/pentaho/amazon/s3/S3DetailsTest.java
+++ b/legacy/src/test/java/org/pentaho/amazon/s3/S3DetailsTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.amazon.s3;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class S3DetailsTest {
+
+  private S3Details s3Details = new S3Details();
+
+  @Test
+  public void getProperties() {
+    s3Details.setName( "name" );
+    s3Details.setRegion( "aws-west-1" );
+    s3Details.setAccessKey( "ASIAXJ3TZZPFVO3NK6O" );
+    s3Details.setSecretKey( "jKbmptEdHk6cTXXqGodacxJn5yaETIIhKjJb/oZ" );
+
+    Map<String, String> props = s3Details.getProperties();
+    assertThat( props.get( "name" ), equalTo( "name" ) );
+    assertThat( props.get( "region" ), equalTo( "aws-west-1" ) );
+    assertThat( props.get( "accessKey" ), equalTo( "ASIAXJ3TZZPFVO3NK6O" ) );
+    assertThat( props.get( "secretKey" ), equalTo( "jKbmptEdHk6cTXXqGodacxJn5yaETIIhKjJb/oZ" ) );
+    assertThat( props.size(), equalTo( 10 ) );
+    assertThat( props.entrySet().stream().filter( e -> e.getValue() != null ).count(), equalTo( 4L ) );
+  }
+}


### PR DESCRIPTION
Used to get connection info w/o adding a dependency on big-data-legacy
to the shims.

https://jira.pentaho.com/browse/BACKLOG-30731