### PR TITLE
[BACKLOG-36466] Ensure all js dependencies are declared as bundle

### DIFF
--- a/assemblies/features/src/main/feature/feature.xml
+++ b/assemblies/features/src/main/feature/feature.xml
@@ -82,7 +82,10 @@
   <feature name="pentaho-hadoop-cluster-ui" version="1.0">
     <bundle>mvn:org.pentaho.di.plugins/core-ui/${project.version}</bundle>
     <bundle>mvn:pentaho/hadoop-cluster-ui/${project.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular/${angular.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-animate/${angular.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-i18n/${angular.version}</bundle>
+    <bundle>pentaho-webjars:mvn:org.webjars.bower/requirejs-text/${requirejs-text.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__core/${uirouter-core.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.npm/uirouter__angularjs/${uirouter-angularjs.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.npm/jquery/${jquery.version}</bundle>

--- a/kettle-plugins/hadoop-cluster/pom.xml
+++ b/kettle-plugins/hadoop-cluster/pom.xml
@@ -27,7 +27,6 @@
     <pentaho-osgi-bundles.version>9.4.0.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <platform.version>9.4.0.0-SNAPSHOT</platform.version>
     <cxf.karaf.version>3.0.13</cxf.karaf.version>
-    <requirejs-text.version>2.0.10</requirejs-text.version>
     <require-css.version>0.1.8</require-css.version>
     <swt.version>4.6</swt.version>
     <dependency.javax.servlet-api.version>3.0.1</dependency.javax.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <thoughtworks.paranamer.version>2.7</thoughtworks.paranamer.version>
     <dependency.commons-httpclient.revision>3.1</dependency.commons-httpclient.revision>
     <powermock.version>1.7.3</powermock.version>
+    <requirejs-text.version>2.0.10</requirejs-text.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
dependencies for hadoop cluster UI.  Some dependencies necessary for the hadoop cluster UI were previously being loaded by other plugins which are no longer present.