### PR TITLE
[BACKLOG-34864] Determine Maprfs storage scheme based on Shim Vendor

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManager.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManager.java
@@ -114,6 +114,8 @@ public class HadoopClusterManager implements RuntimeTestProgressCallback {
   private static final String CONFIG_PROPERTIES = "config.properties";
   private static final String KEYTAB_AUTH_FILE = "keytabAuthFile";
   private static final String KEYTAB_IMPL_FILE = "keytabImpFile";
+  public static final String MAPR_SHIM = "Map-R";
+  public static final String MAPRFS_SCHEME = "maprfs";
 
   private static final LogChannelInterface log =
     KettleLogStore.getLogChannelInterfaceFactory().create( "HadoopClusterManager" );
@@ -212,6 +214,9 @@ public class HadoopClusterManager implements RuntimeTestProgressCallback {
       nc.setName( model.getName() );
       nc.setHdfsUsername( model.getHdfsUsername() );
       nc.setHdfsPassword( nc.encodePassword( model.getHdfsPassword() ) );
+      if (MAPR_SHIM.equals(model.getShimVendor())) {
+        nc.setStorageScheme(MAPRFS_SCHEME);
+      }
       if ( variableSpace != null ) {
         nc.shareVariablesWith( variableSpace );
       } else {
@@ -260,6 +265,9 @@ public class HadoopClusterManager implements RuntimeTestProgressCallback {
     nc.setOozieUrl( model.getOozieUrl() );
     nc.setKafkaBootstrapServers( model.getKafkaBootstrapServers() );
     resolveShimIdentifier( nc, model.getShimVendor(), model.getShimVersion() );
+    if (MAPR_SHIM.equals(model.getShimVendor())) {
+      nc.setStorageScheme(MAPRFS_SCHEME);
+    }
     setupKnoxSecurity( nc, model );
     if ( variableSpace != null ) {
       nc.shareVariablesWith( variableSpace );

--- a/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
@@ -86,6 +86,8 @@ public class HadoopClusterManagerTest {
   private static final String HIVE_SITE = "hive-site.xml";
   private static final String OOZIE_SITE = "oozie-site.xml";
   private static final String YARN_SITE = "yarn-site.xml";
+  public static final String MAPR_SHIM_VENDOR = "Map-R";
+  public static final String MAPRFS_SCHEME = "maprfs";
 
   @Mock private Spoon spoon;
   @Mock private LogChannelInterfaceFactory logChannelFactory;
@@ -224,6 +226,14 @@ public class HadoopClusterManagerTest {
     model.setName( ncTestName );
     JSONObject result = hadoopClusterManager.createNamedCluster( model, getFiles( "/" ) );
     assertEquals( ncTestName, result.get( "namedCluster" ) );
+    verify( namedCluster, never() ).setStorageScheme( any( String.class ) );
+  }
+
+  @Test public void testMaprCreateNamedCluster() {
+    ThinNameClusterModel model = new ThinNameClusterModel();
+    model.setShimVendor(MAPR_SHIM_VENDOR);
+    JSONObject result = hadoopClusterManager.createNamedCluster( model, getFiles( "/" ) );
+    verify( namedCluster ).setStorageScheme( eq( MAPRFS_SCHEME ));
   }
 
   @Test public void testOverwriteNamedClusterCaseInsensitive() {

--- a/s3-vfs/pom.xml
+++ b/s3-vfs/pom.xml
@@ -125,7 +125,16 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/s3-vfs/src/main/java/org/pentaho/s3common/S3CommonFileSystem.java
+++ b/s3-vfs/src/main/java/org/pentaho/s3common/S3CommonFileSystem.java
@@ -176,11 +176,13 @@ public abstract class S3CommonFileSystem extends AbstractFileSystem {
           .withCredentials( awsCredentialsProvider )
           .build();
       } else {
-        client = AmazonS3ClientBuilder.standard()
+        AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard()
           .enableForceGlobalBucketAccess()
-          .withRegion( regions )
-          .withCredentials( awsCredentialsProvider )
-          .build();
+          .withCredentials( awsCredentialsProvider );
+        if ( !isRegionSet() ) {
+          clientBuilder.withRegion( regions );
+        }
+        client = clientBuilder.build();
       }
     }
 
@@ -219,6 +221,10 @@ public abstract class S3CommonFileSystem extends AbstractFileSystem {
     //check if configuration file exists in default location
     File awsConfigFolder = new File(
       System.getProperty( "user.home" ) + File.separator + S3Util.AWS_FOLDER + File.separator + S3Util.CONFIG_FILE );
-    return awsConfigFolder.exists();
+    if ( awsConfigFolder.exists() ) {
+      return true;
+    }
+    //When running on an Amazon EC2 instance getCurrentRegion will get its region. Null if not running in an EC2 instance
+    return Regions.getCurrentRegion() != null;
   }
 }

--- a/s3-vfs/src/test/java/org/pentaho/s3n/vfs/S3NFileSystemTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3n/vfs/S3NFileSystemTest.java
@@ -1,5 +1,5 @@
 /*!
-* Copyright 2010 - 2019 Hitachi Vantara.  All rights reserved.
+* Copyright 2010 - 2020 Hitachi Vantara.  All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 */
 package org.pentaho.s3n.vfs;
 
-import org.apache.commons.vfs2.Capability;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3Client;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.UserAuthenticationData;
@@ -24,15 +25,21 @@ import org.apache.commons.vfs2.UserAuthenticator;
 import org.apache.commons.vfs2.impl.DefaultFileSystemConfigBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.pentaho.amazon.s3.S3Util;
 import org.pentaho.s3.vfs.S3FileName;
 import org.pentaho.s3.vfs.S3FileNameTest;
 import org.pentaho.s3.vfs.S3FileProvider;
-import org.pentaho.s3.vfs.S3FileSystem;
+import org.pentaho.s3common.S3CommonFileSystem;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +47,9 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for S3FileSystem
  */
+@RunWith( PowerMockRunner.class )
+@PowerMockIgnore( { "javax.management.*", "javax.net.ssl.*" } )
+@PrepareForTest( { S3CommonFileSystem.class, Regions.class, System.class } )
 public class S3NFileSystemTest {
 
   S3NFileSystem fileSystem;
@@ -75,5 +85,26 @@ public class S3NFileSystemTest {
 
     fileSystem = new S3NFileSystem( fileName, options );
     assertNotNull( fileSystem.getS3Client() );
+  }
+
+  @Test
+  public void getS3ClientWithDefaultRegion() throws Exception {
+    FileSystemOptions options = new FileSystemOptions();
+    PowerMockito.mockStatic( Regions.class );
+    PowerMockito.mockStatic( System.class );
+    File file = mock( File.class );
+    //No Region set in env
+    when( System.getenv( S3Util.AWS_REGION ) ).thenReturn( null );
+    //No Config file with region set
+    when( System.getenv( S3Util.AWS_CONFIG_FILE ) ).thenReturn( null );
+    //No Config File with region
+    when( file.exists() ).thenReturn( false );
+    PowerMockito.whenNew( File.class ).withAnyArguments().thenReturn( file );
+    //Not under an EC2 instance - getCurrentRegion returns null
+    when( Regions.getCurrentRegion() ).thenReturn( null );
+    fileSystem = new S3NFileSystem( fileName, options );
+    AmazonS3Client s3Client = (AmazonS3Client) fileSystem.getS3Client();
+    assertEquals( "No Region was configured - client must have default region",
+      Regions.DEFAULT_REGION.getName(), s3Client.getRegionName() );
   }
 }


### PR DESCRIPTION
This change sets the storage scheme to maprfs in the NamedCluster. 
This change resonates across successful execution of Hadoop copy files directory structure and also with HBase jobs.