### PR TITLE
[BACKLOG-32617] repoConnection still needs to be set in init

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/import/import.component.js
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/import/import.component.js
@@ -89,7 +89,9 @@ define([
           vm.data.type = "import";
           vm.shimVendor = vm.shimVendors[0];
         }
+        vm.data.connectedToRepo = connectedToRepo;
       });
+
       vm.buttons = getButtons();
       vm.overwriteDialogButtons = getOverwriteDialogButtons();
     }

--- a/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/newEdit/newEdit.component.js
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/newEdit/newEdit.component.js
@@ -121,8 +121,8 @@ define([
           vm.data.created = false;
           vm.shimVendor = vm.shimVendors[0];
         }
+        vm.data.connectedToRepo = connectedToRepo;
       });
-
       vm.buttons = getButtons();
       vm.overwriteDialogButtons = getOverwriteDialogButtons();
     }


### PR DESCRIPTION
Last commit removed the repo message on new / import

https://jira.pentaho.com/browse/BACKLOG-32617