### PR TITLE
[BACKLOG-36262] - Localization missing for DetectLastRow step and other in PDI

### DIFF
--- a/legacy-amazon/pom.xml
+++ b/legacy-amazon/pom.xml
@@ -365,6 +365,12 @@
       <version>${platform.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>pentaho-s3-vfs</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
Adding back the removed dependency with scope tests to fix failing unit test (AbstractAmazonJobExecutorTest.testGetS3FileObjectPath_validPath()).

