### PR TITLE
[TAP-634] Create a catalog write payload step in PDI - Exported the S…

### DIFF
--- a/kettle-plugins/formats/pom.xml
+++ b/kettle-plugins/formats/pom.xml
@@ -88,6 +88,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>org.pentaho.big.data.kettle.plugins.formats.impl.*;version=${project.version}</Export-Package>
             <Import-Package>org.eclipse.swt*;resolution:=optional,org.pentaho.di.ui.xul*;resolution:=optional,org.pentaho.ui.xul*;resolution:=optional,org.pentaho.di.osgi,org.pentaho.di.core.plugins,org.pentaho.hadoop.shim.api.cluster,*</Import-Package>
           </instructions>
         </configuration>


### PR DESCRIPTION
Exported the GUI step implementations to make the big data formats available for use by the catalog steps. Export the following package and it's sub-packages: "org.pentaho.big.data.kettle.plugins.formats.impl"  This give use the ability to wrap the big data steps while still leveraging the shim code indirectly. For example you can now access and create instances of the Parquet Step outside of UserInterface (Dialog) so you have direct access to   ParquetOutput, ParquetOutputMeta and ParquetOutputData.