### PR TITLE
[BACKLOG-31426] Use active.hadoop.configuration variable in place of

### DIFF
--- a/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
+++ b/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
@@ -2,14 +2,16 @@
 # including HDFS, Hive, HBase, and Sqoop.
 # For more configuration options specific to the Hadoop configuration choosen
 # here see the config.properties file in that configuration's directory.
+# Note: should no longer be used and will be ignored after named cluster configurations have been updated for 9.0+
+# Will only be referenced if site configuration files are not found in the expected locations in the metastore folders
 active.hadoop.configuration=
 
-# Path to the directory that contains the available Hadoop configurations
+# If using shim configurations from 8.3 and prior and have not migrated to 9.0 configurations:
+#     Path to the directory that contains the available Hadoop configurations
+# If using shim configurations from 9.0+:
+#     Path to metastore to use when running on a Pentaho slave server (e.g. Pan or Kitchen)
+#     To use an existing PDI metastore, for example, the directory is /home/user/.pentaho
 hadoop.configurations.path=hadoop-configurations
-
-# Path to metastore to use when running on a Pentaho slave server
-# To use an existing PDI metastore, for example, the directory is /home/user/.pentaho
-big.data.slave.metastore.dir=
 
 # Version of Kettle to use from the Kettle HDFS installation directory. This can be set globally here or overridden per job
 # as a User Defined property. If not set we will use the version of Kettle that is used to submit the Pentaho MapReduce job.

--- a/impl/cluster/src/main/java/org/pentaho/big/data/impl/cluster/NamedClusterManager.java
+++ b/impl/cluster/src/main/java/org/pentaho/big/data/impl/cluster/NamedClusterManager.java
@@ -63,7 +63,7 @@ import java.util.Properties;
 
 public class NamedClusterManager implements NamedClusterService {
 
-  public static final String BIG_DATA_SLAVE_METASTORE_DIR = "big.data.slave.metastore.dir";
+  public static final String BIG_DATA_SLAVE_METASTORE_DIR = "hadoop.configurations.path";
   private static final Class<?> PKG = NamedClusterManager.class;
   private BundleContext bundleContext;
 


### PR DESCRIPTION
adding a new one for this release.