### PR TITLE
[SP-5875] Log kafka consumer exceptions that stop row processing.

### DIFF
--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaStreamSource.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaStreamSource.java
@@ -148,6 +148,9 @@ public class KafkaStreamSource extends BlockingQueueStreamSource<List<Object>> {
           throw e;
         }
         return null;
+      } catch ( Exception ef ) {
+        KafkaStreamSource.this.streamStep.logError( "Exception consuming messages.", ef );
+        return null;
       } finally {
         commitOffsets();
         consumer.close();


### PR DESCRIPTION
This commit is a cherry-pick from master e64c6e7f9.