### PR TITLE
Multishim: Changing the vendor shim of a fully configured cluster does not set back to default

### DIFF
--- a/kettle-plugins/common/ui/src/main/resources/org/pentaho/big/data/plugins/common/ui/messages/messages_en_US.properties
+++ b/kettle-plugins/common/ui/src/main/resources/org/pentaho/big/data/plugins/common/ui/messages/messages_en_US.properties
@@ -59,4 +59,3 @@ Spoon.Dialog.ErrorAddingNewConfigurationForCluster.Title=Error
 Spoon.Dialog.ErrorAddingNewConfigurationForCluster.Message=Something went wrong trying to add the new configuration for the cluster: {0}
 Spoon.Dialog.ErrorRenamingPreviousClusterConfig.Title=Error
 Spoon.Dialog.ErrorRenamingPreviousClusterConfig.Message=Couldn't rename the previous shim configuration file
-Spoon.Dialog.ErrorRenamingPreviousClusterConfig.Exception=File couldn't be renamed


### PR DESCRIPTION
[BACKLOG-29907] Changing to platform independent method to backup config file

Hey @angel-ramoscardona, @jgminder, @peterrinehart: Could you please take a look at this pull request? Thanks!