### PR TITLE
[BACKLOG-39478] Repository based VFS connection ( AWS) failing to con…

### DIFF
--- a/s3-vfs/src/main/java/org/pentaho/amazon/s3/S3DetailComposite.java
+++ b/s3-vfs/src/main/java/org/pentaho/amazon/s3/S3DetailComposite.java
@@ -129,7 +129,7 @@ public class S3DetailComposite implements VFSDetailsComposite {
     wAuthType.select( Integer.parseInt( Const.NVL( details.getAuthType(), "0" ) ) );
     wRegion = createStandbyComboVar();
     wRegion.setItems( regionChoices );
-    wRegion.select( 0 );
+    wRegion.select( computeComboIndex( Const.NVL( details.getRegion(), regionChoices[ 0 ] ), regionChoices, -1 ) );
     wAccessKey = createStandbyPasswordVisibleTextVar();
     wSecretKey = createStandbyPasswordVisibleTextVar();
     wSessionToken = createStandbyPasswordVisibleTextVar();


### PR DESCRIPTION
…nect to Amazon server while it is accepting the connection without connecting to repository.

Due to changes in https://github.com/pentaho/big-data-plugin/pull/2511/files PR. It is populating the initial value (regionChoices[0]) even while opening the edit VFS connection Dialog. Need to populate the updated region.

