### PR TITLE
[Backlog-35705][Bigdata|CDP71] - Incorrect config.properties file is …

### DIFF
--- a/kettle-plugins/common/ui/src/main/resources/cdpdc71sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/cdpdc71sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2022 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual


### PR DESCRIPTION
[Backlog-35705][Bigdata|CDP71] - Incorrect config.properties file is getting created for Hadoop Cluster connection with CDP71 shim. New sampleconfig.properties file is added.