### PR TITLE
[BACKLOG-32812] Create a property to allow users to configure the number

### DIFF
--- a/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
+++ b/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
@@ -66,3 +66,8 @@ maxTimeoutBeforeLoadingShim=300
 # Setting this property to false will save space within HDFS but can cause concurrency and security issues if multiple users are using the same 
 # pmr.kettle.dfs.install.dir.
 pmr.create.unique.metastore.dir=true
+
+# Value to use for the ipc.client.connect.max.retries.on.timeouts Hadoop property when connecting to HDFS
+# Note that this value overrides any ipc.client.connect.max.retries.on.timeouts set in *site.xml files for individual
+# Hadoop cluster definitions
+hadoopfs.ipc.client.connect.max.retries.on.timeouts=5


### PR DESCRIPTION
of timeouts when connecting to HDFS.