### PR TITLE
[PPP-4391] Remove c3p0 dependency; was never really used except as a

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -573,11 +573,6 @@
       <version>1.3.2</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-c3p0</artifactId>
-      <version>5.4.24.Final</version>
-    </dependency>
-    <dependency>
       <groupId>org.hibernate.common</groupId>
       <artifactId>hibernate-commons-annotations</artifactId>
       <version>5.1.2.Final</version>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -157,7 +157,6 @@
         <include>org.eclipse.jetty:jetty-util</include>
         <include>org.eobjects.sassyreader:SassyReader</include>
         <include>org.fife.ui:rsyntaxtextarea</include>
-        <include>org.hibernate:hibernate-c3p0</include>
         <include>org.hibernate:hibernate-commons-annotations</include>
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-ehcache</include>


### PR DESCRIPTION
connection pool for hibernate, and tomcat handles that.