### PR TITLE
[PPP-4495] Use of Vulnerable Component: Components/legion-of-the-boun…

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk14</artifactId>
-      <version>1.65</version>
     </dependency>
     <dependency>
       <groupId>bsf</groupId>


### PR DESCRIPTION
…cy-castle-java-crytography-api

Related with https://github.com/pentaho/maven-parent-poms/pull/262.

Now using version from parent POM.