### PR TITLE
[SP-5820] : Backport of BACKLOG-34864

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManager.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManager.java
@@ -114,6 +114,8 @@ public class HadoopClusterManager implements RuntimeTestProgressCallback {
   private static final String CONFIG_PROPERTIES = "config.properties";
   private static final String KEYTAB_AUTH_FILE = "keytabAuthFile";
   private static final String KEYTAB_IMPL_FILE = "keytabImpFile";
+  public static final String MAPR_SHIM = "Map-R";
+  public static final String MAPRFS_SCHEME = "maprfs";
 
   private static final LogChannelInterface log =
     KettleLogStore.getLogChannelInterfaceFactory().create( "HadoopClusterManager" );
@@ -212,6 +214,9 @@ public class HadoopClusterManager implements RuntimeTestProgressCallback {
       nc.setName( model.getName() );
       nc.setHdfsUsername( model.getHdfsUsername() );
       nc.setHdfsPassword( nc.encodePassword( model.getHdfsPassword() ) );
+      if (MAPR_SHIM.equals(model.getShimVendor())) {
+        nc.setStorageScheme(MAPRFS_SCHEME);
+      }
       if ( variableSpace != null ) {
         nc.shareVariablesWith( variableSpace );
       } else {
@@ -260,6 +265,9 @@ public class HadoopClusterManager implements RuntimeTestProgressCallback {
     nc.setOozieUrl( model.getOozieUrl() );
     nc.setKafkaBootstrapServers( model.getKafkaBootstrapServers() );
     resolveShimIdentifier( nc, model.getShimVendor(), model.getShimVersion() );
+    if (MAPR_SHIM.equals(model.getShimVendor())) {
+      nc.setStorageScheme(MAPRFS_SCHEME);
+    }
     setupKnoxSecurity( nc, model );
     if ( variableSpace != null ) {
       nc.shareVariablesWith( variableSpace );

--- a/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/test/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterManagerTest.java
@@ -86,6 +86,8 @@ public class HadoopClusterManagerTest {
   private static final String HIVE_SITE = "hive-site.xml";
   private static final String OOZIE_SITE = "oozie-site.xml";
   private static final String YARN_SITE = "yarn-site.xml";
+  public static final String MAPR_SHIM_VENDOR = "Map-R";
+  public static final String MAPRFS_SCHEME = "maprfs";
 
   @Mock private Spoon spoon;
   @Mock private LogChannelInterfaceFactory logChannelFactory;
@@ -224,6 +226,14 @@ public class HadoopClusterManagerTest {
     model.setName( ncTestName );
     JSONObject result = hadoopClusterManager.createNamedCluster( model, getFiles( "/" ) );
     assertEquals( ncTestName, result.get( "namedCluster" ) );
+    verify( namedCluster, never() ).setStorageScheme( any( String.class ) );
+  }
+
+  @Test public void testMaprCreateNamedCluster() {
+    ThinNameClusterModel model = new ThinNameClusterModel();
+    model.setShimVendor(MAPR_SHIM_VENDOR);
+    JSONObject result = hadoopClusterManager.createNamedCluster( model, getFiles( "/" ) );
+    verify( namedCluster ).setStorageScheme( eq( MAPRFS_SCHEME ));
   }
 
   @Test public void testOverwriteNamedClusterCaseInsensitive() {


### PR DESCRIPTION
Backport of BACKLOG-34864
Setting storageScheme as maprfs for NamedClusters based on the Shim Vendor.
This change sets the storage scheme to maprfs in the NamedCluster.
This change resonates across successful execution of Hadoop copy files directory structure and also with HBase jobs.