### PR TITLE
[BACKLOG-37434] Move metastore locator plugin access out of constructors

### DIFF
--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileProvider.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileProvider.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Pentaho Big Data
  * <p>
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  * <p>
  * ******************************************************************************
  * <p>
@@ -106,6 +106,11 @@ public class HDFSFileProvider extends AbstractOriginatingFileProvider {
     this.hadoopFileSystemLocator = hadoopFileSystemLocator;
     this.namedClusterService = namedClusterService;
     this.metaStoreService = metaStore;
+    setFileNameParser( fileNameParser );
+    fileSystemManager.addProvider( schemes, this );
+  }
+
+  protected MetastoreLocator getMetastoreLocator() {
     if ( this.metaStoreService == null ) {
       try {
         Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
@@ -114,8 +119,7 @@ public class HDFSFileProvider extends AbstractOriginatingFileProvider {
         logger.error( "Error getting MetastoreLocator", e );
       }
     }
-    setFileNameParser( fileNameParser );
-    fileSystemManager.addProvider( schemes, this );
+    return this.metaStoreService;
   }
 
   @Override protected FileSystem doCreateFileSystem( final FileName name, final FileSystemOptions fileSystemOptions )
@@ -138,7 +142,7 @@ public class HDFSFileProvider extends AbstractOriginatingFileProvider {
 
   @Override
   public FileSystemConfigBuilder getConfigBuilder() {
-    return NamedClusterConfigBuilder.getInstance( metaStoreService, namedClusterService );
+    return NamedClusterConfigBuilder.getInstance( getMetastoreLocator(), namedClusterService );
   }
 
   private NamedCluster resolveNamedCluster( String hostName, int port, final FileName name ) {

--- a/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/NamedClusterResolver.java
+++ b/kettle-plugins/formats/src/main/java/org/pentaho/big/data/kettle/plugins/formats/impl/NamedClusterResolver.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -45,12 +45,19 @@ public class NamedClusterResolver {
                                NamedClusterService namedClusterService ) {
     this.namedClusterServiceLocator = namedClusterServiceLocator;
     this.namedClusterService = namedClusterService;
-    try {
-      Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
-      this.metaStoreService = metastoreLocators.stream().findFirst().get();
-    } catch ( Exception e ) {
-      LOG.logError( "Error getting MetastoreLocator", e );
+
+  }
+
+  protected MetastoreLocator getMetastoreLocator() {
+    if ( this.metaStoreService == null ) {
+      try {
+        Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
+        this.metaStoreService = metastoreLocators.stream().findFirst().get();
+      } catch ( Exception e ) {
+        LOG.logError( "Error getting MetastoreLocator", e );
+      }
     }
+    return this.metaStoreService;
   }
 
   private static final LogChannelInterface LOG = LogChannel.GENERAL;
@@ -67,17 +74,17 @@ public class NamedClusterResolver {
       String scheme = uri.get().getScheme();
       String hostName = uri.get().getHost();
       if ( scheme != null && scheme.equals( "hc" ) ) {
-        namedCluster = namedClusterService.getNamedClusterByName( hostName, metaStoreService.getMetastore( ) );
+        namedCluster = namedClusterService.getNamedClusterByName( hostName, getMetastoreLocator().getMetastore( ) );
         if ( namedCluster == null && embeddedMetastoreKey != null ) {
           namedCluster = namedClusterService
-            .getNamedClusterByName( hostName, metaStoreService.getExplicitMetastore( embeddedMetastoreKey ) );
+            .getNamedClusterByName( hostName, getMetastoreLocator().getExplicitMetastore( embeddedMetastoreKey ) );
         }
       } else {
         namedCluster =
-          namedClusterService.getNamedClusterByHost( hostName, metaStoreService.getMetastore( embeddedMetastoreKey ) );
+          namedClusterService.getNamedClusterByHost( hostName, getMetastoreLocator().getMetastore( embeddedMetastoreKey ) );
         if ( namedCluster == null && embeddedMetastoreKey != null ) {
           namedCluster = namedClusterService
-            .getNamedClusterByHost( hostName, metaStoreService.getExplicitMetastore( embeddedMetastoreKey ) );
+            .getNamedClusterByHost( hostName, getMetastoreLocator().getExplicitMetastore( embeddedMetastoreKey ) );
         }
       }
     }

--- a/kettle-plugins/formats/src/test/java/org/pentaho/big/data/kettle/plugins/formats/impl/NamedClusterResolverTest.java
+++ b/kettle-plugins/formats/src/test/java/org/pentaho/big/data/kettle/plugins/formats/impl/NamedClusterResolverTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -65,12 +65,7 @@ public class NamedClusterResolverTest {
       .thenReturn( namedCluster );
     when( namedClusterService.getNamedClusterByHost( "somehost", null ) )
       .thenReturn( namedCluster );
-    Collection<MetastoreLocator> metastoreLocatorCollection = new ArrayList<>();
-    metastoreLocatorCollection.add( metaStoreService );
-    try ( MockedStatic<PluginServiceLoader> pluginServiceLoaderMockedStatic = Mockito.mockStatic( PluginServiceLoader.class ) ) {
-      pluginServiceLoaderMockedStatic.when( () -> PluginServiceLoader.loadServices( MetastoreLocator.class ) ).thenReturn( metastoreLocatorCollection );
-      namedClusterResolver = new NamedClusterResolver( namedClusterServiceLocator, namedClusterService );
-    }
+    namedClusterResolver = new NamedClusterResolver( namedClusterServiceLocator, namedClusterService );
   }
 
   @Test
@@ -82,18 +77,29 @@ public class NamedClusterResolverTest {
 
   @Test
   public void testNamedClusterByName() {
-    NamedCluster cluster = namedClusterResolver.resolveNamedCluster( "hc://testhc/path" );
-    assertEquals( namedCluster, cluster );
+    Collection<MetastoreLocator> metastoreLocatorCollection = new ArrayList<>();
+    metastoreLocatorCollection.add( metaStoreService );
+    try ( MockedStatic<PluginServiceLoader> pluginServiceLoaderMockedStatic = Mockito.mockStatic( PluginServiceLoader.class ) ) {
+      pluginServiceLoaderMockedStatic.when( () -> PluginServiceLoader.loadServices( MetastoreLocator.class ) )
+        .thenReturn( metastoreLocatorCollection );
+      NamedCluster cluster = namedClusterResolver.resolveNamedCluster( "hc://testhc/path" );
+      assertEquals( namedCluster, cluster );
 
-    cluster = namedClusterResolver.resolveNamedCluster( "hc://nosuchhc/path" );
-    assertNull( cluster );
-
+      cluster = namedClusterResolver.resolveNamedCluster( "hc://nosuchhc/path" );
+      assertNull( cluster );
+    }
   }
 
   @Test
   public void testNamedClusterByHost() {
-    NamedCluster cluster = namedClusterResolver.resolveNamedCluster( "hdfs://somehost/path" );
-    assertEquals( namedCluster, cluster );
+    Collection<MetastoreLocator> metastoreLocatorCollection = new ArrayList<>();
+    metastoreLocatorCollection.add( metaStoreService );
+    try ( MockedStatic<PluginServiceLoader> pluginServiceLoaderMockedStatic = Mockito.mockStatic( PluginServiceLoader.class ) ) {
+      pluginServiceLoaderMockedStatic.when( () -> PluginServiceLoader.loadServices( MetastoreLocator.class ) )
+        .thenReturn( metastoreLocatorCollection );
+      NamedCluster cluster = namedClusterResolver.resolveNamedCluster( "hdfs://somehost/path" );
+      assertEquals( namedCluster, cluster );
+    }
   }
 
 }

--- a/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterEndpoints.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/endpoints/HadoopClusterEndpoints.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2019-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2019-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,11 +34,9 @@ import org.pentaho.di.core.logging.KettleLogStore;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.service.PluginServiceLoader;
 import org.pentaho.di.ui.spoon.Spoon;
-import org.pentaho.metastore.locator.api.MetastoreLocator;
 import org.pentaho.hadoop.shim.api.cluster.NamedClusterService;
+import org.pentaho.metastore.locator.api.MetastoreLocator;
 import org.pentaho.runtime.test.RuntimeTester;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -93,20 +91,26 @@ public class HadoopClusterEndpoints {
   public HadoopClusterEndpoints( NamedClusterService namedClusterService,
                                  RuntimeTester runtimeTester, String internalShim, boolean secureEnabled ) {
     this.namedClusterService = namedClusterService;
-    try {
-      Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
-      this.metastoreLocator = metastoreLocators.stream().findFirst().get();
-    } catch ( Exception e ) {
-      log.logError( "Error getting MetastoreLocator", e );
-    }
     this.runtimeTester = runtimeTester;
     this.internalShim = internalShim;
     this.secureEnabled = secureEnabled;
   }
 
+  protected MetastoreLocator getMetastoreLocator() {
+    if ( this.metastoreLocator == null ) {
+      try {
+        Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
+        this.metastoreLocator = metastoreLocators.stream().findFirst().get();
+      } catch ( Exception e ) {
+        log.logError( "Error getting MetastoreLocator", e );
+      }
+    }
+    return this.metastoreLocator;
+  }
+
   private HadoopClusterManager getClusterManager() {
     return new HadoopClusterManager( spoonSupplier.get(), this.namedClusterService,
-      this.metastoreLocator.getMetastore(),
+    getMetastoreLocator().getMetastore(),
       internalShim );
   }
 

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/output/HBaseOutputMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,7 +38,6 @@ import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
-import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.service.PluginServiceLoader;
 import org.pentaho.di.core.util.Utils;
@@ -166,12 +165,18 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
                           RuntimeTestActionService runtimeTestActionService, RuntimeTester runtimeTester ) {
     this( namedClusterService, namedClusterServiceLocator,
       runtimeTestActionService, runtimeTester, new NamedClusterLoadSaveUtil(), null );
-    try {
-      Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
-      this.metaStoreService = metastoreLocators.stream().findFirst().get();
-    } catch ( Exception e ) {
-      getLog().logError( "Error getting MetastoreLocator", e );
+  }
+
+  protected MetastoreLocator getMetastoreService() {
+    if ( this.metaStoreService == null ) {
+      try {
+        Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
+        this.metaStoreService = metastoreLocators.stream().findFirst().get();
+      } catch ( Exception e ) {
+        getLog().logError( "Error getting MetastoreLocator", e );
+      }
     }
+    return this.metaStoreService;
   }
 
   @VisibleForTesting
@@ -272,7 +277,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
       // the namedCluster present in the local metastore.  Time to load it from the embedded Metastore which is only
       // present at runtime
       NamedCluster nc = namedClusterService.getNamedClusterByName( namedCluster.getName(),
-        metaStoreService.getExplicitMetastore( getParentStepMeta().getParentTransMeta().getEmbeddedMetastoreProviderKey() ) );
+        getMetastoreService().getExplicitMetastore( getParentStepMeta().getParentTransMeta().getEmbeddedMetastoreProviderKey() ) );
       if ( nc != null && nc.getShimIdentifier() != null ) {
         namedCluster = nc; //Overwrite with the real one
       }
@@ -382,7 +387,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     throws KettleXMLException {
 
     if ( metaStore == null ) {
-      metaStore = metaStoreService.getMetastore();
+      metaStore = getMetastoreService().getMetastore();
     }
 
     this.namedCluster =
@@ -429,7 +434,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     throws KettleException {
 
     if ( metaStore == null ) {
-      metaStore = metaStoreService.getMetastore();
+      metaStore = getMetastoreService().getMetastore();
     }
 
     this.namedCluster =
@@ -461,7 +466,7 @@ public class HBaseOutputMeta extends BaseStepMeta implements StepMetaInterface {
     throws KettleException {
 
     if ( metaStore == null ) {
-      metaStore = metaStoreService.getMetastore();
+      metaStore = getMetastoreService().getMetastore();
     }
 
     namedClusterLoadSaveUtil

--- a/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMeta.java
+++ b/kettle-plugins/hbase/src/main/java/org/pentaho/big/data/kettle/plugins/hbase/rowdecoder/HBaseRowDecoderMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -38,7 +38,6 @@ import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.injection.Injection;
 import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
-import org.pentaho.di.core.logging.LogChannel;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.core.row.value.ValueMetaBase;
@@ -121,12 +120,18 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
                               NamedClusterService namedClusterService,
                               RuntimeTestActionService runtimeTestActionService, RuntimeTester runtimeTester ) {
     this( namedClusterServiceLocator, namedClusterService, runtimeTestActionService, runtimeTester, null );
-    try {
-      Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
-      this.metaStoreService = metastoreLocators.stream().findFirst().get();
-    } catch ( Exception e ) {
-      logError( "Error getting MetastoreLocator", e );
+  }
+
+  public MetastoreLocator getMetastoreLocators() {
+    if ( this.metaStoreService == null ) {
+      try {
+        Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
+        this.metaStoreService = metastoreLocators.stream().findFirst().get();
+      } catch ( Exception e ) {
+        logError( "Error getting MetastoreLocator", e );
+      }
     }
+    return this.metaStoreService;
   }
 
   @VisibleForTesting
@@ -344,7 +349,7 @@ public class HBaseRowDecoderMeta extends BaseStepMeta implements StepMetaInterfa
 
   public void loadXML( Node stepnode, List<DatabaseMeta> databases, IMetaStore metaStore ) throws KettleXMLException {
     if ( metaStore == null ) {
-      metaStore = metaStoreService.getMetastore();
+      metaStore = getMetastoreLocators().getMetastore();
     }
 
     mIncomingKeyField = XMLHandler.getTagValue( stepnode, INCOMING_KEY_FIELD );

--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/Hive2DatabaseMeta.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/Hive2DatabaseMeta.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2022 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2023 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,17 +22,16 @@
 package org.pentaho.big.data.kettle.plugins.hive;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.service.PluginServiceLoader;
-import org.pentaho.hadoop.shim.api.cluster.NamedClusterService;
-import org.pentaho.hadoop.shim.api.jdbc.DriverLocator;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.plugins.DatabaseMetaPlugin;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.service.PluginServiceLoader;
+import org.pentaho.hadoop.shim.api.cluster.NamedClusterService;
+import org.pentaho.hadoop.shim.api.jdbc.DriverLocator;
 import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.metastore.locator.api.MetastoreLocator;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,12 +56,18 @@ public class Hive2DatabaseMeta extends DatabaseMetaWithVersion {
   public Hive2DatabaseMeta( DriverLocator driverLocator, NamedClusterService namedClusterService ) {
     super( driverLocator );
     this.namedClusterService = namedClusterService;
-    try {
-      Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
-      this.metastoreLocator = metastoreLocators.stream().findFirst().get();
-    } catch ( Exception e ) {
-      logger.error( "Error getting metastore locator", e );
+  }
+
+  public MetastoreLocator getMetastoreLocator() {
+    if ( this.metastoreLocator == null ) {
+      try {
+        Collection<MetastoreLocator> metastoreLocators = PluginServiceLoader.loadServices( MetastoreLocator.class );
+        this.metastoreLocator = metastoreLocators.stream().findFirst().get();
+      } catch ( Exception e ) {
+        logger.error( "Error getting metastore locator", e );
+      }
     }
+    return this.metastoreLocator;
   }
 
   @VisibleForTesting
@@ -259,7 +264,7 @@ public class Hive2DatabaseMeta extends DatabaseMetaWithVersion {
 
   @Override public List<String> getNamedClusterList() {
     try {
-      return namedClusterService.listNames( metastoreLocator.getMetastore() );
+      return namedClusterService.listNames( getMetastoreLocator().getMetastore() );
     } catch ( MetaStoreException e ) {
       e.printStackTrace();
       return null;


### PR DESCRIPTION
to ensure the plugin is loaded before trying to use it.