### PR TITLE
[BACKLOG-37531] Bouncycastle release/version mismatch causing problems

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -42,22 +42,23 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcmail-jdk14</artifactId>
-      <version>${bcprov-jdk14.version}</version>
+      <artifactId>bcmail-jdk15to18</artifactId>
+      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk14</artifactId>
-      <version>${bcprov-jdk14.version}</version>
+      <artifactId>bcpkix-jdk15to18</artifactId>
+      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcutil-jdk14</artifactId>
-      <version>${bcprov-jdk14.version}</version>
+      <artifactId>bcutil-jdk15to18</artifactId>
+      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk14</artifactId>
+      <artifactId>bcprov-jdk15to18</artifactId>
+      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>bsf</groupId>
@@ -138,11 +139,31 @@
       <groupId>com.lowagie</groupId>
       <artifactId>itext</artifactId>
       <version>2.1.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.lowagie</groupId>
       <artifactId>itext-rtf</artifactId>
       <version>2.1.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.tinkerpop.blueprints</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -30,10 +30,10 @@
         <include>io.reactivex.rxjava2:rxjava</include>
         <include>ascsapjco3wrp:ascsapjco3wrp</include>
         <include>asm:asm</include>
-        <include>org.bouncycastle:bcmail-jdk14</include>
-        <include>org.bouncycastle:bcprov-jdk14</include>
-        <include>org.bouncycastle:bcutil-jdk14</include>
-        <include>org.bouncycastle:bcpkix-jdk14</include>
+        <include>org.bouncycastle:bcmail-jdk15to18</include>
+        <include>org.bouncycastle:bcprov-jdk15to18</include>
+        <include>org.bouncycastle:bcutil-jdk15to18</include>
+        <include>org.bouncycastle:bcpkix-jdk15to18</include>
         <include>bsf:bsf</include>
         <include>cglib:cglib-nodep</include>
         <include>com.enterprisedt:edtftpj</include>


### PR DESCRIPTION
for karaf ssh service (and presumably anything else in karaf reliant on them).  Standardizing on the jdk15to18 packages since these still work on JDK1.8 (they are not multiversion jars).