### PR TITLE
[BACKLOG-42825] Avoiding special characters to be entered in in the cluster name at the import cluster dialog [BACKLOG-42828] Enabling cancel and finish buttons at the Test Results page

### DIFF
--- a/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/dialog/wizard/NamedClusterDialog.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/dialog/wizard/NamedClusterDialog.java
@@ -229,7 +229,7 @@ public class NamedClusterDialog extends Wizard {
   public boolean performFinish() {
     boolean finish = false;
     String currentPage = super.getContainer().getCurrentPage().getName();
-    if ( !currentPage.equals( reportPage.getClass().getSimpleName() ) &&
+    if ( reportPage != null && !currentPage.equals( reportPage.getClass().getSimpleName() ) &&
       !currentPage.equals( testResultsPage.getClass().getSimpleName() ) ) {
       if ( isEditMode || isDuplicating ) {
         saveEditedNamedCluster();
@@ -301,9 +301,6 @@ public class NamedClusterDialog extends Wizard {
       if ( currentPage.equals( clusterSettingsPage.getClass().getSimpleName() ) ) {
         ( (CustomWizardDialog) getContainer() ).enableCancelButton( true );
       }
-      if ( currentPage.equals( reportPage.getClass().getSimpleName() ) ) {
-        ( (CustomWizardDialog) getContainer() ).enableCancelButton( false );
-      }
       return
         ( currentPage.equals( securitySettingsPage.getClass().getSimpleName() )
           && securitySettingsPage.getSecurityType()
@@ -317,7 +314,7 @@ public class NamedClusterDialog extends Wizard {
       // Set to Initialize "TestResultsPage" when "dialogState" is "testing" and disable its "Finish" button.
       // Couldn't be done elsewhere because the "TestResultsPage" was not initialized by the wizard.
       initialize( thinNameClusterModel );
-      return false;
+      return true;
     }
   }
 

--- a/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/dialog/wizard/pages/ClusterSettingsPage.java
+++ b/kettle-plugins/hadoop-cluster/ui/src/main/java/org/pentaho/big/data/kettle/plugins/hadoopcluster/ui/dialog/wizard/pages/ClusterSettingsPage.java
@@ -486,7 +486,9 @@ public class ClusterSettingsPage extends WizardPage {
         && thinNameClusterModel.getName().matches( "^[a-zA-Z0-9-]+$" ) );
     }
     if ( ( (NamedClusterDialog) getWizard() ).getDialogState().equals( "import" ) ) {
-      setPageComplete( !thinNameClusterModel.getName().isBlank() && !thinNameClusterModel.getSiteFiles().isEmpty() );
+      setPageComplete( !thinNameClusterModel.getName().isBlank()
+        && !thinNameClusterModel.getSiteFiles().isEmpty()
+        && thinNameClusterModel.getName().matches( "^[a-zA-Z0-9-]+$" ) );
     }
   }
 


### PR DESCRIPTION
[BACKLOG-42825] Avoiding special characters to be entered in in the cluster name at the import cluster dialog 
[BACKLOG-42828] Enabling cancel and finish buttons at the Test Results page

[BACKLOG-42825]: https://hv-eng.atlassian.net/browse/BACKLOG-42825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BACKLOG-42828]: https://hv-eng.atlassian.net/browse/BACKLOG-42828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ