### PR TITLE
[BACKLOG-37368] Update bouncycastle dependencies to remove old version

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -41,9 +41,19 @@
       <version>3.2</version>
     </dependency>
     <dependency>
-      <groupId>bouncycastle</groupId>
+      <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk14</artifactId>
-      <version>138</version>
+      <version>${bcprov-jdk14.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk14</artifactId>
+      <version>${bcprov-jdk14.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk14</artifactId>
+      <version>${bcprov-jdk14.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -30,8 +30,10 @@
         <include>io.reactivex.rxjava2:rxjava</include>
         <include>ascsapjco3wrp:ascsapjco3wrp</include>
         <include>asm:asm</include>
-        <include>bouncycastle:bcmail-jdk14</include>
+        <include>org.bouncycastle:bcmail-jdk14</include>
         <include>org.bouncycastle:bcprov-jdk14</include>
+        <include>org.bouncycastle:bcutil-jdk14</include>
+        <include>org.bouncycastle:bcpkix-jdk14</include>
         <include>bsf:bsf</include>
         <include>cglib:cglib-nodep</include>
         <include>com.enterprisedt:edtftpj</include>


### PR DESCRIPTION
and match latest used by license manager.