### PR TITLE
[SP-6319] - Backport of PPP-3713 - Beanshell version we're using is vulnerable to serialization exploit - CVE-2016-2510 (9.3 Suite)

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -524,9 +524,9 @@
       <version>${apache-xmlgraphics.revision}</version>
     </dependency>
     <dependency>
-      <groupId>org.beanshell</groupId>
+      <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
-      <version>1.3.0</version>
+      <version>${beanshell.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -140,7 +140,7 @@
         <include>org.apache.xmlgraphics:batik-xml</include>
         <include>org.apache.xmlgraphics:batik-constants</include>
         <include>org.apache.xmlgraphics:batik-i18n</include>
-        <include>org.beanshell:bsh</include>
+        <include>org.apache-extras.beanshell:bsh</include>
         <include>org.codehaus.groovy:groovy</include>
         <include>org.codehaus.jackson:jackson-core-asl</include>
         <include>org.codehaus.jackson:jackson-jaxrs</include>


### PR DESCRIPTION
@andreramos89 
@bcostahitachivantara 
@smmribeiro 

Original PR: https://github.com/pentaho/big-data-plugin/pull/2402