### PR TITLE
[PPP-4461] Use of Vulnerable Component: com.fasterxml.jackson.core:ja…

### DIFF
--- a/assemblies/features/src/main/feature/feature.xml
+++ b/assemblies/features/src/main/feature/feature.xml
@@ -5,8 +5,8 @@
     <bundle>wrap:mvn:com.amazonaws/aws-java-sdk/1.11.275</bundle>
     <bundle>mvn:commons-cli/commons-cli/1.2</bundle>
     <bundle>wrap:mvn:com.github.stephenc.high-scale-lib/high-scale-lib/1.1.2</bundle>
-    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.5.2</bundle>
-    <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.5.2</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus-jackson.version}</bundle>
     <bundle>wrap:mvn:net.java.dev.jets3t/jets3t/0.9.4</bundle>
     <bundle>wrap:mvn:jline/jline/0.9.94</bundle>
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/1.1</bundle>


### PR DESCRIPTION
…ckson-databind: CVE-2019-16943 and others

Additional PR to complete work in https://github.com/pentaho/maven-parent-poms/pull/201.
We were pulling `codehaus-jackson` **1.5.2** which is vulnerable.

@graimundo 