### PR TITLE
[PPP-4496] Use of Vulnerable Component: Components/kafka

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -1016,7 +1016,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${kafka-clients.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/impl/clusterTests/pom.xml
+++ b/impl/clusterTests/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${kafka-clients.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/kettle-plugins/kafka/pom.xml
+++ b/kettle-plugins/kafka/pom.xml
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${kafka-clients.version}</version>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
     <dependency.avro.revision>1.6.2</dependency.avro.revision>
     <dependency.cxf.revision>3.0.13</dependency.cxf.revision>
     <aws-java-sdk.version>1.11.275</aws-java-sdk.version>
-    <kafka-clients.version>0.10.2.1</kafka-clients.version>
     <dependency.hamcrest.revision>1.3</dependency.hamcrest.revision>
     <commons-xul.version>9.1.0.0-SNAPSHOT</commons-xul.version>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>


### PR DESCRIPTION
* [PPP-4496] Upgrading to version 0.10.2.2
* [PPP-4496] Removing version reference, maven-parent-pom will control version info.

This is from a series of Pull Requests:
- https://github.com/pentaho/maven-parent-poms/pull/218
- https://github.com/pentaho/big-data-plugin/pull/2032
- https://github.com/pentaho/pdi-plugins-ee/pull/168
- https://github.com/pentaho/pentaho-platform/pull/4649
- https://github.com/pentaho/pentaho-reporting/pull/1327
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/152
- https://github.com/pentaho/pentaho-metadata-editor/pull/190
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/85
- https://github.com/pentaho/pentaho-kettle/pull/7309
- https://github.com/pentaho/pentaho-big-data-ee/pull/441