### PR TITLE
Revert "[SP-5678] Backport of PDI-18840.  Provide a way to exclude in…

### DIFF
--- a/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
+++ b/assemblies/legacy-plugin/src/main/assembly/resources/plugin.properties
@@ -51,11 +51,6 @@ pmr.libraries.archive.file=pentaho-mapreduce-libraries.zip
 # e.g. pmr.kettle.additional.plugins=my-test-plugin,steps/DummyPlugin
 pmr.kettle.additional.plugins=pdi-core-plugins
 
-# Individual file name prefixes to not include when adding plugins to the Pentaho MapReduce Kettle Environment. This should be a comma-separated
-# list of file prefixes to exclude.  The pdi-core-plugins-ui value should not be removed, only added to as demonstrated below.
-# e.g. to exclude the file some-jar-file-name-9.0.0.0-xxx.jar: pmr.kettle.exclude.plugin.files=pdi-core-plugins-ui,some-jar-file-name
-pmr.kettle.exclude.plugin.files=pdi-core-plugins-ui
-
 notificationsBeforeLoadingShim=1
 maxTimeoutBeforeLoadingShim=300
 

--- a/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
+++ b/impl/shim/mapreduce/src/main/java/org/pentaho/big/data/impl/shim/mapreduce/PentahoMapReduceJobBuilderImpl.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2020 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -96,7 +96,6 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
   public static final String PENTAHO_MAPREDUCE_PROPERTY_KETTLE_HDFS_INSTALL_DIR = "pmr.kettle.dfs.install.dir";
   public static final String PENTAHO_MAPREDUCE_PROPERTY_KETTLE_INSTALLATION_ID = "pmr.kettle.installation.id";
   public static final String PENTAHO_MAPREDUCE_PROPERTY_ADDITIONAL_PLUGINS = "pmr.kettle.additional.plugins";
-  public static final String PENTAHO_MAPREDUCE_PROPERTY_EXCLUDE_FILES = "pmr.kettle.exclude.plugin.files";
   public static final String PENTAHO_MAP_REDUCE_JOB_BUILDER_IMPL_INPUT_STEP_NOT_SPECIFIED =
     "PentahoMapReduceJobBuilderImpl.InputStepNotSpecified";
   public static final String PENTAHO_MAP_REDUCE_JOB_BUILDER_IMPL_INPUT_STEP_NOT_FOUND =
@@ -514,8 +513,6 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
           // Load additional plugin folders as requested
           String additionalPluginNames =
             getProperty( conf, pmrProperties, PENTAHO_MAPREDUCE_PROPERTY_ADDITIONAL_PLUGINS, null );
-          String excludePluginFileNames =
-            getProperty( conf, pmrProperties, PENTAHO_MAPREDUCE_PROPERTY_EXCLUDE_FILES, null );
           if ( pmrLibArchive == null ) {
             throw new KettleException(
               BaseMessages.getString( PKG, JOB_ENTRY_HADOOP_TRANS_JOB_EXECUTOR_UNABLE_TO_LOCATE_ARCHIVE,
@@ -528,7 +525,7 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
           FileObject bigDataPluginFolder = vfsPluginDirectory;
           hadoopShim.getDistributedCacheUtil()
             .installKettleEnvironment( pmrLibArchive, fs, kettleEnvInstallDir, bigDataPluginFolder,
-              additionalPluginNames, excludePluginFileNames );
+              additionalPluginNames );
 
           log.logBasic( BaseMessages
             .getString( PKG, "JobEntryHadoopTransJobExecutor.InstallationOfKettleSuccessful", kettleEnvInstallDir ) );
@@ -587,7 +584,7 @@ public class PentahoMapReduceJobBuilderImpl extends MapReduceJobBuilderImpl impl
     snapshotMetaStore( localMetaStoreSnapshotDirPath.toString() );
 
     // Stage the local metastore to hdfs
-    hadoopShim.getDistributedCacheUtil().stageForCache( localMetaStoreSnapshotDirObject, fs, hdfsMetaStoreDirForCurrentJobPath, "", overwrite, true );
+    hadoopShim.getDistributedCacheUtil().stageForCache( localMetaStoreSnapshotDirObject, fs, hdfsMetaStoreDirForCurrentJobPath, overwrite, true );
     hadoopShim.getDistributedCacheUtil().addCachedFiles( conf, fs, hdfsMetaStoreDirForCurrentJobPath, null );
   }
 


### PR DESCRIPTION
Reverts pentaho/big-data-plugin#2092

Reverting this from `8.3.0.14` for two reasons:
1. This fix is not scheduled for the August SP
2. This fix is breaking the 8.3 service pack build.

This is probably because the shims aren't rebuilt in the service pack build.

Leaving in the `8.3` branch to be addressed in the September SP.