### PR TITLE
[SP-6602]-Backport of PPP-4968 - Vulnerable Component: xmlbeans 2.5.0 (10.2 Suite)

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -451,7 +451,7 @@
     <dependency>
       <groupId>org.apache.xmlbeans</groupId>
       <artifactId>xmlbeans</artifactId>
-      <version>2.5.0</version>
+      <version>${xmlbeans.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
[SP-6602]-Backport of PPP-4968 - Vulnerable Component: xmlbeans 2.5.0 (10.2 Suite)

[SP-6602]: https://hv-eng.atlassian.net/browse/SP-6602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ