### PR TITLE
renaming the artifact id from

### DIFF
--- a/assemblies/kafka-plugin/pom.xml
+++ b/assemblies/kafka-plugin/pom.xml
@@ -10,7 +10,7 @@
     <version>10.0.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>pentaho-streaming-kafka-plugin-zip</artifactId>
+  <artifactId>pentaho-streaming-kafka-plugin</artifactId>
   <version>10.0.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 

--- a/assemblies/kafka-plugin/src/assembly/assembly.xml
+++ b/assemblies/kafka-plugin/src/assembly/assembly.xml
@@ -1,7 +1,7 @@
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
-  <id>pentaho-streaming-kafka-plugin-zip</id>
+  <id>pentaho-streaming-kafka-plugin</id>
   <formats>
     <format>zip</format>
   </formats>


### PR DESCRIPTION
pentaho-streaming-kafka-plugin-zip to
pentaho-streaming-kafka-plugin and
fixed the id in the following path assemblies/kafka-plugin/src/assembly/assembly.xml from pentaho-streaming-kafka-plugin-zip to pentaho-streaming-kafka-plugin