### PR TITLE
[BACKLOG-34078] - Site XML parsing logic for Google Dataproc files

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
@@ -192,6 +192,33 @@ public class HadoopClusterManagerTest {
     assertTrue( StringUtil.isEmpty( thinNameClusterModel.getJobTrackerPort() ) );
   }
 
+  @Test public void testSiteXMLParsingImportNamedCluster() {
+    ThinNameClusterModel model = new ThinNameClusterModel();
+    model.setName( ncTestName );
+    model.setShimVendor( "Cloudera" );
+    model.setShimVersion( "5.14" );
+    JSONObject result =
+            hadoopClusterManager.importNamedCluster( model, getFiles( "src/test/resources/unsecured" ) );
+    assertEquals( ncTestName, result.get( "namedCluster" ) );
+    verify( namedCluster ).setJobTrackerHost( "svqxbdcn6cdh514un3.pentahoqa.com" );
+    verify( namedCluster ).setJobTrackerPort( "8032" );
+    verify( namedCluster ).setZooKeeperHost( "svqxbdcn6cdh514un1.pentahoqa.com,svqxbdcn6cdh514un5.pentahoqa.com," +
+            "svqxbdcn6cdh514un4.pentahoqa.com,svqxbdcn6cdh514un2.pentahoqa.com,svqxbdcn6cdh514un3.pentahoqa.com" );
+  }
+
+  @Test public void testSiteXMLParsingImportDataprocNamedCluster() {
+    ThinNameClusterModel model = new ThinNameClusterModel();
+    model.setName( ncTestName );
+    model.setShimVendor( "Dataproc" );
+    model.setShimVersion( "1.4" );
+    JSONObject result =
+            hadoopClusterManager.importNamedCluster( model, getFiles( "src/test/resources/dataproc" ) );
+    assertEquals( ncTestName, result.get( "namedCluster" ) );
+    verify( namedCluster ).setJobTrackerHost( "cluster-ec0a-m-0" );
+    verify( namedCluster ).setJobTrackerPort( "" );
+    verify( namedCluster ).setZooKeeperHost( "cluster-ec0a-m-0,cluster-ec0a-m-1,cluster-ec0a-m-2" );
+  }
+
   @Test public void testCreateNamedCluster() {
     ThinNameClusterModel model = new ThinNameClusterModel();
     model.setName( ncTestName );

--- a/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/core-site.xml
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/core-site.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<!-- Put site-specific property overrides in this file. -->
+<configuration>
+  <property>
+    <name>fs.default.name</name>
+    <value>hdfs://cluster-ec0a</value>
+    <description>The old FileSystem used by FsShell.</description>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.hive.groups</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.security.token.service.use_ip</name>
+    <value>false</value>
+    <description>
+      Controls whether tokens always use IP addresses. DNS changes will not
+      be detected if this option is enabled. Existing client connections that
+      break will always reconnect to the IP of the original host. New clients
+      will connect to the host's new IP but fail to locate a token. Disabling
+      this option will allow existing and new clients to detect an IP change
+      and continue to locate the new host's token.
+    </description>
+  </property>
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>/hadoop/tmp</value>
+    <description>A base for other temporary directories.</description>
+  </property>
+  <property>
+    <name>ha.zookeeper.parent-znode</name>
+    <value>/hadoop/hadoop-ha</value>
+    <description>
+      The ZooKeeper znode under which the ZK failover controller stores
+      its information. Note that the nameservice ID is automatically
+      appended to this znode, so it is not normally necessary to       configure
+      this, even in a federated environment.
+    </description>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.hive.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>ha.zookeeper.quorum</name>
+    <value>cluster-ec0a-m-0:2181,cluster-ec0a-m-1:2181,cluster-ec0a-m-2:2181</value>
+  </property>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://cluster-ec0a</value>
+    <description>
+      The name of the default file system. A URI whose scheme and authority
+      determine the FileSystem implementation. The uri's scheme determines
+      the config property (fs.SCHEME.impl) naming the FileSystem
+      implementation class. The uri's authority is used to determine the
+      host, port, etc. for a filesystem.
+    </description>
+  </property>
+  <property>
+    <name>hadoop.zk.address</name>
+    <value>cluster-ec0a-m-0:2181,cluster-ec0a-m-1:2181,cluster-ec0a-m-2:2181</value>
+  </property>
+  <property>
+    <name>hadoop.http.filter.initializers</name>
+    <value>org.apache.hadoop.security.HttpCrossOriginFilterInitializer,org.apache.hadoop.http.lib.StaticUserWebFilter</value>
+  </property>
+  <property>
+    <name>fs.gs.working.dir</name>
+    <value>/</value>
+    <description>
+      The directory relative gs: uris resolve in inside of the default bucket.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.system.bucket</name>
+    <value>dataproc-staging-us-central1-888792280192-7eit8tmn</value>
+    <description>
+      GCS bucket to use as a default bucket if fs.default.name is not a gs: uri.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.metadata.cache.directory</name>
+    <value>/hadoop_gcs_connector_metadata_cache</value>
+    <description>
+      Only used if fs.gs.metadata.cache.type is FILESYSTEM_BACKED, specifies
+      the local path to use as the base path for storing mirrored GCS metadata.
+      Must be an absolute path, must be a directory, and must be fully
+      readable/writable/executable by any user running processes which use the
+      GCS connector.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.impl</name>
+    <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem</value>
+    <description>The FileSystem for gs: (GCS) uris.</description>
+  </property>
+  <property>
+    <name>fs.gs.project.id</name>
+    <value>hitachi3-281807</value>
+    <description>
+      Google Cloud Project ID with access to configured GCS buckets.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.metadata.cache.enable</name>
+    <value>false</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>fs.gs.implicit.dir.infer.enable</name>
+    <value>true</value>
+    <description>
+      If set, we create and return in-memory directory objects on the fly when
+      no backing object exists, but we know there are files with the same
+      prefix.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.application.name.suffix</name>
+    <value>-dataproc</value>
+    <description>
+      Appended to the user-agent header for API requests to GCS to help identify
+      the traffic as coming from Dataproc.
+    </description>
+  </property>
+  <property>
+    <name>fs.AbstractFileSystem.gs.impl</name>
+    <value>com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS</value>
+    <description>The AbstractFileSystem for gs: (GCS) uris.</description>
+  </property>
+  <property>
+    <name>fs.gs.metadata.cache.type</name>
+    <value>FILESYSTEM_BACKED</value>
+    <description>
+      Specifies which implementation of DirectoryListCache to use for
+      supplementing GCS API &amp;amp;amp;amp;quot;list&amp;amp;amp;amp;quot; requests.
+      Supported       implementations:       IN_MEMORY: Enforces immediate
+      consistency within       same Java process.       FILESYSTEM_BACKED:
+      Enforces consistency across       all cooperating processes       pointed
+      at the same local mirror       directory, which may be an NFS directory
+      for massively-distributed       coordination.
+    </description>
+  </property>
+  <property>
+    <name>fs.gs.block.size</name>
+    <value>134217728</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>hadoop.ssl.enabled.protocols</name>
+    <value>TLSv1,TLSv1.1,TLSv1.2</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.oozie.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.oozie.groups</name>
+    <value>*</value>
+  </property>
+</configuration>

--- a/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/hdfs-site.xml
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/hdfs-site.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<!-- Put site-specific property overrides in this file. -->
+<configuration>
+  <property>
+    <name>dfs.namenode.file.close.num-committed-allowed</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>dfs.namenode.shared.edits.dir</name>
+    <value>qjournal://cluster-ec0a-m-0:8485;cluster-ec0a-m-1:8485;cluster-ec0a-m-2:8485/cluster-ec0a</value>
+    <description>
+      A directory on shared storage between the multiple namenodes       in an
+      HA cluster. This directory will be written by the active and read       by
+      the standby in order to keep the namespaces synchronized. This directory
+      does not need to be listed in dfs.namenode.edits.dir above. It should be
+      left empty in a non-HA cluster.
+    </description>
+  </property>
+  <property>
+    <name>dfs.namenode.name.dir</name>
+    <value>file:///hadoop/dfs/name</value>
+    <description>
+      Determines where on the local filesystem the DFS namenode should store the
+      name table(fsimage). If this is a comma-delimited list of directories then
+      the name table is replicated in all of thedirectories, for redundancy.
+    </description>
+  </property>
+  <property>
+    <name>dfs.permissions.enabled</name>
+    <value>false</value>
+    <description>
+      If &amp;amp;quot;true&amp;amp;quot;, enable permission checking in HDFS. If
+      &amp;amp;quot;false&amp;amp;quot;, permission       checking is turned off, but
+      all other       behavior is unchanged. Switching       from one parameter
+      value to the       other does not change the mode, owner or       group of
+      files or       directories.
+    </description>
+  </property>
+  <property>
+    <name>dfs.client.read.shortcircuit</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>dfs.ha.automatic-failover.enabled</name>
+    <value>true</value>
+    <description>
+      Whether automatic failover is enabled. See the HDFS High
+      Availability documentation for details on automatic HA
+      configuration.
+    </description>
+  </property>
+  <property>
+    <name>dfs.journalnode.edits.dir</name>
+    <value>/var/tmp</value>
+  </property>
+  <property>
+    <name>dfs.replication</name>
+    <value>2</value>
+    <description>
+      Default block replication. The actual number of replications can be
+      specified when the file is created. The default is used if replication
+      is not specified in create time.
+    </description>
+  </property>
+  <property>
+    <name>dfs.namenode.checkpoint.dir</name>
+    <value>file:///hadoop/dfs/namesecondary</value>
+    <description>
+      Determines where on the local filesystem the DFS secondary namenode should
+      store       the temporary images to merge. If this is a comma-delimited
+      list of directories then       the image is replicated in all of the
+      directories for redundancy.
+    </description>
+  </property>
+  <property>
+    <name>dfs.nameservices</name>
+    <value>cluster-ec0a</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.datanode.data.dir</name>
+    <value>/hadoop/dfs/data</value>
+    <description>
+      Determines where on the local filesystem an DFS datanode should store its
+      blocks. If this is a comma-delimited list of directories, then data will
+      be stored in all named directories, typically on different
+      devices.Directories that do not exist are ignored.
+    </description>
+  </property>
+  <property>
+    <name>dfs.namenode.rpc-address.cluster-ec0a.nn1</name>
+    <value>cluster-ec0a-m-1:8020</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.rpc-address.cluster-ec0a.nn0</name>
+    <value>cluster-ec0a-m-0:8020</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.client.failover.proxy.provider.cluster-ec0a</name>
+    <value>org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider</value>
+  </property>
+  <property>
+    <name>dfs.permissions.supergroup</name>
+    <value>hadoop</value>
+    <description>The name of the group of super-users.</description>
+  </property>
+  <property>
+    <name>dfs.hosts</name>
+    <value>/etc/hadoop/conf/nodes_include</value>
+  </property>
+  <property>
+    <name>dfs.ha.fencing.methods</name>
+    <value>shell(/bin/true)</value>
+  </property>
+  <property>
+    <name>dfs.namenode.datanode.registration.retry-hostname-dns-lookup</name>
+    <value>true</value>
+    <description>
+      If true, then the namenode will retry reverse dns lookup for hostname of
+      the       datanode. This helps in environments where DNS lookup can be
+      flaky.
+    </description>
+  </property>
+  <property>
+    <name>dfs.ha.namenodes.cluster-ec0a</name>
+    <value>nn0,nn1</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.http-address.cluster-ec0a.nn1</name>
+    <value>cluster-ec0a-m-1:9870</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.http-address.cluster-ec0a.nn0</name>
+    <value>cluster-ec0a-m-0:9870</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.domain.socket.path</name>
+    <value>/var/lib/hadoop-hdfs/dn_socket</value>
+  </property>
+  <property>
+    <name>dfs.hosts.exclude</name>
+    <value>/etc/hadoop/conf/nodes_exclude</value>
+  </property>
+  <property>
+    <name>dfs.datanode.data.dir.perm</name>
+    <value>700</value>
+    <description>
+      Permissions for the directories on on the local filesystem where the DFS
+      data node store its blocks. The permissions can either be octal or
+      symbolic.
+    </description>
+  </property>
+  <property>
+    <name>dfs.namenode.servicerpc-address.cluster-ec0a.nn1</name>
+    <value>cluster-ec0a-m-1:8051</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.servicerpc-address.cluster-ec0a.nn0</name>
+    <value>cluster-ec0a-m-0:8051</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.https-address.cluster-ec0a.nn1</name>
+    <value>cluster-ec0a-m-1:9871</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.https-address.cluster-ec0a.nn0</name>
+    <value>cluster-ec0a-m-0:9871</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.https-address</name>
+    <value>0.0.0.0:9871</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.service.handler.count</name>
+    <value>10</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.handler.count</name>
+    <value>20</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.datanode.address</name>
+    <value>0.0.0.0:9866</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.http-address</name>
+    <value>0.0.0.0:9870</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.datanode.https.address</name>
+    <value>0.0.0.0:9865</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.secondary.http-address</name>
+    <value>0.0.0.0:9868</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.secondary.https-address</name>
+    <value>0.0.0.0:9869</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.datanode.http.address</name>
+    <value>0.0.0.0:9864</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.datanode.ipc.address</name>
+    <value>0.0.0.0:9867</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.lifeline.rpc-address.cluster-ec0a.nn0</name>
+    <value>cluster-ec0a-m-0:8050</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>dfs.namenode.lifeline.rpc-address.cluster-ec0a.nn1</name>
+    <value>cluster-ec0a-m-1:8050</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+</configuration>

--- a/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/hive-site.xml
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/hive-site.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <!-- Hive Configuration can either be stored in this file or in the hadoop configuration files  -->
+  <!-- that are implied by Hadoop setup variables.                                                -->
+  <!-- Aside from Hadoop setup variables - this file is provided as a convenience so that Hive    -->
+  <!-- users do not have to edit hadoop configuration files (that may be managed as a centralized -->
+  <!-- resource).                                                                                 -->
+  <!-- Hive Execution Parameters -->
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <!--
+      Will be clobbered at startup by master 0.
+      Required to run schema tool during image build.
+    -->
+    <value>jdbc:mysql://cluster-ec0a-m-0/metastore</value>
+    <description>the URL of the MySQL database</description>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionDriverName</name>
+    <value>com.mysql.jdbc.Driver</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionUserName</name>
+    <value>hive</value>
+  </property>
+  <property>
+    <name>datanucleus.fixedDatastore</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value>hive-password</value>
+  </property>
+  <property>
+    <name>datanucleus.autoStartMechanism</name>
+    <value>SchemaTable</value>
+  </property>
+  <property>
+    <!--
+      Crank up low-level retries from default value of 3. Hive 2.* will have
+      metastore connection attempts fast-fail instead of hanging between
+      "Starting hive metastore" and "Started the new metastore...", and
+      these retries happen with only 1 second between attempts. Metastore
+      startup appears to take ~5 seconds; in the rare case of startup
+      longer than 60 seconds, the secondary retry loop waits 1 minute between
+      attempts.
+    -->
+    <name>hive.metastore.connect.retries</name>
+    <value>60</value>
+  </property>
+  <property>
+    <name>datanucleus.autoCreateSchema</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>hive.localize.resource.num.wait.attempts</name>
+    <value>25</value>
+  </property>
+  <property>
+    <name>hive.execution.engine</name>
+    <value>tez</value>
+  </property>
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>thrift://cluster-ec0a-m-0:9083,thrift://cluster-ec0a-m-1:9083,thrift://cluster-ec0a-m-2:9083</value>
+  </property>
+  <property>
+    <name>hive.zookeeper.quorum</name>
+    <value>cluster-ec0a-m-0:2181,cluster-ec0a-m-1:2181,cluster-ec0a-m-2:2181</value>
+  </property>
+  <property>
+    <name>hive.zookeeper.client.port</name>
+    <value>2181</value>
+  </property>
+  <property>
+    <name>hive.server2.support.dynamic.service.discovery</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hive.server2.zookeeper.namespace</name>
+    <value>hiveserver2</value>
+  </property>
+  <property>
+    <name>hive.support.concurrency</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hive.zookeeper.session.timeout</name>
+    <value>1200000</value>
+  </property>
+  <property>
+    <name>hive.user.install.directory</name>
+    <value>gs://dataproc-staging-us-central1-888792280192-7eit8tmn/google-cloud-dataproc-metainfo/e553cf63-468f-4b23-a59f-1025ad8e335d/hive/user-install-dir</value>
+  </property>
+</configuration>

--- a/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/mapred-site.xml
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/mapred-site.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>mapreduce.job.reduces</name>
+    <value>2</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.address</name>
+    <value>cluster-ec0a-m-0:10020</value>
+    <description>MapReduce JobHistory Server IPC host:port</description>
+  </property>
+  <property>
+    <name>mapreduce.framework.name</name>
+    <value>yarn</value>
+  </property>
+  <property>
+    <name>mapreduce.fileoutputcommitter.task.cleanup.enabled</name>
+    <value>true</value>
+    <description>
+      Whether tasks should delete their task temporary directories. This is
+      purely an optimization for filesystems without O(1) recursive delete,
+      as commitJob will recursively delete the entire job temporary
+      directory. HDFS has O(1) recursive delete, so this parameter is left
+      false by default. Users of object stores, for example, may want to set
+      this to true.        Note: this is only used if
+      mapreduce.fileoutputcommitter.algorithm.version=2       See
+      https://issues.apache.org/jira/browse/MAPREDUCE-7029 for details.
+    </description>
+  </property>
+  <property>
+    <name>yarn.app.mapreduce.am.resource.mb</name>
+    <value>1024</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.map.java.opts</name>
+    <value>-Xmx819m</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.recovery.store.fs.uri</name>
+    <value>${hadoop.tmp.dir}/mapred/history/recoverystore</value>
+    <description>URI where history server state is stored.</description>
+  </property>
+  <property>
+    <name>mapreduce.job.working.dir</name>
+    <value>/user/${user.name}</value>
+    <description>
+      The FileSystem working directory to use for relative paths.
+    </description>
+  </property>
+  <property>
+    <name>mapred.local.dir</name>
+    <value>/hadoop/mapred/local</value>
+    <description>
+      Directories on the local machine in which to store mapreduce temp files.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.fileoutputcommitter.failures.attempts</name>
+    <value>4</value>
+    <description>
+      Number of attempts when failure happens in commit job.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.reduce.java.opts</name>
+    <value>-Xmx1638m</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.map.memory.mb</name>
+    <value>1024</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.reduce.memory.mb</name>
+    <value>2048</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.recovery.enable</name>
+    <value>true</value>
+    <description>
+      Enable history server to recover server state on startup.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.tasktracker.map.tasks.maximum</name>
+    <value>1</value>
+    <description>
+      Property from MapReduce version 1 still used for TeraGen sharding.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.input.fileinputformat.list-status.num-threads</name>
+    <value>20</value>
+    <description>
+      The number of threads to use to list and fetch block locations for the
+      specified input paths. Note: multiple threads should not be used if a
+      custom non thread-safe path filter is used. Setting a larger value than
+      the default of 1 can significantly improve job startup overhead,
+      especially if using GCS as input with multi-level directories, such
+      as in partitioned Hive tables.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.reduce.cpu.vcores</name>
+    <value>1</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.map.cpu.vcores</name>
+    <value>1</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.recovery.store.class</name>
+    <value>org.apache.hadoop.mapreduce.v2.hs.HistoryServerFileSystemStateStoreService</value>
+    <description>
+      Class used to store history server state for recovery.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.job.maps</name>
+    <value>15</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.webapp.address</name>
+    <value>cluster-ec0a-m-0:19888</value>
+    <description>MapReduce JobHistory Server Web UI host:port</description>
+  </property>
+  <property>
+    <name>yarn.app.mapreduce.am.command-opts</name>
+    <value>-Xmx819m</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>yarn.app.mapreduce.am.resource.cpu-vcores</name>
+    <value>1</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.always-scan-user-dir</name>
+    <value>true</value>
+    <description>Enable history server to always scan user dir.</description>
+  </property>
+  <property>
+    <name>mapreduce.fileoutputcommitter.algorithm.version</name>
+    <value>2</value>
+    <description>
+      Updated file output committer algorithm in Hadoop 2.7+. Significantly
+      improves commitJob times when using the Google Cloud Storage connector.
+      See https://issues.apache.org/jira/browse/MAPEDUCE-4815 for more details.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.application.classpath</name>
+    <value>$HADOOP_MAPRED_HOME/share/hadoop/mapreduce/*,
+      $HADOOP_MAPRED_HOME/share/hadoop/mapreduce/lib/*,
+      /usr/local/share/google/dataproc/lib/*</value>
+  </property>
+  <property>
+    <name>mapred.bq.project.id</name>
+    <value>hitachi3-281807</value>
+    <description>
+      Google Cloud Project ID to use for BigQuery operations.
+    </description>
+  </property>
+  <property>
+    <name>mapred.bq.output.buffer.size</name>
+    <value>67108864</value>
+    <description>
+      The size in bytes of the output buffer to use when writing to BigQuery.
+    </description>
+  </property>
+  <property>
+    <name>mapred.bq.gcs.bucket</name>
+    <value>dataproc-staging-us-central1-888792280192-7eit8tmn</value>
+    <description>
+      The GCS bucket holding temporary BigQuery data for the input connector.
+    </description>
+  </property>
+  <property>
+    <name>mapreduce.job.reduce.slowstart.completedmaps</name>
+    <value>0.95</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>mapreduce.task.io.sort.mb</name>
+    <value>256</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+</configuration>

--- a/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/yarn-site.xml
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/resources/dataproc/yarn-site.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" ?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<configuration>
+  <!-- Site specific YARN configuration properties -->
+  <property>
+    <name>yarn.resourcemanager.webapp.methods-allowed</name>
+    <value>GET,HEAD</value>
+    <description>
+      The HTTP methods allowed by the YARN Resource Manager web UI and REST API.
+    </description>
+  </property>
+  <property>
+    <description>
+      Name of the cluster. In a HA setting,       this is used to ensure the RM
+      participates in leader       election for this cluster and ensures it does
+      not affect       other clusters
+    </description>
+    <name>yarn.resourcemanager.cluster-id</name>
+    <value>cluster-ec0a</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.store.class</name>
+    <value>org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.local-dirs</name>
+    <value>/hadoop/yarn/nm-local-dir</value>
+    <description>
+      Directories on the local machine in which to application temp files.
+    </description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.hostname</name>
+    <value>cluster-ec0a-m-0</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.resource.memory-mb</name>
+    <value>3072</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>yarn.scheduler.minimum-allocation-mb</name>
+    <value>256</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.nodes.include-path</name>
+    <value>/etc/hadoop/conf/nodes_include</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.container-executor.os.sched.priority.adjustment</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.resource.cpu-vcores</name>
+    <value>1</value>
+    <description>
+      Number of vcores that can be allocated for containers. This is used by
+      the RM scheduler when allocating resources for containers. This is not
+      used to limit the number of physical cores used by YARN containers.
+    </description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.ha.automatic-failover.zk-base-path</name>
+    <value>/hadoop/yarn-leader-election</value>
+    <description>
+      The base znode path to use for storing leader information,       when
+      using ZooKeeper based leader election.
+    </description>
+  </property>
+  <property>
+    <name>yarn.scheduler.maximum-allocation-mb</name>
+    <value>3072</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.ha.enabled</name>
+    <value>true</value>
+    <description>
+      Enable RM high-availability. When enabled,       (1) The RM starts in the
+      Standby mode by default, and transitions to       the Active mode when
+      prompted to.       (2) The nodes in the RM ensemble are listed in
+      yarn.resourcemanager.ha.rm-ids       (3) The id of each RM either comes
+      from yarn.resourcemanager.ha.id       if yarn.resourcemanager.ha.id is
+      explicitly specified or can be       figured out by matching
+      yarn.resourcemanager.address.{id} with local address       (4) The actual
+      physical addresses come from the configs of the pattern       - {rpc-
+      config}.{id}
+    </description>
+  </property>
+  <property>
+    <name>yarn.client.failover-sleep-max-ms</name>
+    <value>15000</value>
+    <description>
+      When HA is enabled, the maximum sleep time (in milliseconds) between
+      failovers. When set, this overrides the yarn.resourcemanager.connect.*
+      settings. When not set, yarn.resourcemanager.connect.retry-interval.ms is
+      used instead.
+    </description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.zk-state-store.parent-path</name>
+    <value>/hadoop/rmstore</value>
+    <description>
+      Full path of the ZooKeeper znode where RM state will be     stored. This
+      must be supplied when using
+      org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore
+      as the value for yarn.resourcemanager.store.class
+    </description>
+  </property>
+  <property>
+    <name>yarn.log-aggregation-enable</name>
+    <value>false</value>
+    <description>Enable remote logs aggregation to the default FS.</description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.hostname.rm0</name>
+    <value>cluster-ec0a-m-0</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.hostname.rm1</name>
+    <value>cluster-ec0a-m-1</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.hostname.rm2</name>
+    <value>cluster-ec0a-m-2</value>
+  </property>
+  <property>
+    <name>yarn.client.failover-max-attempts</name>
+    <value>15</value>
+    <description>
+      When HA is enabled, the max number of times FailoverProxyProvider should
+      attempt failover. When set, this overrides the
+      yarn.resourcemanager.connect.max-wait.ms. When not set, this is inferred
+      from yarn.resourcemanager.connect.max-wait.ms.
+    </description>
+  </property>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle,spark_shuffle</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.vmem-check-enabled</name>
+    <value>false</value>
+  </property>
+  <property>
+    <description>
+      The maximum allocation for every container request at the RM,       in
+      terms of virtual CPU cores. Requests higher than this won't take
+      effect, and will get capped to this value.
+    </description>
+    <name>yarn.scheduler.maximum-allocation-vcores</name>
+    <value>32000</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.webapp.address.rm0</name>
+    <value>cluster-ec0a-m-0:8088</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.webapp.address.rm1</name>
+    <value>cluster-ec0a-m-1:8088</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.webapp.address.rm2</name>
+    <value>cluster-ec0a-m-2:8088</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.nodes.exclude-path</name>
+    <value>/etc/hadoop/conf/nodes_exclude</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.zk-timeout-ms</name>
+    <value>60000</value>
+    <description>
+      ZooKeeper session timeout in milliseconds. Session expiration is managed
+      by the ZooKeeper cluster itself, not by the client. This value is used by
+      the cluster to determine when the client's session expires. Expirations
+      happens when the cluster does not hear from the client within the
+      specified session timeout period (i.e. no heartbeat).
+    </description>
+  </property>
+  <property>
+    <name>yarn.client.failover-sleep-base-ms</name>
+    <value>500</value>
+    <description>
+      When HA is enabled, the sleep base (in milliseconds) to be used for
+      calculating the exponential delay between failovers. When set, this
+      overrides the yarn.resourcemanager.connect.* settings. When not set,
+      yarn.resourcemanager.connect.retry-interval.ms is used instead.
+    </description>
+  </property>
+  <property>
+    <name>yarn.nodemanager.remote-app-log-dir</name>
+    <value>/yarn-logs/</value>
+    <description>
+      The remote path, on the default FS, to store logs.
+    </description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.recovery.enabled</name>
+    <value>true</value>
+    <description>Enable RM to recover state after starting.</description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.ha.rm-ids</name>
+    <value>rm0,rm1,rm2</value>
+    <description>
+      The list of RM nodes in the cluster when HA is       enabled. See
+      description of yarn.resourcemanager.ha       .enabled for full details on
+      how this is used.
+    </description>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.bind-host</name>
+    <value>0.0.0.0</value>
+  </property>
+  <property>
+    <name>yarn.application.classpath</name>
+    <value>$HADOOP_CONF_DIR,$HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,
+      $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,$HADOOP_MAPRED_HOME/*,
+      $HADOOP_MAPRED_HOME/lib/*,$HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*,
+      /usr/local/share/google/dataproc/lib/*</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.aux-services.spark_shuffle.class</name>
+    <value>org.apache.spark.network.yarn.YarnShuffleService</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.http-cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.hostname</name>
+    <value>cluster-ec0a-m-0</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.bind-host</name>
+    <value>0.0.0.0</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.system-metrics-publisher.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.generic-application-history.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.ui-names</name>
+    <value>tez</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.ui-on-disk-path.tez</name>
+    <value>/usr/lib/tez/tez-ui-0.9.2.war</value>
+  </property>
+  <property>
+    <name>yarn.timeline-service.ui-web-path.tez</name>
+    <value>/tez-ui</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.nodemanager-graceful-decommission-timeout-secs</name>
+    <value>86400</value>
+    <final>false</final>
+    <source>Dataproc Cluster Properties</source>
+  </property>
+</configuration>


### PR DESCRIPTION
1. Google Dataproc 1.4 site xml files have different properties in site xml files, modified xml parsing logic to include them
2. Supports HDFS, Yarn(hostname only) for default clusters, supports zookeerper also for HA clusters
3. Oozie address is not supported as the property is not available in oozie-site.xml