### PR TITLE
[SP-5385] Backport of PDI-18595 - Hadoop Cluster Dialog - dialog header disappear after going Back to initial dialog (New Cluster and Edit dialogs) (9.0 Suite)

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/newEdit/newEdit.component.js
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/components/newEdit/newEdit.component.js
@@ -116,6 +116,13 @@ define([
             //Most of the data already exists in the model
             loadShimDropDowns();
             vm.siteFiles = fileService.getFiles();
+            if (vm.data.type) {
+              if (vm.data.type === "new") {
+                vm.header = i18n.get('new.header');
+              } else if (vm.data.type === "edit" || vm.data.type === "duplicate") {
+                vm.header = i18n.get('edit.header');
+              }
+            }
           }
         } else {
           //this is a new state, no name exists in the model or on the URL


### PR DESCRIPTION
Cherry-pick of https://github.com/pentaho/big-data-plugin/pull/2005