### PR TITLE
[PDI-20140] Add a kettle property and logic to force Hadoop File

### DIFF
--- a/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileObject.java
+++ b/impl/vfs/hdfs/src/main/java/org/pentaho/big/data/impl/vfs/hdfs/HDFSFileObject.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Big Data
  *
- * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2024 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -72,6 +72,9 @@ public class HDFSFileObject extends AbstractFileObject  {
   @Override
   protected FileType doGetType() throws Exception {
     HadoopFileStatus status = null;
+    if ( null == hdfs ) {
+      throw new IllegalStateException( "No HDFS file system present" );
+    }
     try {
       status = hdfs.getFileStatus( hdfs.getPath( getName().getPath() ) );
     } catch ( Exception ex ) {

--- a/kettle-plugins/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/kettle-plugins/hdfs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,6 +14,7 @@
   </bean>
   <bean id="hadoopFileInputMeta" class="org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileInputMeta" scope="prototype">
     <argument ref="namedClusterService"/>
+    <argument ref="hadoopFileSystemService"/>
     <pen:di-plugin type="org.pentaho.di.core.plugins.StepPluginType"/>
   </bean>
   <bean id="hadoopFileOutputMeta" class="org.pentaho.big.data.kettle.plugins.hdfs.trans.HadoopFileOutputMeta" scope="prototype">
@@ -32,6 +33,7 @@
   <reference id="namedClusterService" interface="org.pentaho.hadoop.shim.api.cluster.NamedClusterService"/>
   <reference id="runtimeTester" interface="org.pentaho.runtime.test.RuntimeTester"/>
   <reference id="runtimeTestActionService" interface="org.pentaho.runtime.test.action.RuntimeTestActionService"/>
+  <reference id="hadoopFileSystemService" interface="org.pentaho.hadoop.shim.api.hdfs.HadoopFileSystemLocator"/>
 
 
   <bean id="MetaverseGraphImpl" class="org.pentaho.metaverse.api.model.BaseSynchronizedGraphFactory" factory-method="open">


### PR DESCRIPTION
Input/Output steps to fail if the necessary HDFS file system is not accessible.  This property will effectively override the value of the Required column for any HDFS files in the Hadoop File Input step.