### PR TITLE
[PPP-4495] Use of Vulnerable Component: Components/legion-of-the-boun…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -44,9 +44,9 @@
       <version>138</version>
     </dependency>
     <dependency>
-      <groupId>bouncycastle</groupId>
+      <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk14</artifactId>
-      <version>138</version>
+      <version>1.65</version>
     </dependency>
     <dependency>
       <groupId>bsf</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -31,7 +31,7 @@
         <include>ascsapjco3wrp:ascsapjco3wrp</include>
         <include>asm:asm</include>
         <include>bouncycastle:bcmail-jdk14</include>
-        <include>bouncycastle:bcprov-jdk14</include>
+        <include>org.bouncycastle:bcprov-jdk14</include>
         <include>bsf:bsf</include>
         <include>cglib:cglib-nodep</include>
         <include>com.enterprisedt:edtftpj</include>


### PR DESCRIPTION
…cy-castle-java-crytography-api

- Bumping `bcprov-jdk14` to version 1.65 which now has a new `groupId`
- Version 1.65 was released **Apr 06, 2020**

Related PRs:
1. https://github.com/pentaho/modeler/pull/365
2. https://github.com/pentaho/pentaho-kettle/pull/7450
3. https://github.com/pentaho/pentaho-platform/pull/4689
4. https://github.com/pentaho/pentaho-reporting/pull/1347
5. https://github.com/pentaho/big-data-plugin/pull/2059 (this one)
6. https://github.com/pentaho/pentaho-big-data-ee/pull/447
7. https://github.com/pentaho/pentaho-karaf-assembly/pull/640