### PR TITLE
[BACKLOG-32449] Fixed issues: Losing keytab path in config.properties…

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
@@ -172,6 +172,7 @@ public class HadoopClusterManagerTest {
 
   @Test public void testEditNamedCluster() {
     ThinNameClusterModel model = new ThinNameClusterModel();
+    model.setKerberosSubType( "" );
     model.setName( ncTestName );
     model.setOldName( ncTestName );
     JSONObject result = hadoopClusterManager.editNamedCluster( model, true, getFiles( "/" ) );


### PR DESCRIPTION
… when changing vendor while editing an existing Named Cluster with Kerberos security set AND not removing the keytab path in config.properties when changing Kerberos sub type to Password when editing an existing Named Cluster.