### PR TITLE
[BACKLOG-32824] Avro/Parquet/Orc don't allow variables in filename

### DIFF
--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/input/AvroInputDialog.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/input/AvroInputDialog.java
@@ -134,7 +134,9 @@ public class AvroInputDialog extends BaseAvroStepDialog {
 
     List<? extends IAvroInputField> defaultFields;
     try {
-      defaultFields = AvroInput.getLeafFields( meta.getNamedClusterServiceLocator(), meta.getNamedCluster(), schemaFileName, avroFileName );
+      defaultFields = AvroInput
+        .getLeafFields( meta.getNamedClusterServiceLocator(), meta.getNamedCluster( avroFileName ), schemaFileName,
+          avroFileName );
       if ( defaultFields != null ) {
         wInputFields.clearAll();
         for ( IAvroInputField field : defaultFields ) {
@@ -201,7 +203,8 @@ public class AvroInputDialog extends BaseAvroStepDialog {
     colinf2[ 0 ].setAutoResize( false );
     colinf2[ 1 ].setAutoResize( false );
     colinf2[ 2 ].setAutoResize( false );
-    wLookupView = new TableView( transMeta, wVarsComp, SWT.FULL_SELECTION | SWT.MULTI | SWT.BORDER, colinf2, 1, lsMod, props );
+    wLookupView =
+      new TableView( transMeta, wVarsComp, SWT.FULL_SELECTION | SWT.MULTI | SWT.BORDER, colinf2, 1, lsMod, props );
     wLookupView.setLayoutData( new FormDataBuilder().top( 0, Const.MARGIN * 2 )
       .bottom( wGetLookupFieldsBut, -Const.MARGIN * 2 ).left().right().result() );
 
@@ -355,7 +358,8 @@ public class AvroInputDialog extends BaseAvroStepDialog {
     layout.marginHeight = MARGIN;
     layout.marginWidth = MARGIN;
     wFileSettingsGroup.setLayout( layout );
-    wFileSettingsGroup.setLayoutData( new FormDataBuilder().top( encodingLabel, 35 ).left( 0, MARGIN ).right( 100, -MARGIN ).result() );
+    wFileSettingsGroup
+      .setLayoutData( new FormDataBuilder().top( encodingLabel, 35 ).left( 0, MARGIN ).right( 100, -MARGIN ).result() );
 
     Label separator = new Label( wFileSettingsGroup, SWT.SEPARATOR | SWT.VERTICAL );
     separator.setLayoutData( new FormDataBuilder().left( 0, RADIO_BUTTON_WIDTH ).top().bottom().result() );
@@ -425,7 +429,8 @@ public class AvroInputDialog extends BaseAvroStepDialog {
     schemaLayout.marginWidth = MARGIN;
     schemaLayout.marginHeight = MARGIN;
     wSourceGroup.setLayout( schemaLayout );
-    wSourceGroup.setLayoutData( new FormDataBuilder().top( wFileSettingsGroup, 10 ).right( 100, -MARGIN ).left( 0, MARGIN ).result() );
+    wSourceGroup.setLayoutData(
+      new FormDataBuilder().top( wFileSettingsGroup, 10 ).right( 100, -MARGIN ).left( 0, MARGIN ).result() );
 
     Label schemaSeparator = new Label( wSourceGroup, SWT.SEPARATOR | SWT.VERTICAL );
     schemaSeparator.setLayoutData( new FormDataBuilder().left( 0, RADIO_BUTTON_WIDTH ).top().bottom().result() );
@@ -684,7 +689,8 @@ public class AvroInputDialog extends BaseAvroStepDialog {
     Matcher m = p.matcher( value );
     while ( m.find() ) {
       if ( m.end() - m.start() < 3 ) {
-        value = new StringBuilder( value ).insert( m.start() + 1, item.getText( AVRO_INDEXED_VALUES_COLUMN_INDEX ) ).toString();
+        value = new StringBuilder( value ).insert( m.start() + 1, item.getText( AVRO_INDEXED_VALUES_COLUMN_INDEX ) )
+          .toString();
       } else {
         value = value.replace( m.group( 1 ), item.getText( AVRO_INDEXED_VALUES_COLUMN_INDEX ) );
       }

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/output/AvroOutputMeta.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/avro/output/AvroOutputMeta.java
@@ -65,8 +65,8 @@ public class AvroOutputMeta extends AvroOutputMetaBase {
     return new AvroOutputData();
   }
 
-  public NamedCluster getNamedCluster() {
-    return NamedClusterResolver.resolveNamedCluster( namedClusterService, metaStoreService, this.getFilename() );
+  public NamedCluster getNamedCluster( String filename ) {
+    return NamedClusterResolver.resolveNamedCluster( namedClusterService, metaStoreService, filename );
   }
 
 }

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/orc/input/OrcInput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/orc/input/OrcInput.java
@@ -52,7 +52,7 @@ public class OrcInput extends BaseFileInputStep<OrcInputMeta, OrcInputData> {
   private final NamedClusterServiceLocator namedClusterServiceLocator;
 
   public OrcInput( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-      Trans trans, NamedClusterServiceLocator namedClusterServiceLocator ) {
+                   Trans trans, NamedClusterServiceLocator namedClusterServiceLocator ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
     this.namedClusterServiceLocator = namedClusterServiceLocator;
   }
@@ -67,10 +67,10 @@ public class OrcInput extends BaseFileInputStep<OrcInputMeta, OrcInputData> {
         if ( meta.inputFiles == null || meta.getFilename() == null || meta.getFilename().length() == 0 ) {
           throw new KettleException( "No input files defined" );
         }
-        data.input = formatService.createInputFormat( IPentahoOrcInputFormat.class, meta.getNamedCluster() );
+        data.input = formatService.createInputFormat( IPentahoOrcInputFormat.class, getNamedCluster() );
 
         String inputFileName = getKettleVFSFileName(
-                meta.getParentStepMeta().getParentTransMeta().environmentSubstitute( meta.getFilename() ) );
+          meta.getParentStepMeta().getParentTransMeta().environmentSubstitute( meta.getFilename() ) );
 
         data.input.setInputFile( inputFileName );
         data.input.setSchema( createSchemaFromMeta( meta ) );
@@ -95,10 +95,14 @@ public class OrcInput extends BaseFileInputStep<OrcInputMeta, OrcInputData> {
     }
   }
 
+  private NamedCluster getNamedCluster() {
+    return meta.getNamedCluster( environmentSubstitute( meta.getFilename() ) );
+  }
+
   private FormatService getFormatService() throws KettleException {
     FormatService formatService;
     try {
-      formatService = namedClusterServiceLocator.getService( meta.getNamedCluster(), FormatService.class );
+      formatService = namedClusterServiceLocator.getService( getNamedCluster(), FormatService.class );
     } catch ( ClusterInitializationException e ) {
       throw new KettleException( "can't get service format shim ", e );
     }
@@ -118,12 +122,12 @@ public class OrcInput extends BaseFileInputStep<OrcInputMeta, OrcInputData> {
   }
 
   public static List<IOrcInputField> retrieveSchema( NamedClusterServiceLocator namedClusterServiceLocator,
-                                                               NamedCluster namedCluster, String dataPath ) throws Exception {
+                                                     NamedCluster namedCluster, String dataPath ) throws Exception {
     FormatService formatService = namedClusterServiceLocator.getService( namedCluster, FormatService.class );
     IPentahoOrcInputFormat in = formatService.createInputFormat( IPentahoOrcInputFormat.class, namedCluster );
 
     in.setInputFile( getKettleVFSFileName( dataPath ) );
-    return in.readSchema( );
+    return in.readSchema();
   }
 
   public static List<IOrcInputField> createSchemaFromMeta( OrcInputMetaBase meta ) {

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/orc/output/OrcOutputMeta.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/orc/output/OrcOutputMeta.java
@@ -64,8 +64,8 @@ public class OrcOutputMeta extends OrcOutputMetaBase {
     return new OrcOutputData();
   }
 
-  public NamedCluster getNamedCluster() {
-    return NamedClusterResolver.resolveNamedCluster( namedClusterService, metaStoreService, this.getFilename() );
+  public NamedCluster getNamedCluster( String filename ) {
+    return NamedClusterResolver.resolveNamedCluster( namedClusterService, metaStoreService, filename );
   }
 
 }

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutput.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutput.java
@@ -23,6 +23,7 @@
 package org.pentaho.big.data.kettle.plugins.formats.impl.parquet.output;
 
 import org.apache.commons.vfs2.FileObject;
+import org.pentaho.hadoop.shim.api.cluster.NamedCluster;
 import org.pentaho.hadoop.shim.api.cluster.NamedClusterServiceLocator;
 import org.pentaho.hadoop.shim.api.cluster.ClusterInitializationException;
 import org.pentaho.big.data.kettle.plugins.formats.parquet.output.ParquetOutputMetaBase;
@@ -52,7 +53,7 @@ public class ParquetOutput extends BaseStep implements StepInterface {
   private ParquetOutputData data;
 
   public ParquetOutput( StepMeta stepMeta, StepDataInterface stepDataInterface, int copyNr, TransMeta transMeta,
-      Trans trans, NamedClusterServiceLocator namedClusterServiceLocator ) {
+                        Trans trans, NamedClusterServiceLocator namedClusterServiceLocator ) {
     super( stepMeta, stepDataInterface, copyNr, transMeta, trans );
     this.namedClusterServiceLocator = namedClusterServiceLocator;
   }
@@ -101,7 +102,8 @@ public class ParquetOutput extends BaseStep implements StepInterface {
   public void init( RowMetaInterface rowMeta ) throws Exception {
     FormatService formatService;
     try {
-      formatService = namedClusterServiceLocator.getService( meta.getNamedCluster(), FormatService.class );
+      formatService = namedClusterServiceLocator
+        .getService( getNamedCluster(), FormatService.class );
     } catch ( ClusterInitializationException e ) {
       throw new KettleException( "can't get service format shim ", e );
     }
@@ -109,7 +111,7 @@ public class ParquetOutput extends BaseStep implements StepInterface {
       throw new KettleException( "No output files defined" );
     }
 
-    data.output = formatService.createOutputFormat( IPentahoParquetOutputFormat.class, meta.getNamedCluster() );
+    data.output = formatService.createOutputFormat( IPentahoParquetOutputFormat.class, getNamedCluster() );
 
     String outputFileName = environmentSubstitute( meta.constructOutputFilename() );
     FileObject outputFileObject = KettleVFS.getFileObject( outputFileName, getTransMeta() );
@@ -144,6 +146,10 @@ public class ParquetOutput extends BaseStep implements StepInterface {
     }
 
     data.writer = data.output.createRecordWriter();
+  }
+
+  private NamedCluster getNamedCluster() {
+    return meta.getNamedCluster( environmentSubstitute( meta.getFilename() ) );
   }
 
   public void closeWriter() throws KettleException {

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutputMeta.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/parquet/output/ParquetOutputMeta.java
@@ -63,8 +63,8 @@ public class ParquetOutputMeta extends ParquetOutputMetaBase {
     return new ParquetOutput( stepMeta, stepDataInterface, copyNr, transMeta, trans, namedClusterServiceLocator );
   }
 
-  public NamedCluster getNamedCluster() {
-    return NamedClusterResolver.resolveNamedCluster( namedClusterService, metaStoreService, this.getFilename() );
+  public NamedCluster getNamedCluster( String filename ) {
+    return NamedClusterResolver.resolveNamedCluster( namedClusterService, metaStoreService, filename );
   }
 
   @Override


### PR DESCRIPTION
Doing variable substitution prior to getting namedcluster in each
of the 6 places we retrieve the named cluster (parquet/orc/avro, in/out).
Would love to see this refactored to reduce the duplication post 9.0.

https://jira.pentaho.com/browse/BACKLOG-32824