### PR TITLE
[PPP-4784] Vulnerable Component: groovy

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -541,7 +541,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.4.8</version>
+      <version>2.4.21</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -542,6 +542,12 @@
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
       <version>2.4.21</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
- Update groovy minor version to 2.4.21 to address CVE-2020-17521
- exclude transitive dependencies and their vulnerabilities

JIRA: https://hv-eng.atlassian.net/browse/PPP-4784

PR Set:
- https://github.com/pentaho/pentaho-platform/pull/5680
- https://github.com/pentaho/pentaho-reporting/pull/1676
- https://github.com/pentaho/big-data-plugin/pull/2584
- https://github.com/pentaho/pentaho-big-data-ee/pull/612
- https://github.com/pentaho/mondrian/pull/1386