### PR TITLE
[SP-6649] backport of [PPP-4897] Updated the version of aws-java-sdk …

### DIFF
--- a/assemblies/features/src/main/feature/feature.xml
+++ b/assemblies/features/src/main/feature/feature.xml
@@ -1,7 +1,7 @@
 <features name="pentaho-big-data-features" xmlns="http://karaf.apache.org/xmlns/features/v1.2.1">
 
   <feature name="pentaho-big-data-common" version="1.0">
-    <bundle>wrap:mvn:com.amazonaws/aws-java-sdk/1.11.275</bundle>
+    <bundle>wrap:mvn:com.amazonaws/aws-java-sdk/1.12.759</bundle>
     <bundle>mvn:commons-cli/commons-cli/1.2</bundle>
     <bundle>wrap:mvn:com.github.stephenc.high-scale-lib/high-scale-lib/1.1.2</bundle>
     <bundle>mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}</bundle>


### PR DESCRIPTION
…from 1.11.275 to 1.12.759 in feature.xml under big-data-plugin/features

verified that the newer version of aws-java-sdk is packaged in pentaho-mapreduce-libraries.zip and in pentaho-server-ee under system/karaf/system