### PR TITLE
[BACKLOG-33449 BACKLOG-33406] Upgrade Angular JS library from 1.5.8 version to 1.7.8 for pentaho-kettle

### DIFF
--- a/impl/connections/s3/pom.xml
+++ b/impl/connections/s3/pom.xml
@@ -15,9 +15,8 @@
   <name>Pentaho S3 Connection UI</name>
 
   <properties>
-    <js.project.list>requirejs,requirejs-text,angular,angular-ui-router,ui-router-extras,require-css</js.project.list>
+    <js.project.list>requirejs,requirejs-text,angular,require-css</js.project.list>
     <maven-replacer-plugin.version>1.5.2</maven-replacer-plugin.version>
-    <angular.version>1.5.8</angular.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
@@ -44,13 +43,11 @@
     <dependency>
       <groupId>org.webjars.bower</groupId>
       <artifactId>angular</artifactId>
-      <version>${angular.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
-      <version>${angular.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/impl/connections/s3/src/main/resources-filtered/app/package.json
+++ b/impl/connections/s3/src/main/resources-filtered/app/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "angular": "${angular.version}",
     "angular-animate": "${angular.version}",
-    "angular-i18n": "${angular-i18n.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
+    "angular-i18n": "${angular.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}"
   },

--- a/kettle-plugins/hadoop-cluster/pom.xml
+++ b/kettle-plugins/hadoop-cluster/pom.xml
@@ -24,14 +24,10 @@
     <dependency.osgi.version>4.3.1</dependency.osgi.version>
     <version.for.license>${project.version}</version.for.license>
     <js.project.list>requirejs,requirejs-text,angular,require-css,angular-i18n</js.project.list>
-    <angular.version>1.5.8</angular.version>
-    <angular-animate.version>${angular.version}</angular-animate.version>
     <pentaho-osgi-bundles.version>9.1.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
-    <angular-ui-router.version>0.4.2</angular-ui-router.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
     <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
-    <angular-i18n.version>1.5.6</angular-i18n.version>
     <swt.version>4.6</swt.version>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>
     <dependency.javax.ws.rs-api.version>2.0</dependency.javax.ws.rs-api.version>
@@ -115,18 +111,6 @@
         <groupId>org.eclipse.swt</groupId>
         <artifactId>org.eclipse.swt.gtk.linux.x86_64</artifactId>
         <version>${swt.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular</artifactId>
-        <version>${angular.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>angular-i18n</artifactId>
-        <version>${angular-i18n.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/kettle-plugins/hadoop-cluster/ui/pom.xml
+++ b/kettle-plugins/hadoop-cluster/ui/pom.xml
@@ -100,7 +100,7 @@
       <artifactId>angular</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.webjars.bower</groupId>
+      <groupId>org.webjars.npm</groupId>
       <artifactId>angular-i18n</artifactId>
     </dependency>
     <dependency>

--- a/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/dialog/HadoopClusterDialog.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/dialog/HadoopClusterDialog.java
@@ -65,7 +65,7 @@ public class HadoopClusterDialog extends ThinDialog {
 
     StringBuilder clientPath = new StringBuilder();
     clientPath.append( getClientPath() );
-    clientPath.append( "#/" );
+    clientPath.append( "#!/" );
     if ( thinAppState != null ) {
       clientPath.append( thinAppState );
     }

--- a/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/app.animation.js
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/app.animation.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2019-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ define(
   function () {
     'use strict';
 
-    var factoryArray = ["$rootScope", "$state", factory];
+    var factoryArray = ["$rootScope", "$state", "$transitions", factory];
     var module = {
       class: ".transition",
       factory: factoryArray
@@ -36,11 +36,11 @@ define(
      * @param {Object} $rootScope
      * @returns {Object} The callbacks for animation
      */
-    function factory($rootScope, $state) {
+    function factory($rootScope, $state, $transitions) {
       var transition = $state.params.transition;
-      $rootScope.$on('$stateChangeStart', function (evt, toState, toParams, fromState, fromParams) {
-        if (toParams.transition) {
-          transition = toParams.transition;
+      $transitions.onStart({ }, function(trans) {
+        if (trans.targetState().params().transition) {
+          transition = trans.targetState().params().transition;
         }
       });
 

--- a/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/app.module.js
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/javascript/app/app.module.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Hitachi Vantara. All rights reserved.
+ * Copyright 2019-2020 Hitachi Vantara. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ define([
   "./service/helper.service",
   "./service/data.service",
   "./service/file.service",
-  "angular-ui-router",
+  "@uirouter/angularjs",
   "angular-animate"
 ], function (angular, appConfig, appAnimation, importComponent, newEditComponent, creatingComponent, testingComponent,
              statusComponent, testResultsComponent, addDriverComponent, installingDriverComponent,

--- a/kettle-plugins/hadoop-cluster/ui/src/main/resources-filtered/app/index.html
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/resources-filtered/app/index.html
@@ -17,7 +17,6 @@
       // overrides just for this app
       require.config({
         paths: {
-          "pentaho/i18n-osgi": "../i18n-osgi@${project.version}/js/i18n",
           "pentaho": "../di-core-ui@${project.version}/pentaho",
           "css": "../../require-css@${require-css.version}/css",
           "text": "../../requirejs-text@${requirejs-text.version}/text"

--- a/kettle-plugins/hadoop-cluster/ui/src/main/resources-filtered/app/package.json
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/resources-filtered/app/package.json
@@ -14,8 +14,9 @@
   "dependencies": {
     "angular": "${angular.version}",
     "angular-animate": "${angular.version}",
-    "angular-i18n": "${angular-i18n.version}",
-    "angular-ui-router": "${angular-ui-router.version}",
+    "angular-i18n": "${angular.version}",
+    "@uirouter/core": "${uirouter-core.version}",
+    "@uirouter/angularjs": "${uirouter-angularjs.version}",
     "require-css": "${require-css.version}",
     "requirejs-text": "${requirejs-text.version}",
     "jquery": "${jquery.version}",


### PR DESCRIPTION
Related PRs:
https://github.com/pentaho/pentaho-kettle/pull/7311
https://github.com/pentaho/pdi-plugins-ee/pull/169