### PR TITLE
[BACKLOG-31963] Add support for s3a URLs to PDI - S3 File Output Brow…

### DIFF
--- a/legacy/src/main/java/org/pentaho/amazon/s3/S3AVfsFileChooserHelper.java
+++ b/legacy/src/main/java/org/pentaho/amazon/s3/S3AVfsFileChooserHelper.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.amazon.s3;
+
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.eclipse.swt.widgets.Shell;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.ui.vfs.VfsFileChooserHelper;
+import org.pentaho.s3a.vfs.S3AFileProvider;
+import org.pentaho.vfs.ui.VfsFileChooserDialog;
+
+
+public class S3AVfsFileChooserHelper extends VfsFileChooserHelper {
+
+  public S3AVfsFileChooserHelper( Shell shell, VfsFileChooserDialog fileChooserDialog, VariableSpace variableSpace ) {
+    super( shell, fileChooserDialog, variableSpace );
+    setDefaultScheme( S3AFileProvider.SCHEME );
+    setSchemeRestriction( S3AFileProvider.SCHEME );
+  }
+
+  public S3AVfsFileChooserHelper( Shell shell, VfsFileChooserDialog fileChooserDialog, VariableSpace variableSpace,
+                                  FileSystemOptions fileSystemOptions ) {
+    super( shell, fileChooserDialog, variableSpace, fileSystemOptions );
+    setDefaultScheme( S3AFileProvider.SCHEME );
+    setSchemeRestriction( S3AFileProvider.SCHEME );
+  }
+
+  @Override
+  protected boolean returnsUserAuthenticatedFileObjects() {
+    return true;
+  }
+}

--- a/legacy/src/main/java/org/pentaho/amazon/s3/S3FileOutputDialog.java
+++ b/legacy/src/main/java/org/pentaho/amazon/s3/S3FileOutputDialog.java
@@ -86,6 +86,7 @@ import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
 import org.pentaho.di.ui.trans.step.TableItemInsertListener;
+import org.pentaho.di.ui.vfs.VfsFileChooserHelper;
 import org.pentaho.vfs.ui.VfsFileChooserDialog;
 
 import java.nio.charset.Charset;
@@ -236,7 +237,7 @@ public class S3FileOutputDialog extends BaseStepDialog implements StepDialogInte
 
   private boolean gotPreviousFields = false;
 
-  private S3NVfsFileChooserHelper helper = null;
+  private VfsFileChooserHelper helper = null;
   private VfsFileChooserDialog fileChooserDialog = null;
 
   public S3FileOutputDialog( Shell parent, Object in, TransMeta transMeta, String sname ) {
@@ -1670,9 +1671,9 @@ public class S3FileOutputDialog extends BaseStepDialog implements StepDialogInte
     return this.getClass().getName();
   }
 
-  protected S3NVfsFileChooserHelper getFileChooserHelper() throws KettleFileException, FileSystemException {
+  protected VfsFileChooserHelper getFileChooserHelper() throws KettleFileException, FileSystemException {
     if ( helper == null ) {
-      helper = new S3NVfsFileChooserHelper( shell, getFileChooserDialog(), getVariableSpace(), getFileSystemOptions() );
+      helper = new S3AVfsFileChooserHelper( shell, getFileChooserDialog(), getVariableSpace(), getFileSystemOptions() );
     }
     return helper;
   }


### PR DESCRIPTION
…se Error

When in S3 File Output Step we click browse the VFS window opens with no selection in the Location ComboBox

This is due to the introduction of S3A in:
https://github.com/pentaho/pentaho-s3-vfs/pull/86/files
https://github.com/pentaho/big-data-plugin/pull/1862/files
In particular this addition:
https://github.com/pentaho/big-data-plugin/pull/1862/files#diff-17250df2ce6febb3107baaa07bcc5943R45
 
@ddiroma @bmorrise @rmansoor @pentaho-lmartins 