### PR TITLE
[BACKLOG-32812-2] Final cleanup; should get the Hadoop File Input GUI…

### DIFF
--- a/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
+++ b/kettle-plugins/hdfs/src/main/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -138,26 +138,17 @@ public class HadoopFileInputMeta extends TextFileInputMeta implements HadoopFile
     NamedCluster c = namedClusterService.getNamedClusterByName( ncName, metastore );
     if ( c != null ) {
       url = c.processURLsubstitution( url, metastore, new Variables() );
-      if ( !Utils.isEmpty( ncName ) && !Utils.isEmpty( url ) && mappings != null ) {
-        mappings.put( url, ncName );
-        // in addition to the url as-is, add the public uri string version of the url (hidden password) to the map,
-        // since that is the value that the data-lineage analyzer will have access to for cluster lookup
-        try {
-          mappings.put( getFriendlyUri( url ).toString(), ncName );
-        } catch ( final Exception e ) {
-          // no-op
-        }
-      }
-    } else {
-      mappings.put( url, null );
+    }
+    if ( !Utils.isEmpty( ncName ) && !Utils.isEmpty( url ) && mappings != null ) {
+      mappings.put( url, ncName );
+      // in addition to the url as-is, add the public uri string version of the url (hidden password) to the map,
+      // since that is the value that the data-lineage analyzer will have access to for cluster lookup
       try {
-        URI friendlyUri = getFriendlyUri( url );
-        mappings.put( friendlyUri.toString(), null );
-      } catch ( URISyntaxException e ) {
+        mappings.put( getFriendlyUri( url ).toString(), ncName );
+      } catch ( final Exception e ) {
         // no-op
       }
     }
-
     return url;
   }
 

--- a/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMetaTest.java
+++ b/kettle-plugins/hdfs/src/test/java/org/pentaho/big/data/kettle/plugins/hdfs/trans/HadoopFileInputMetaTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p/>
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
  * <p/>
  * ******************************************************************************
  * <p/>
@@ -148,7 +148,7 @@ public class HadoopFileInputMetaTest {
     //create spy to check whether saveSource now is called
     IMetaStore metaStore = mock( IMetaStore.class );
     spy.loadXML( node, Collections.emptyList(), metaStore );
-    assertNull( hadoopFileInputMeta.getNamedClusterURLMapping().get( TEST_FILE_NAME ) );
+    assertEquals( TEST_CLUSTER_NAME, hadoopFileInputMeta.getNamedClusterURLMapping().get( TEST_FILE_NAME ) );
     verify( spy, times( 1 ) ).loadSource( any( Node.class ), any( Node.class ), anyInt(), any( IMetaStore.class ) );
   }
 


### PR DESCRIPTION
… to not show named

cluster names that do not exist in the current environment and also not
truncate static/local/s3 URLs.