### PR TITLE
[Backlog-35741][All Shims] Discrepancies in Copyright Years are updated

### DIFF
--- a/kettle-plugins/common/ui/src/main/resources/apachesampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/apachesampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2021 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/cdh514sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/cdh514sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/cdh61sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/cdh61sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/dataproc1421sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/dataproc1421sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/emr521sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/emr521sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2019 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/hdi40sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/hdi40sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2021 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/hdp26sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/hdp26sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/hdp30sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/hdp30sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2017 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/mapr60sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/mapr60sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2019 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual

--- a/kettle-plugins/common/ui/src/main/resources/mapr61sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/mapr61sampleconfig.properties
@@ -1,7 +1,7 @@
 #
 #  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
 #
-#  Copyright 2002 - 2021 Hitachi Vantara. All rights reserved.
+#  Copyright 2007 - 2022 Hitachi Vantara. All rights reserved.
 #
 #  NOTICE: All information including source code contained herein is, and
 #  remains the sole property of Hitachi Vantara and its licensors. The intellectual


### PR DESCRIPTION
[All Shims] Discrepancies in Copyright Years detail in config.properties file with all different Shims. (#2289)

(cherry picked from commit 2b5963b652916d153afac5846d814f1ac550fd14)