### PR TITLE
[BAD-1946][BACKLOG-41496] Add EMR versions 5.36 and 7.0 to available …

### DIFF
--- a/legacy-amazon/src/main/java/org/pentaho/amazon/AmazonEmrReleases.java
+++ b/legacy-amazon/src/main/java/org/pentaho/amazon/AmazonEmrReleases.java
@@ -27,6 +27,8 @@ package org.pentaho.amazon;
  * Created by Aliaksandr_Zhuk on 1/20/2018.
  */
 public enum AmazonEmrReleases {
+  EMR_700( "emr-7.0.0" ),
+  EMR_5360( "emr-5.36.0" ),
   EMR_5110( "emr-5.11.0" ),
   EMR_5100( "emr-5.10.0" ),
   EMR_590( "emr-5.9.0" ),

--- a/legacy-amazon/src/test/java/org/pentaho/amazon/AbstractAmazonJobExecutorControllerTest.java
+++ b/legacy-amazon/src/test/java/org/pentaho/amazon/AbstractAmazonJobExecutorControllerTest.java
@@ -98,7 +98,7 @@ public class AbstractAmazonJobExecutorControllerTest {
   @Test
   public void testPopulateReleases_getValidCountOfEnumElements() throws Exception {
 
-    int expectedCountOfReleases = 32;
+    int expectedCountOfReleases = 34;
 
     AbstractModelList<String> listReleases = jobExecutorController.populateReleases();
 
@@ -108,7 +108,7 @@ public class AbstractAmazonJobExecutorControllerTest {
   @Test
   public void testPopulateReleases_setFirstEmrReleaseInJobEntry() throws Exception {
 
-    String expectedEmrRelease = "emr-5.11.0";
+    String expectedEmrRelease = "emr-7.0.0";
 
     AmazonHiveJobExecutor jobEntry = spy( new AmazonHiveJobExecutor() );
     AmazonHiveJobExecutorController hiveJobExecutorController =
@@ -140,7 +140,7 @@ public class AbstractAmazonJobExecutorControllerTest {
   @Test
   public void testPopulateReleases_addNewEmrReleaseToReleasesList() throws Exception {
 
-    int expectedCountOfReleases = 33;
+    int expectedCountOfReleases = 35;
 
     when( jobExecutorController.getJobEntry().getEmrRelease() ).thenReturn( "emr-5.12.0" );
     AbstractModelList<String> listReleases = jobExecutorController.populateReleases();
@@ -152,7 +152,7 @@ public class AbstractAmazonJobExecutorControllerTest {
   @Test
   public void testPopulateReleases_setEmrReleaseToFirstElementFromEmrReleasesList() throws Exception {
 
-    String expectedEmrRelease = "emr-5.11.0";
+    String expectedEmrRelease = "emr-7.0.0";
 
     AmazonHiveJobExecutor jobEntry = spy( new AmazonHiveJobExecutor() );
 


### PR DESCRIPTION
…EMR Release versions to Amazon Hive and Amazon EMR job executor job entries - 10.2.0.0 branch