### PR TITLE
Fixed an issue where kettle could not connect to Impala in authentica…

### DIFF
--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/ImpalaDatabaseDialect.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/ImpalaDatabaseDialect.java
@@ -80,7 +80,7 @@ public class ImpalaDatabaseDialect extends Hive2DatabaseDialect {
       return urlBuffer.toString();
     }
 
-    urlBuffer.append( ";auth=noSasl" );
+    // urlBuffer.append( ";auth=noSasl" );
     return urlBuffer.toString();
   }
 

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/ImpalaDatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/ImpalaDatabaseMeta.java
@@ -144,9 +144,9 @@ public class ImpalaDatabaseMeta extends Hive2DatabaseMeta implements DatabaseInt
       getAttributes().getProperty( ATTRIBUTE_PREFIX_EXTRA_OPTION + getPluginId() + ".principal" );
     urlBuffer.append( "jdbc:hive2://" ).append( hostname ).append( ":" ).append( port ).append( "/" )
       .append( databaseName );
-    if ( principal == null && extraPrincipal == null ) {
-      urlBuffer.append( AUTH_NO_SASL );
-    }
+    // if ( principal == null && extraPrincipal == null ) {
+    //   urlBuffer.append( AUTH_NO_SASL );
+    // }
     urlBuffer.append( ";impala_db=true" );
     return urlBuffer.toString();
   }


### PR DESCRIPTION
If the auth of Impala is 'noSasl' or 'Kerberos',this plugin will work fine.
But if the auth of Impala is 'none'(using password and username to connect Impala), kettle will report a error like picture1.
And the type of auth could not edit on the kettle's interface, kettle will report a error about 'duplicate key'.
So , I think the type of auth of Impala shoud be defined on the kettle's interface by user. I edited the code like this merge,the all problems are solved in my project.
[![oaGr8g.png](https://z3.ax1x.com/2021/12/03/oaGr8g.png)](https://imgtu.com/i/oaGr8g)
[![oaGDPS.jpg](https://z3.ax1x.com/2021/12/03/oaGDPS.jpg)](https://imgtu.com/i/oaGDPS)
[![oaG058.jpg](https://z3.ax1x.com/2021/12/03/oaG058.jpg)](https://imgtu.com/i/oaG058)