### PR TITLE
[BACKLOG-43841] Tag Deprecated DB Types in PUC UI

### DIFF
--- a/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/HiveDatabaseDialect.java
+++ b/kettle-plugins/hive/src/main/java/org/pentaho/big/data/kettle/plugins/hive/HiveDatabaseDialect.java
@@ -34,7 +34,7 @@ public class HiveDatabaseDialect extends AbstractDatabaseDialect {
 
   private static final int DEFAULT_PORT = 10000;
 
-  private static final IDatabaseType DBTYPE = new DatabaseType( "Hadoop Hive", "HIVE", DatabaseAccessType.getList(
+  private static final IDatabaseType DBTYPE = new DatabaseType( "Hadoop Hive (deprecated)", "HIVE", DatabaseAccessType.getList(
       DatabaseAccessType.NATIVE, DatabaseAccessType.JNDI ), DEFAULT_PORT,
       "https://cwiki.apache.org/Hive/hiveclient.html" );
 

--- a/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/HiveDatabaseDialectTest.java
+++ b/kettle-plugins/hive/src/test/java/org/pentaho/big/data/kettle/plugins/hive/HiveDatabaseDialectTest.java
@@ -52,7 +52,7 @@ public class HiveDatabaseDialectTest {
   @Test
   public void testGetDatabaseType() {
     IDatabaseType dbType = dialect.getDatabaseType();
-    Assert.assertEquals( dbType.getName(), "Hadoop Hive" );
+    Assert.assertEquals( dbType.getName(), "Hadoop Hive (deprecated)" );
   }
 
   @Test


### PR DESCRIPTION
[BACKLOG-43841] Tag Deprecated DB Types in PUC UI

[BACKLOG-43841]: https://hv-eng.atlassian.net/browse/BACKLOG-43841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ