### PR TITLE
[BACKLOG-41371] - Incorrect "NAME OF CONFIGURATION" and "Copyright" years are present in config.properties file while creating hadoop connection using apachevanilla shim

### DIFF
--- a/kettle-plugins/common/ui/src/main/resources/apachevanillasampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/apachevanillasampleconfig.properties
@@ -1,0 +1,76 @@
+#
+#  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+#
+#  Copyright 2024 Hitachi Vantara. All rights reserved.
+#
+#  NOTICE: All information including source code contained herein is, and
+#  remains the sole property of Hitachi Vantara and its licensors. The intellectual
+#  and technical concepts contained herein are proprietary and confidential
+#  to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+#  patents, or patents in process, and are protected by trade secret and
+#  copyright laws. The receipt or possession of this source code and/or related
+#  information does not convey or imply any rights to reproduce, disclose or
+#  distribute its contents, or to manufacture, use, or sell anything that it
+#  may describe, in whole or in part. Any reproduction, modification, distribution,
+#  or public display of this information without the express written authorization
+#  from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+#  international treaties. Access to the source code contained herein is strictly
+#  prohibited to anyone except those individuals and entities who have executed
+#  confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+#  explicitly covering such access.
+#
+# ADDITIONAL RESOURCES
+# For additional questions please visit help.pentaho.com
+# Search for impersonation or secure impersonation
+#
+
+#
+#
+# THE NAME OF YOUR CONFIGURATION
+name= Apache Vanilla 3.3.0
+#
+
+#
+#
+# GENERAL CONFIGURATIONS
+# These  are comma-separated lists of the following:
+#
+# Directories and/or file lists available for this configuration
+classpath=
+#
+# Native libraries
+library.path=
+#
+# Classes or packages to ignore from the Hadoop configuration directory
+ignore.classes=org.apache.derby.iapi.services
+mr1.java.system.hadoop.cluster.path.separator=:
+
+#
+#
+# SECURITY CONFIGURATIONS
+#
+# Kerberos Authentication
+pentaho.authentication.default.kerberos.principal=exampleUser@EXAMPLE.COM
+#
+# Please define one of the following:
+pentaho.authentication.default.kerberos.keytabLocation=
+pentaho.authentication.default.kerberos.password=
+#
+# Secure Impersonation
+# Please choose one of the following:
+#
+# disabled - when using an unsecured cluster
+# simple - when using a 1 to 1 mapping from the server to your cluster
+pentaho.authentication.default.mapping.impersonation.type=disabled
+pentaho.authentication.default.mapping.server.credentials.kerberos.principal=exampleUser@EXAMPLE.COM
+#
+# Please define one of the following:
+pentaho.authentication.default.mapping.server.credentials.kerberos.keytabLocation=
+pentaho.authentication.default.mapping.server.credentials.kerberos.password=
+#
+
+#
+#
+# OOZIE
+pentaho.oozie.proxy.user=oozie
+#


### PR DESCRIPTION
[BACKLOG-41371] - Added config.properties for ApacheVanilla shim

[BACKLOG-41186]: https://hv-eng.atlassian.net/browse/BACKLOG-41186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BACKLOG-41371]: https://hv-eng.atlassian.net/browse/BACKLOG-41371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ