### PR TITLE
[BACKLOG-35131] Add Azure parser for AzureHDInsights specific scheme's

### DIFF
--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/AzureHdInsightsFileNameParser.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/AzureHdInsightsFileNameParser.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2021 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.big.data.impl.vfs.hdfs;
+
+import org.apache.commons.vfs2.provider.URLFileNameParser;
+
+@SuppressWarnings( "deprecation" )
+public class AzureHdInsightsFileNameParser extends URLFileNameParser {
+
+  public static final String EMPTY_HOSTNAME = "";
+
+  private static final AzureHdInsightsFileNameParser INSTANCE = new AzureHdInsightsFileNameParser();
+
+  private AzureHdInsightsFileNameParser() {
+    super( -1 );
+  }
+
+  public static AzureHdInsightsFileNameParser getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Extracts the hostname from a URI.
+   *
+   * @param name string buffer with the "scheme://[userinfo@]" part has been removed already. Will be modified.
+   * @return the host name  or null.
+   */
+  @Override protected String extractHostName( StringBuilder name ) {
+    final String hostname = super.extractHostName( name );
+    // Trick the URLFileNameParser into thinking we have a hostname so we don't have to refactor it.
+    return hostname == null ? EMPTY_HOSTNAME : hostname;
+  }
+}

--- a/impl/vfs/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/impl/vfs/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,6 +4,7 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
   <bean id="hdfsFileNameParser" class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileNameParser" scope="singleton" factory-method="getInstance"/>
   <bean id="maprfsFileNameParser" class="org.pentaho.big.data.impl.vfs.hdfs.MapRFileNameParser" scope="singleton" factory-method="getInstance"/>
+  <bean id="azurefsFileNameParser" class="org.pentaho.big.data.impl.vfs.hdfs.AzureHdInsightsFileNameParser" scope="singleton" factory-method="getInstance"/>
   <bean class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider" scope="singleton">
     <argument ref="hadoopFileSystemService"/>
     <argument ref="namedClusterService"/>
@@ -21,17 +22,17 @@
   </bean>
 
   <bean class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider" scope="singleton">
-      <argument ref="hadoopFileSystemService"/>
-      <argument ref="namedClusterService"/>
-      <argument ref="maprfsFileNameParser" />
-      <argument value="escalefs" type="java.lang.String"/>
+    <argument ref="hadoopFileSystemService"/>
+    <argument ref="namedClusterService"/>
+    <argument ref="maprfsFileNameParser" />
+    <argument value="escalefs" type="java.lang.String"/>
     <argument ref="metastoreLocatorOsgi" />
   </bean>
 
   <bean class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider" scope="singleton">
     <argument ref="hadoopFileSystemService"/>
     <argument ref="namedClusterService"/>
-    <argument ref="maprfsFileNameParser" />
+    <argument ref="azurefsFileNameParser" />
     <argument value="wasb" type="java.lang.String"/>
     <argument ref="metastoreLocatorOsgi" />
   </bean>
@@ -39,7 +40,7 @@
   <bean class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider" scope="singleton">
     <argument ref="hadoopFileSystemService"/>
     <argument ref="namedClusterService"/>
-    <argument ref="maprfsFileNameParser" />
+    <argument ref="azurefsFileNameParser" />
     <argument value="wasbs" type="java.lang.String"/>
     <argument ref="metastoreLocatorOsgi" />
   </bean>
@@ -49,6 +50,14 @@
     <argument ref="namedClusterService"/>
     <argument ref="hdfsFileNameParser" />
     <argument value="hc" type="java.lang.String"/>
+    <argument ref="metastoreLocatorOsgi" />
+  </bean>
+
+  <bean class="org.pentaho.big.data.impl.vfs.hdfs.HDFSFileProvider" scope="singleton">
+    <argument ref="hadoopFileSystemService"/>
+    <argument ref="namedClusterService"/>
+    <argument ref="azurefsFileNameParser" />
+    <argument value="abfs" type="java.lang.String"/>
     <argument ref="metastoreLocatorOsgi" />
   </bean>
 

--- a/impl/vfs/hdfs/src/test/java/org/pentaho/big/data/impl/vfs/hdfs/AzureFileNameParserTest.java
+++ b/impl/vfs/hdfs/src/test/java/org/pentaho/big/data/impl/vfs/hdfs/AzureFileNameParserTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Pentaho Big Data
+ * <p>
+ * Copyright (C) 2015-2021 by Hitachi Vantara : http://www.pentaho.com
+ * <p>
+ * ******************************************************************************
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+
+package org.pentaho.big.data.impl.vfs.hdfs;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+import org.apache.commons.vfs2.provider.FileNameParser;
+import org.apache.commons.vfs2.provider.UriParser;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( { UriParser.class, VFS.class } )
+public class AzureFileNameParserTest {
+
+  private static final String BASE_PATH = "//";
+  private static final String WASB_PREFIX = "wasb";
+  private static final String WASB_BASE_URI = WASB_PREFIX + ":" + BASE_PATH;
+  private static final String ABFS_PREFIX = "abfs";
+  private static final String ABFS_BASE_URI = ABFS_PREFIX + ":" + BASE_PATH;
+
+  private StandardFileSystemManager fsm;
+
+  @Before
+  public void setUp() throws Exception {
+    mockStatic( VFS.class );
+    mockStatic( UriParser.class );
+    spy( UriParser.class );
+
+    fsm = mock( StandardFileSystemManager.class );
+    when( VFS.getManager() ).thenReturn( fsm );
+  }
+
+  @Test
+  public void testDefaultPort() {
+    assertEquals( -1, AzureHdInsightsFileNameParser.getInstance().getDefaultPort() );
+  }
+
+  @Test
+  public void rootPathNoClusterNameWasb() throws Exception {
+    final String FILEPATH = "/";
+    final String URI = WASB_BASE_URI + FILEPATH;
+
+    buildExtractSchemeMocks( WASB_PREFIX, URI, BASE_PATH + FILEPATH );
+
+    FileNameParser parser = AzureHdInsightsFileNameParser.getInstance();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( WASB_PREFIX, name.getScheme() );
+  }
+
+  @Test
+  public void withPathWasb() throws Exception {
+    final String FILEPATH = "/my/file/path";
+    final String URI = WASB_BASE_URI + FILEPATH;
+
+    buildExtractSchemeMocks( WASB_PREFIX, URI, BASE_PATH + FILEPATH );
+
+    FileNameParser parser = AzureHdInsightsFileNameParser.getInstance();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( WASB_PREFIX, name.getScheme() );
+    assertEquals( FILEPATH, name.getPath() );
+  }
+
+  @Test
+  public void withPathAndClusterNameWasb() throws Exception {
+    final String HOST = "cluster2";
+    final String FILEPATH = "/my/file/path";
+    final String URI = WASB_BASE_URI + HOST + FILEPATH;
+
+    buildExtractSchemeMocks( WASB_PREFIX, URI, BASE_PATH + HOST + FILEPATH );
+
+    FileNameParser parser = AzureHdInsightsFileNameParser.getInstance();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( WASB_PREFIX, name.getScheme() );
+    assertTrue( name.getURI().startsWith( WASB_PREFIX + ":" + BASE_PATH + HOST ) );
+    assertEquals( FILEPATH, name.getPath() );
+  }
+
+  @Test
+  public void rootPathNoClusterNameAbfs() throws Exception {
+    final String FILEPATH = "/";
+    final String URI = ABFS_BASE_URI + FILEPATH;
+
+    buildExtractSchemeMocks( ABFS_PREFIX, URI, BASE_PATH + FILEPATH );
+
+    FileNameParser parser = AzureHdInsightsFileNameParser.getInstance();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( ABFS_PREFIX, name.getScheme() );
+  }
+
+  @Test
+  public void withPathAbfs() throws Exception {
+    final String FILEPATH = "/my/file/path";
+    final String URI = ABFS_BASE_URI + FILEPATH;
+
+    buildExtractSchemeMocks( ABFS_PREFIX, URI, BASE_PATH + FILEPATH );
+
+    FileNameParser parser = AzureHdInsightsFileNameParser.getInstance();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( ABFS_PREFIX, name.getScheme() );
+    assertEquals( FILEPATH, name.getPath() );
+  }
+
+  @Test
+  public void withPathAndClusterNameAbfs() throws Exception {
+    final String HOST = "cluster2";
+    final String FILEPATH = "/my/file/path";
+    final String URI = ABFS_BASE_URI + HOST + FILEPATH;
+
+    buildExtractSchemeMocks( ABFS_PREFIX, URI, BASE_PATH + HOST + FILEPATH );
+
+    FileNameParser parser = AzureHdInsightsFileNameParser.getInstance();
+    FileName name = parser.parseUri( null, null, URI );
+
+    assertEquals( URI, name.getURI() );
+    assertEquals( ABFS_PREFIX, name.getScheme() );
+    assertTrue( name.getURI().startsWith( ABFS_PREFIX + ":" + BASE_PATH + HOST ) );
+    assertEquals( FILEPATH, name.getPath() );
+  }
+
+  private Answer buildSchemeAnswer( String prefix, String buildPath ) {
+    Answer extractSchemeAnswer = invocation -> {
+      Object[] args = invocation.getArguments();
+      ( (StringBuilder) args[2] ).append( buildPath );
+      return prefix;
+    };
+    return extractSchemeAnswer;
+  }
+
+  private void buildExtractSchemeMocks( String prefix, String fullPath, String pathWithoutPrefix ) throws Exception {
+    String[] schemes = { "wasb", "abfs" };
+    when( fsm.getSchemes() ).thenReturn( schemes );
+    doAnswer( buildSchemeAnswer( prefix, pathWithoutPrefix ) ).when( UriParser.class, "extractScheme",
+      eq( schemes ), eq( fullPath ), any( StringBuilder.class ) );
+  }
+}


### PR DESCRIPTION
Updated to enable file system parser to list and select files on Azure HDInsights shim jobs