### PR TITLE
perf[SP-6869]: Enhance S3 file tranfer (#2762)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ override.properties
 /pdi-bin
 *.iml
 .idea/
+.vscode/
 target/
 rebel.xml
 .DS_Store

--- a/s3-vfs/pom.xml
+++ b/s3-vfs/pom.xml
@@ -180,5 +180,11 @@
       <version>${slf4j-api.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/s3-vfs/src/main/java/org/pentaho/s3/vfs/S3FileObject.java
+++ b/s3-vfs/src/main/java/org/pentaho/s3/vfs/S3FileObject.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.provider.AbstractFileName;
@@ -106,8 +107,8 @@ public class S3FileObject extends S3CommonFileObject {
   @Override
   protected OutputStream doGetOutputStream( boolean bAppend ) throws Exception {
     SimpleEntry<String, String> newPath = fixFilePath( key, bucketName );
-    return new S3CommonPipedOutputStream( this.fileSystem, newPath.getValue(), newPath.getKey(),
-            ( (S3FileSystem) this.fileSystem ).getPartSize() );
+    int partSize = (int) Long.min( Integer.MAX_VALUE, this.fileSystem.getPartSize() );
+    return new S3CommonPipedOutputStream( this.fileSystem, newPath.getValue(), newPath.getKey(), partSize );
   }
 
   @Override

--- a/s3-vfs/src/main/java/org/pentaho/s3/vfs/S3FileSystem.java
+++ b/s3-vfs/src/main/java/org/pentaho/s3/vfs/S3FileSystem.java
@@ -17,71 +17,23 @@ import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.AbstractFileName;
-import org.pentaho.di.core.logging.LogChannel;
-import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.util.StorageUnitConverter;
-import org.pentaho.di.i18n.BaseMessages;
-import org.pentaho.s3common.S3CommonFileSystem;
 import org.pentaho.s3common.S3KettleProperty;
+import org.pentaho.s3common.S3CommonFileSystem;
 
 public class S3FileSystem extends S3CommonFileSystem {
 
-  private static final Class<?> PKG = S3FileSystem.class;
-  private static final LogChannelInterface consoleLog = new LogChannel( BaseMessages.getString( PKG, "TITLE.S3File" ) );
-
-  protected StorageUnitConverter storageUnitConverter;
-  protected S3KettleProperty s3KettleProperty;
-
-  /**
-   * Minimum part size specified in documentation
-   * see https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
-   */
-  private static final String MIN_PART_SIZE = "5MB";
-  /**
-   * Maximum part size specified in documentation
-   * see https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
-   */
-  private static final String MAX_PART_SIZE = "5GB";
-
   protected S3FileSystem( final FileName rootName, final FileSystemOptions fileSystemOptions ) {
-    this( rootName, fileSystemOptions, new StorageUnitConverter(), new S3KettleProperty() );
+    super( rootName, fileSystemOptions );
   }
 
   protected S3FileSystem( final FileName rootName, final FileSystemOptions fileSystemOptions,
                           final StorageUnitConverter storageUnitConverter, final S3KettleProperty s3KettleProperty ) {
-    super( rootName, fileSystemOptions );
-    this.storageUnitConverter = storageUnitConverter;
-    this.s3KettleProperty = s3KettleProperty;
+    super( rootName, fileSystemOptions, storageUnitConverter, s3KettleProperty );
   }
 
-  protected FileObject createFile( AbstractFileName name ) throws Exception {
+  protected FileObject createFile( AbstractFileName name ) {
     return new S3FileObject( name, this );
   }
 
-  public int getPartSize() {
-    long parsedPartSize = parsePartSize( s3KettleProperty.getPartSize() );
-    return convertToInt( parsedPartSize );
-  }
-
-  protected long parsePartSize( String partSizeString ) {
-    long parsePartSize = convertToLong( partSizeString );
-    if ( parsePartSize < convertToLong( MIN_PART_SIZE ) ) {
-      consoleLog.logBasic( BaseMessages.getString( PKG, "WARN.S3MultiPart.DefaultPartSize", partSizeString, MIN_PART_SIZE ) );
-      parsePartSize = convertToLong( MIN_PART_SIZE );
-    }
-
-    // still allow > 5GB, api might be updated in the future
-    if ( parsePartSize > convertToLong( MAX_PART_SIZE ) ) {
-      consoleLog.logBasic( BaseMessages.getString( PKG, "WARN.S3MultiPart.MaximumPartSize", partSizeString, MAX_PART_SIZE ) );
-    }
-    return parsePartSize;
-  }
-
-  protected int convertToInt( long parsedPartSize ) {
-    return (int) Long.min( Integer.MAX_VALUE, parsedPartSize );
-  }
-
-  protected long convertToLong( String partSize ) {
-    return storageUnitConverter.displaySizeToByteCount( partSize );
-  }
 }

--- a/s3-vfs/src/main/java/org/pentaho/s3common/S3CommonFileObject.java
+++ b/s3-vfs/src/main/java/org/pentaho/s3common/S3CommonFileObject.java
@@ -13,6 +13,25 @@
 
 package org.pentaho.s3common;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSelector;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileObject;
+import org.pentaho.di.connections.vfs.provider.ConnectionFileObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
@@ -23,20 +42,6 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.FileType;
-import org.apache.commons.vfs2.provider.AbstractFileName;
-import org.apache.commons.vfs2.provider.AbstractFileObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class S3CommonFileObject extends AbstractFileObject<S3CommonFileSystem> {
 
@@ -81,10 +86,10 @@ public abstract class S3CommonFileObject extends AbstractFileObject<S3CommonFile
         }
 
         if ( !exists() ) {
-          OutputStream outputStream = getOutputStream();
-          //Force to write an empty array to force file creation on S3 bucket
-          outputStream.write( new byte[] {} );
-          outputStream.close();
+          try ( OutputStream outputStream = getOutputStream() ) {
+            //Force to write an empty array to force file creation on S3 bucket
+            outputStream.write( new byte[] {} );
+          }
           endOutput();
         }
       } catch ( final RuntimeException re ) {
@@ -340,7 +345,58 @@ public abstract class S3CommonFileObject extends AbstractFileObject<S3CommonFile
 
   @Override
   protected OutputStream doGetOutputStream( boolean bAppend ) throws Exception {
-    return new S3CommonPipedOutputStream( this.fileSystem, bucketName, key );
+    int partSize = (int) Long.min( Integer.MAX_VALUE, this.fileSystem.getPartSize() );
+    return new S3CommonPipedOutputStream( this.fileSystem, bucketName, key, partSize );
+  }
+
+  /**
+   * Attempts to extract an S3FileObject from a FileObject, including wrappers like ResolvedConnectionFileObject (via reflection for getResolvedFileObject()).
+   */
+  private S3CommonFileObject extractDelegateS3FileObject( FileObject file ) {
+    if ( file instanceof S3CommonFileObject ) {
+      return (S3CommonFileObject) file;
+    }
+    if ( file instanceof ConnectionFileObject ) {
+      // If it's a ResolvedConnectionFileObject, we can try to get the underlying S3FileObject
+      ConnectionFileObject resolved = (ConnectionFileObject) file;
+      FileObject delegate = resolved.getResolvedFileObject();
+      if ( delegate instanceof S3CommonFileObject ) {
+        return (S3CommonFileObject) delegate;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Copies the content of the specified file to this file, using server-side multipart copy if both files are S3FileObjects in the same region.
+   * If the source is not an S3FileObject or is in a different region, it uses TransferManager to upload the content.
+   *
+   * @param file     The source file to copy from.
+   * @param selector A FileSelector to filter which files to copy.
+   * @throws FileSystemException If an error occurs during the copy operation.
+   */
+  @Override
+  public void copyFrom( final FileObject file, final FileSelector selector ) throws FileSystemException {
+    S3CommonFileObject s3Src = extractDelegateS3FileObject( file );
+    if ( s3Src != null ) {
+      // S3 to S3 copy
+      try {
+        logger.info( "Attempting S3->S3 server-side multipart copy from {} to {}",
+                     s3Src.getQualifiedName(), this.getQualifiedName() );
+        fileSystem.copy( s3Src, this );
+        return;
+      } catch ( FileSystemException e ) {
+        logger.warn( "S3->S3 multipart copy failed, falling back to TransferManager upload: {}", e.getMessage(), e );
+        // fallback to TransferManager upload below
+      }
+    }
+    // For non-S3FileObject or fallback, use TransferManager upload
+    try {
+      logger.info( "Uploading to S3 using TransferManager from {} to {}", file.getName(), this.getName() );
+      fileSystem.upload( file, this );
+    } catch ( Exception e ) {
+      logger.error( "TransferManager upload failed, falling back to default copy: {}", e.getMessage(), e );
+    }
   }
 
   @Override
@@ -418,4 +474,5 @@ public abstract class S3CommonFileObject extends AbstractFileObject<S3CommonFile
   protected String getQualifiedName( S3CommonFileObject s3nFileObject ) {
     return s3nFileObject.bucketName + "/" + s3nFileObject.key;
   }
+
 }

--- a/s3-vfs/src/main/java/org/pentaho/s3common/S3KettleProperty.java
+++ b/s3-vfs/src/main/java/org/pentaho/s3common/S3KettleProperty.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 public class S3KettleProperty {
   private static final Class<?> PKG = S3KettleProperty.class;
   private static final Logger logger = LoggerFactory.getLogger( S3KettleProperty.class );
+
   public static final String S3VFS_PART_SIZE = "s3.vfs.partSize";
 
   public String getPartSize() {
@@ -42,7 +43,7 @@ public class S3KettleProperty {
       properties = EnvUtil.readProperties( filename );
       partSizeString = properties.getProperty( property );
     } catch ( KettleException ke ) {
-      logger.error( BaseMessages.getString( PKG, "WARN.S3Commmon.PropertyNotFound",
+      logger.error( BaseMessages.getString( PKG, "WARN.S3Common.PropertyNotFound",
         property, filename ) );
     }
     return partSizeString;

--- a/s3-vfs/src/main/java/org/pentaho/s3common/S3TransferManager.java
+++ b/s3-vfs/src/main/java/org/pentaho/s3common/S3TransferManager.java
@@ -1,0 +1,126 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.transfer.Copy;
+
+public class S3TransferManager {
+
+  private static final Class<?> PKG = S3TransferManager.class;
+  private static final Logger logger = LoggerFactory.getLogger( PKG );
+
+  private final TransferManager transferManager;
+
+  public S3TransferManager( TransferManager transferManager ) {
+    this.transferManager = transferManager;
+  }
+
+  public TransferManager getTransferManager() {
+    return transferManager;
+  }
+
+  /**
+   * Perform S3->S3 multipart copy with a custom thread pool size.
+   *
+   * @param src           Source S3FileObject
+   * @param dst           Destination S3FileObject
+   * @param logger        Logger for logging
+   * @throws FileSystemException if copy fails
+   */
+  public void copy( S3CommonFileObject src, S3CommonFileObject dst ) throws FileSystemException {
+    if ( src == null || dst == null
+      || src.bucketName == null || src.key == null
+      || dst.bucketName == null || dst.key == null ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.null-argument",
+        src != null ? src.getQualifiedName() : "null",
+        dst != null ? dst.getQualifiedName() : "null" );
+    }
+    try {
+      testConnection( src, dst );
+      Copy copy = getTransferManager().copy(
+        src.bucketName, src.key,
+        dst.bucketName, dst.key
+      );
+      copy.waitForCompletion();
+      logger.info( "S3->S3 server-side copy succeeded: {} -> {}",
+                   src.getQualifiedName(), dst.getQualifiedName() );
+    } catch ( InterruptedException ie ) {
+      Thread.currentThread().interrupt();
+      throw new FileSystemException( "vfs.provider.s3/transfer.interrupted",
+                                     src.getQualifiedName(), dst.getQualifiedName(), ie );
+    } catch ( AmazonClientException e ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.error",
+                                     src.getQualifiedName(), dst.getQualifiedName(), e );
+    }
+  }
+
+  /**
+   * Checks if the S3 client has read access to the source object and write access to the destination bucket.
+   * Throws FileSystemException if access is denied.
+   */
+  private void testConnection( S3CommonFileObject src, S3CommonFileObject dst ) throws FileSystemException {
+    // Check read access to source object
+    try {
+      getTransferManager().getAmazonS3Client().getObjectMetadata( src.bucketName, src.key );
+      logger.debug( "Read access to source object: {}", src.getQualifiedName() );
+    } catch ( AmazonClientException e ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.no-read-access", src.getQualifiedName(), e );
+    }
+
+    // Check write access to destination bucket (try to put a zero-byte object and delete it)
+    String testKey = dst.key + ".acltest-" + System.currentTimeMillis();
+    try {
+      getTransferManager().getAmazonS3Client().putObject( dst.bucketName, testKey, "" );
+      getTransferManager().getAmazonS3Client().deleteObject( dst.bucketName, testKey );
+      logger.debug( "Write access to destination bucket: {}", dst.bucketName );
+    } catch ( AmazonClientException e ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.no-write-access", dst.bucketName, e );
+    }
+  }
+
+  public void upload( FileObject src, S3CommonFileObject dst ) throws FileSystemException {
+    if ( src == null || dst == null
+      || dst.bucketName == null || dst.key == null ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.null-argument",
+        src != null ? src.getName().getURI() : "null",
+        dst != null ? dst.getQualifiedName() : "null" );
+    }
+    try ( InputStream in = src.getContent().getInputStream() ) {
+      String bucket = dst.bucketName;
+      String key = dst.key;
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setContentLength( src.getContent().getSize() );
+      TransferManager tm = getTransferManager();
+      tm.upload( bucket, key, in, metadata ).waitForUploadResult();
+    } catch ( InterruptedException e ) {
+      Thread.currentThread().interrupt();
+      throw new FileSystemException( "vfs.provider.s3/transfer.interrupted", e );
+    } catch ( AmazonClientException e ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.error", e );
+    } catch ( IOException e ) {
+      throw new FileSystemException( "vfs.provider.s3/transfer.close-error", e );
+    }
+  }
+}

--- a/s3-vfs/src/main/resources/org/pentaho/s3common/messages/messages.properties
+++ b/s3-vfs/src/main/resources/org/pentaho/s3common/messages/messages.properties
@@ -1,8 +1,4 @@
-WARN.S3Commmon.PropertyNotFound=Property '{0}' could be be read from kettle property '{1}'
-INFO.S3MultiPart.Start=s3 multipart staring ...
-INFO.S3MultiPart.Upload=s3 multipart upload [ partnumber: {0}, fileOffset: {1}, partsize: {2} ]
-INFO.S3MultiPart.Complete=s3 multipart complete
-ERROR.S3MultiPart.Aborted=s3 multipart aborted
-ERROR.S3MultiPart.ExceptionCaught=s3 multipart exception caught
-ERROR.S3MultiPart.UploadOutOfMemory=Out of Memory error caught for s3 multipartUpload. Choose a partSize {0} or less
 TITLE.S3File=S3 File
+WARN.S3Common.PropertyNotFound=Property '{0}' could be read from kettle property '{1}'
+WARN.S3MultiPart.DefaultPartSize=Invalid part size '{0}', using minimum allowed {1}
+WARN.S3MultiPart.MaximumPartSize=Part size '{0}' exceeds maximum allowed {1}

--- a/s3-vfs/src/test/java/org/pentaho/amazon/s3/S3FileOutputMetaProcessFilenameTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/amazon/s3/S3FileOutputMetaProcessFilenameTest.java
@@ -14,9 +14,6 @@
 package org.pentaho.amazon.s3;
 
 import org.junit.Before;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public class S3FileOutputMetaProcessFilenameTest {
 

--- a/s3-vfs/src/test/java/org/pentaho/amazon/s3/S3FileOutputMetaTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/amazon/s3/S3FileOutputMetaTest.java
@@ -18,8 +18,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.pentaho.di.core.KettleEnvironment;
 import org.pentaho.di.core.database.DatabaseMeta;
-
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleXMLException;
 import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.s3common.TestCleanupUtil;
 
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.Document;
@@ -30,17 +32,18 @@ public class S3FileOutputMetaTest {
   S3FileOutputMeta meta = new S3FileOutputMeta();
 
   @BeforeClass
-  public static void setClassUp() throws Exception {
+  public static void setClassUp() throws KettleException {
     KettleEnvironment.init();
   }
 
   @AfterClass
-  public static void tearDownClass() throws Exception {
+  public static void tearDownClass() {
     KettleEnvironment.shutdown();
+    TestCleanupUtil.cleanUpLogsDir();
   }
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() throws KettleXMLException {
     Document doc = XMLHandler.loadXMLFile( "./src/test/resources/s3OutputMetaTest.ktr" );
     meta.loadXML( doc.getFirstChild(), Collections.<DatabaseMeta>emptyList(), (IMetaStore) null );
   }

--- a/s3-vfs/src/test/java/org/pentaho/amazon/s3/S3FileOutputTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/amazon/s3/S3FileOutputTest.java
@@ -20,16 +20,17 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.KettleEnvironment;
+import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.logging.LoggingObjectInterface;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
 import org.pentaho.di.trans.steps.textfileoutput.TextFileOutputData;
+import org.pentaho.s3common.TestCleanupUtil;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.never;
 
 public class S3FileOutputTest {
@@ -39,13 +40,14 @@ public class S3FileOutputTest {
   private S3FileOutputMeta smi;
 
   @BeforeClass
-  public static void setClassUp() throws Exception {
+  public static void setClassUp() throws KettleException {
     KettleEnvironment.init();
   }
 
   @AfterClass
   public static void tearDownClass() {
     KettleEnvironment.shutdown();
+    TestCleanupUtil.cleanUpLogsDir();
   }
 
   @Before
@@ -57,7 +59,7 @@ public class S3FileOutputTest {
       stepMockHelper.logChannelInterface );
     verify( stepMockHelper.logChannelInterface, never() ).logError( anyString() );
     verify( stepMockHelper.logChannelInterface, never() ).logError( anyString(), any( Object[].class ) );
-    verify( stepMockHelper.logChannelInterface, never() ).logError( anyString(), (Throwable) anyObject() );
+    verify( stepMockHelper.logChannelInterface, never() ).logError( anyString(), any( Throwable.class ) );
     when( stepMockHelper.trans.isRunning() ).thenReturn( true );
     verify( stepMockHelper.trans, never() ).stopAll();
 

--- a/s3-vfs/src/test/java/org/pentaho/s3/vfs/S3FileProviderTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3/vfs/S3FileProviderTest.java
@@ -10,16 +10,16 @@
  * Change Date: 2028-08-13
  ******************************************************************************/
 
+
 package org.pentaho.s3.vfs;
 
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.FileType;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-
 
 /**
  * Unit tests for S3FileProvider
@@ -29,13 +29,13 @@ public class S3FileProviderTest {
   S3FileProvider provider;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     provider = new S3FileProvider();
   }
 
   @Test
-  public void testDoCreateFileSystem() throws Exception {
-    FileName fileName = mock( FileName.class );
+  public void testDoCreateFileSystem() {
+    FileName fileName = new S3FileName( "s3", "bucket", "/bucket/key", FileType.FOLDER );
     FileSystemOptions options = new FileSystemOptions();
     assertNotNull( provider.doCreateFileSystem( fileName, options ) );
   }

--- a/s3-vfs/src/test/java/org/pentaho/s3/vfs/S3FileSystemTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3/vfs/S3FileSystemTest.java
@@ -14,11 +14,11 @@ package org.pentaho.s3.vfs;
 
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
-import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.UserAuthenticator;
 import org.apache.commons.vfs2.impl.DefaultFileSystemConfigBuilder;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,15 +27,12 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.util.StorageUnitConverter;
-import org.pentaho.s3common.S3CommonFileSystemTestUtil;
-import org.pentaho.s3common.S3KettleProperty;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.s3common.TestCleanupUtil;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 
 /**
  * Unit tests for S3FileSystem
@@ -47,12 +44,18 @@ public class S3FileSystemTest {
   S3FileName fileName;
 
   @BeforeClass
-  public static void initKettle() throws Exception {
+  public static void setClassUp() throws KettleException {
     KettleEnvironment.init( false );
   }
 
+  @AfterClass
+  public static void tearDownClass() {
+    KettleEnvironment.shutdown();
+    TestCleanupUtil.cleanUpLogsDir();
+  }
+
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     fileName = new S3FileName(
       S3FileNameTest.SCHEME,
       "/",
@@ -62,12 +65,12 @@ public class S3FileSystemTest {
   }
 
   @Test
-  public void testCreateFile() throws Exception {
+  public void testCreateFile() {
     assertNotNull( fileSystem.createFile( new S3FileName( "s3", "bucketName", "/bucketName/key", FileType.FILE ) ) );
   }
 
   @Test
-  public void testGetS3Service() throws Exception {
+  public void testGetS3Service() {
     assertNotNull( fileSystem.getS3Client() );
 
     FileSystemOptions options = new FileSystemOptions();
@@ -78,77 +81,9 @@ public class S3FileSystemTest {
     assertNotNull( fileSystem.getS3Client() );
   }
 
-  @Test
-  public void getPartSize() {
-
-    S3FileSystem s3FileSystem = getTestInstance();
-    s3FileSystem.storageUnitConverter = new StorageUnitConverter();
-    S3KettleProperty s3KettleProperty = mock( S3KettleProperty.class );
-    when( s3KettleProperty.getPartSize() ).thenReturn( "6MB" );
-    s3FileSystem.s3KettleProperty = s3KettleProperty;
-
-
-    //TEST 1: Below max
-    assertEquals( 6 * 1024 * 1024, s3FileSystem.getPartSize() );
-
-    // TEst 2: above max
-    when( s3KettleProperty.getPartSize() ).thenReturn( "600GB" );
-    assertEquals( Integer.MAX_VALUE, s3FileSystem.getPartSize() );
-
-  }
-
-  @Test
-  public void testParsePartSize() {
-    S3FileSystem s3FileSystem = getTestInstance();
-    s3FileSystem.storageUnitConverter = new StorageUnitConverter();
-    long _5MBLong = 5L * 1024L * 1024L;
-    long _124MBLong = 124L * 1024L * 1024L;
-    long _5GBLong = 5L * 1024L * 1024L * 1024L;
-    long _12GBLong = 12L * 1024L * 1024L * 1024L;
-    long minimumPartSize = _5MBLong;
-    long maximumPartSize = _5GBLong;
-
-
-    // TEST 1: below minimum
-    assertEquals( minimumPartSize, s3FileSystem.parsePartSize( "1MB" ) );
-
-    // TEST 2: at minimum
-    assertEquals( minimumPartSize, s3FileSystem.parsePartSize( "5MB" ) );
-
-    // TEST 3: between minimum and maximum
-    assertEquals( _124MBLong, s3FileSystem.parsePartSize( "124MB" ) );
-
-    // TEST 4: at maximum
-    assertEquals( maximumPartSize, s3FileSystem.parsePartSize( "5GB" ) );
-
-    // TEST 5: above maximum
-    assertEquals( _12GBLong, s3FileSystem.parsePartSize( "12GB" ) );
-  }
-
-  @Test
-  public void testConvertToInt() {
-    S3FileSystem s3FileSystem = getTestInstance();
-
-    // TEST 1: below int max
-    assertEquals( 10, s3FileSystem.convertToInt( 10L ) );
-
-    // TEST 2: at int max
-    assertEquals( Integer.MAX_VALUE, s3FileSystem.convertToInt( Integer.MAX_VALUE ) );
-
-    // TEST 3: above int max
-    assertEquals( Integer.MAX_VALUE, s3FileSystem.convertToInt( 5L * 1024L * 1024L * 1024L ) );
-  }
-
-  @Test
-  public void testConvertToLong() {
-    S3FileSystem s3FileSystem = getTestInstance();
-    long _10MBLong = 10L * 1024L * 1024L;
-    s3FileSystem.storageUnitConverter = new StorageUnitConverter();
-    assertEquals( _10MBLong, s3FileSystem.convertToLong( "10MB" ) );
-  }
-
   public S3FileSystem getTestInstance() {
-    FileName rootName = mock( FileName.class );
+    // Use a real S3FileName with dummy but non-null values to avoid NPE in S3Util.getKeysFromURI
+    S3FileName rootName = new S3FileName( "s3", "bucket", "/bucket/key", FileType.FOLDER );
     FileSystemOptions fileSystemOptions = new FileSystemOptions();
     return new S3FileSystem( rootName, fileSystemOptions );
   }
@@ -161,11 +96,11 @@ public class S3FileSystemTest {
       //Not under an EC2 instance - getCurrentRegion returns null
 
       fileSystem = new S3FileSystem( fileName, options );
-      fileSystem = ( S3FileSystem ) S3CommonFileSystemTestUtil.stubRegionUnSet( fileSystem );
 
       AmazonS3Client s3Client = (AmazonS3Client) fileSystem.getS3Client();
       assertEquals( "No Region was configured - client must have default region",
         Regions.DEFAULT_REGION.getName(), s3Client.getRegionName() );
     }
   }
+
 }

--- a/s3-vfs/src/test/java/org/pentaho/s3common/DummyS3CommonObjects.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/DummyS3CommonObjects.java
@@ -1,0 +1,79 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.pentaho.di.core.util.StorageUnitConverter;
+
+public class DummyS3CommonObjects {
+
+  protected static class DummyS3FileName extends AbstractFileName {
+
+    private final String bucketId;
+
+    protected DummyS3FileName( String scheme, String bucketId, String path, FileType type ) {
+      super( scheme, path, type );
+      this.bucketId = bucketId;
+    }
+
+    @Override
+    protected void appendRootUri( StringBuilder buffer, boolean addPassword ) {
+      buffer.append( getScheme() ).append( "://" ).append( bucketId ).append( "/" );
+    }
+
+    @Override
+    public String getURI() {
+      return getScheme() + "://" + bucketId + "/" + getPath();
+    }
+
+    @Override
+    public FileName createName( String absPath, FileType type ) {
+      return new DummyS3FileName( getScheme(), bucketId, absPath, type );
+    }
+  }
+
+  protected static class DummyS3FileObject extends S3CommonFileObject {
+    protected DummyS3FileObject( final DummyS3FileName name, final S3CommonFileSystem fileSystem ) {
+      super( name, fileSystem );
+    }
+  }
+
+  protected static class DummyS3FileSystem extends S3CommonFileSystem {
+
+    protected DummyS3FileSystem( final FileName rootName, final FileSystemOptions fileSystemOptions ) {
+      super( rootName, fileSystemOptions );
+    }
+
+    protected DummyS3FileSystem( final FileName rootName, final FileSystemOptions fileSystemOptions,
+                                 final StorageUnitConverter storageUnitConverter, final S3KettleProperty s3KettleProperty ) {
+      super( rootName, fileSystemOptions, storageUnitConverter, s3KettleProperty );
+    }
+
+    @Override
+    protected DummyS3FileObject createFile( AbstractFileName name ) {
+      return new DummyS3FileObject( (DummyS3FileName) name, this );
+    }
+  }
+
+  protected static DummyS3FileSystem getDummyInstance() {
+    // Use a real S3FileName with dummy but non-null values to avoid NPE in S3Util.getKeysFromURI
+    DummyS3FileName rootName = new DummyS3FileName( "s3", "bucket", "/bucket/key", FileType.FOLDER );
+    FileSystemOptions fileSystemOptions = new FileSystemOptions();
+    return new DummyS3FileSystem( rootName, fileSystemOptions );
+  }
+
+}

--- a/s3-vfs/src/test/java/org/pentaho/s3common/S3CommonFileSystemTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/S3CommonFileSystemTest.java
@@ -1,0 +1,108 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.util.StorageUnitConverter;
+import org.pentaho.s3common.DummyS3CommonObjects.DummyS3FileObject;
+import org.pentaho.s3common.DummyS3CommonObjects.DummyS3FileSystem;
+
+import com.amazonaws.services.s3.transfer.TransferManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.pentaho.s3common.DummyS3CommonObjects.getDummyInstance;
+
+public class S3CommonFileSystemTest {
+
+  @Test
+  public void getPartSize() {
+    DummyS3FileSystem s3FileSystem = getDummyInstance();
+    s3FileSystem.storageUnitConverter = new StorageUnitConverter();
+    S3KettleProperty s3KettleProperty = mock( S3KettleProperty.class );
+    when( s3KettleProperty.getPartSize() ).thenReturn( "6MB" );
+    s3FileSystem.s3KettleProperty = s3KettleProperty;
+
+    //TEST 1: Below max
+    assertEquals( 6 * 1024 * 1024, s3FileSystem.getPartSize() );
+
+    // TEst 2: above max
+    when( s3KettleProperty.getPartSize() ).thenReturn( "600GB" );
+    assertEquals( 600L * 1024 * 1024 * 1024, s3FileSystem.getPartSize() );
+  }
+
+  @Test
+  public void testParsePartSize() {
+    DummyS3FileSystem s3FileSystem = getDummyInstance();
+    s3FileSystem.storageUnitConverter = new StorageUnitConverter();
+    long _5MBLong = 5L * 1024L * 1024L;
+    long _124MBLong = 124L * 1024L * 1024L;
+    long _5GBLong = 5L * 1024L * 1024L * 1024L;
+    long _12GBLong = 12L * 1024L * 1024L * 1024L;
+    long minimumPartSize = _5MBLong;
+    long maximumPartSize = _5GBLong;
+
+
+    // TEST 1: below minimum
+    assertEquals( minimumPartSize, s3FileSystem.parsePartSize( "1MB" ) );
+
+    // TEST 2: at minimum
+    assertEquals( minimumPartSize, s3FileSystem.parsePartSize( "5MB" ) );
+
+    // TEST 3: between minimum and maximum
+    assertEquals( _124MBLong, s3FileSystem.parsePartSize( "124MB" ) );
+
+    // TEST 4: at maximum
+    assertEquals( maximumPartSize, s3FileSystem.parsePartSize( "5GB" ) );
+
+    // TEST 5: above maximum
+    assertEquals( _12GBLong, s3FileSystem.parsePartSize( "12GB" ) );
+  }
+
+  @Test
+  public void testCopy_DelegatesToTransferManager() throws Exception {
+    DummyS3FileObject src = mock( DummyS3FileObject.class );
+    DummyS3FileObject dest = mock( DummyS3FileObject.class );
+    S3TransferManager transferManager = mock( S3TransferManager.class );
+    DummyS3FileSystem fs = Mockito.spy( getDummyInstance() );
+    doReturn( transferManager ).when( fs ).getS3TransferManager();
+    fs.copy( src, dest );
+    verify( transferManager, times( 1 ) ).copy( src, dest );
+  }
+
+  @Test
+  public void testGetS3TransferManager_CreatesWithTransferManager() {
+    DummyS3FileSystem fs = Mockito.spy( getDummyInstance() );
+    S3TransferManager transferManager = mock( S3TransferManager.class );
+    doReturn( transferManager ).when( fs ).getS3TransferManager();
+    S3TransferManager result = fs.getS3TransferManager();
+    assertNotNull( result );
+  }
+
+  @Test
+  public void testBuildTransferManager_CreatesWithS3Client() {
+    DummyS3FileSystem fs = Mockito.spy( getDummyInstance() );
+    com.amazonaws.services.s3.AmazonS3 s3Client = mock( com.amazonaws.services.s3.AmazonS3.class );
+    doReturn( s3Client ).when( fs ).getS3Client();
+    TransferManager tm = fs.buildTransferManager();
+    assertNotNull( tm );
+  }
+
+}

--- a/s3-vfs/src/test/java/org/pentaho/s3common/S3CommonFileSystemTestUtil.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/S3CommonFileSystemTestUtil.java
@@ -21,7 +21,7 @@ public class S3CommonFileSystemTestUtil {
 
   public static S3CommonFileSystem stubRegionUnSet( S3CommonFileSystem fileSystem ) {
     S3CommonFileSystem fileSystemSpy = Mockito.spy( fileSystem );
-    doReturn(false).when(fileSystemSpy).isRegionSet();
+    doReturn( false ).when( fileSystemSpy ).isRegionSet();
     return fileSystemSpy;
   }
 }

--- a/s3-vfs/src/test/java/org/pentaho/s3common/S3KettlePropertyTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/S3KettlePropertyTest.java
@@ -1,0 +1,66 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.util.EnvUtil;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+public class S3KettlePropertyTest {
+
+  @Test
+  public void testGetPartSize() {
+    try ( MockedStatic<EnvUtil> envUtilMock = mockStatic( EnvUtil.class );
+           MockedStatic<Const> constMock = mockStatic( Const.class ) ) {
+      Properties props = new Properties();
+      props.setProperty( S3KettleProperty.S3VFS_PART_SIZE, "10MB" );
+      envUtilMock.when( () -> EnvUtil.readProperties( "kettle.properties" ) ).thenReturn( props );
+      constMock.when( Const::getKettlePropertiesFilename ).thenReturn( "kettle.properties" );
+      S3KettleProperty property = new S3KettleProperty();
+      assertEquals( "10MB", property.getPartSize() );
+    }
+  }
+
+  @Test
+  public void testGetProperty_MissingProperty() {
+    try ( MockedStatic<EnvUtil> envUtilMock = mockStatic( EnvUtil.class );
+           MockedStatic<Const> constMock = mockStatic( Const.class ) ) {
+      Properties props = new Properties();
+      envUtilMock.when( () -> EnvUtil.readProperties( "kettle.properties" ) ).thenReturn( props );
+      constMock.when( Const::getKettlePropertiesFilename ).thenReturn( "kettle.properties" );
+      S3KettleProperty property = new S3KettleProperty();
+      assertNull( property.getProperty( "not.a.real.property" ) );
+    }
+  }
+
+  @Test
+  public void testGetProperty_KettleException() {
+    try ( MockedStatic<EnvUtil> envUtilMock = mockStatic( EnvUtil.class );
+           MockedStatic<Const> constMock = mockStatic( Const.class ) ) {
+      envUtilMock.when( () -> EnvUtil.readProperties( "kettle.properties" ) ).thenThrow( new KettleException( "fail" ) );
+      constMock.when( Const::getKettlePropertiesFilename ).thenReturn( "kettle.properties" );
+      S3KettleProperty property = new S3KettleProperty();
+      // Should return empty string on exception
+      assertEquals( "", property.getProperty( "any.property" ) );
+    }
+  }
+}

--- a/s3-vfs/src/test/java/org/pentaho/s3common/S3TestFileObjectCopyFromTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/S3TestFileObjectCopyFromTest.java
@@ -1,0 +1,100 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSelector;
+import org.apache.commons.vfs2.FileSystemException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.util.StorageUnitConverter;
+import org.pentaho.s3common.DummyS3CommonObjects.DummyS3FileName;
+import org.pentaho.s3common.DummyS3CommonObjects.DummyS3FileObject;
+import org.pentaho.s3common.DummyS3CommonObjects.DummyS3FileSystem;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class S3TestFileObjectCopyFromTest {
+
+  private DummyS3FileObject dst;
+  private DummyS3FileObject src;
+  private FileSelector selector;
+  private DummyS3FileSystem fileSystem;
+
+  @Before
+  public void setUp() {
+    DummyS3FileName fileName = new DummyS3FileName( "s3", "bucket", "/bucket/key", org.apache.commons.vfs2.FileType.FILE );
+    S3KettleProperty kettleProperty = new S3KettleProperty();
+    StorageUnitConverter storageUnitConverter = new StorageUnitConverter();
+    DummyS3FileSystem realFileSystem = new DummyS3FileSystem( fileName, new org.apache.commons.vfs2.FileSystemOptions(), storageUnitConverter, kettleProperty );
+    fileSystem = Mockito.spy( realFileSystem );
+    dst = Mockito.spy( new DummyS3FileObject( fileName, fileSystem ) );
+    src = Mockito.spy( new DummyS3FileObject( fileName, fileSystem ) );
+    selector = mock( FileSelector.class );
+  }
+
+  @After
+  public void tearDown() {
+    dst = null;
+    src = null;
+    selector = null;
+    fileSystem = null;
+  }
+
+  @Test
+  public void testCopyFrom_S3ToS3_Success() throws FileSystemException {
+    // Arrange: dst.fileSystem.copy should succeed
+    doNothing().when( fileSystem ).copy( any( DummyS3FileObject.class ), any( DummyS3FileObject.class ) );
+    // Act
+    dst.copyFrom( src, selector );
+    // Assert: fileSystem.copy was called
+    verify( fileSystem, times( 1 ) ).copy( any( DummyS3FileObject.class ), any( DummyS3FileObject.class ) );
+  }
+
+  @Test
+  public void testCopyFrom_NonS3Source_FallbackToDefault() throws FileSystemException {
+    FileObject nonS3 = mock( FileObject.class );
+    when( nonS3.exists() ).thenReturn( true );
+    // Act
+    dst.copyFrom( nonS3, selector );
+    // Assert: fileSystem.copy was not called and fileSystem.upload was called
+    verify( fileSystem, times( 0 ) ).copy( any( DummyS3FileObject.class ), any( DummyS3FileObject.class ) );
+    verify( fileSystem, times( 1 ) ).upload( any( FileObject.class ), any( DummyS3FileObject.class ) );
+  }
+
+  @Test
+  public void testCopyFrom_S3ToS3_Exception_FallbackToDefault() throws FileSystemException {
+    // Arrange: fileSystem.copy(S3TestFileObject, S3TestFileObject) throws, should fallback to default
+    doThrow( new FileSystemException( "fail" ) ).when( fileSystem ).copy( any( DummyS3FileObject.class ), any( DummyS3FileObject.class ) );
+    FileSelector sel = mock( FileSelector.class );
+    doReturn( org.apache.commons.vfs2.FileType.FILE ).when( dst ).getType();
+    doReturn( org.apache.commons.vfs2.FileType.FILE ).when( src ).getType();
+    doReturn( true ).when( dst ).exists();
+    doReturn( true ).when( src ).exists();
+    dst.copyFrom( src, sel );
+    // Assert: fileSystem.copy was called once and fallback to fileSystem.upload was called
+    verify( fileSystem, times( 1 ) ).copy( any( DummyS3FileObject.class ), any( DummyS3FileObject.class ) );
+    verify( fileSystem, times( 1 ) ).upload( any( FileObject.class ), any( DummyS3FileObject.class ) );
+  }
+
+}

--- a/s3-vfs/src/test/java/org/pentaho/s3common/S3TransferManagerTest.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/S3TransferManagerTest.java
@@ -1,0 +1,247 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import java.io.InputStream;
+
+import org.apache.commons.vfs2.FileContent;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.s3.vfs.S3FileObject;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.services.s3.transfer.TransferManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class S3TransferManagerTest {
+
+  private TransferManager transferManager;
+  private S3TransferManager s3TransferManager;
+  private S3FileObject src;
+  private S3FileObject dst;
+
+  private static class TestS3FileObject extends S3FileObject {
+    public TestS3FileObject( String bucketName, String key ) {
+      super(
+        new org.pentaho.s3.vfs.S3FileName( "s3", bucketName, "/" + bucketName + "/" + key, org.apache.commons.vfs2.FileType.FILE ),
+        createFileSystemWithUseCount()
+      );
+      // Direct assignment since bucketName and key are no longer final or private
+      this.bucketName = bucketName;
+      this.key = key;
+    }
+    private static org.pentaho.s3.vfs.S3FileSystem createFileSystemWithUseCount() {
+      org.pentaho.s3.vfs.S3FileSystem fs = org.mockito.Mockito.mock( org.pentaho.s3.vfs.S3FileSystem.class, org.mockito.Mockito.CALLS_REAL_METHODS );
+      try {
+        java.lang.reflect.Field useCountField = org.apache.commons.vfs2.provider.AbstractFileSystem.class.getDeclaredField( "useCount" );
+        useCountField.setAccessible( true );
+        useCountField.set( fs, new java.util.concurrent.atomic.AtomicLong() );
+      } catch ( Exception e ) {
+        throw new RuntimeException( e );
+      }
+      return fs;
+    }
+    @Override
+    public String getQualifiedName() {
+      return "s3://" + getBucketName() + "/" + getKey();
+    }
+    public String getBucketName() {
+      try {
+        java.lang.reflect.Field bucketField = S3CommonFileObject.class.getDeclaredField( "bucketName" );
+        bucketField.setAccessible( true );
+        return (String) bucketField.get( this );
+      } catch ( Exception e ) {
+        throw new RuntimeException( e );
+      }
+    }
+    public String getKey() {
+      try {
+        java.lang.reflect.Field keyField = S3CommonFileObject.class.getDeclaredField( "key" );
+        keyField.setAccessible( true );
+        return (String) keyField.get( this );
+      } catch ( Exception e ) {
+        throw new RuntimeException( e );
+      }
+    }
+  }
+
+  @Before
+  public void setUp() {
+    transferManager = mock( TransferManager.class );
+    s3TransferManager = new S3TransferManager( transferManager );
+    src = new TestS3FileObject( "src-bucket", "src-key" );
+    dst = new TestS3FileObject( "dst-bucket", "dst-key" );
+  }
+
+  @After
+  public void tearDown() {
+    transferManager = null;
+    s3TransferManager = null;
+    src = null;
+    dst = null;
+  }
+
+  @Test
+  public void testGetTransferManager() {
+    assertEquals( transferManager, s3TransferManager.getTransferManager() );
+  }
+
+  @Test
+  public void testCopy_Success() throws FileSystemException, InterruptedException {
+    Copy copy = mock( Copy.class );
+    when( transferManager.copy( anyString(), anyString(), anyString(), anyString() ) ).thenReturn( copy );
+    doNothing().when( copy ).waitForCompletion();
+    // Mock testConnection: getAmazonS3Client().getObjectMetadata/putObject/deleteObject
+    var s3Client = mock( com.amazonaws.services.s3.AmazonS3.class );
+    when( transferManager.getAmazonS3Client() ).thenReturn( s3Client );
+    // No exception means access is fine
+    s3TransferManager.copy( src, dst );
+    verify( transferManager, times( 1 ) ).copy( "src-bucket", "src-key", "dst-bucket", "dst-key" );
+    verify( copy, times( 1 ) ).waitForCompletion();
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testCopy_NullArguments() throws FileSystemException {
+    s3TransferManager.copy( null, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testCopy_MissingBucketOrKey() throws FileSystemException, NoSuchFieldException, IllegalAccessException {
+    java.lang.reflect.Field bucketField = S3CommonFileObject.class.getDeclaredField( "bucketName" );
+    bucketField.setAccessible( true );
+    bucketField.set( src, null );
+    s3TransferManager.copy( src, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testCopy_ReadAccessDenied() throws FileSystemException {
+    var s3Client = mock( com.amazonaws.services.s3.AmazonS3.class );
+    when( transferManager.getAmazonS3Client() ).thenReturn( s3Client );
+    doThrow( new AmazonClientException( "no read" ) ).when( s3Client ).getObjectMetadata( anyString(), anyString() );
+    s3TransferManager.copy( src, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testCopy_WriteAccessDenied() throws FileSystemException {
+    var s3Client = mock( com.amazonaws.services.s3.AmazonS3.class );
+    when( transferManager.getAmazonS3Client() ).thenReturn( s3Client );
+    // Read access OK
+    // Write access denied
+    doThrow( new AmazonClientException( "no write" ) ).when( s3Client ).putObject( anyString(), contains( ".acltest-" ), anyString() );
+    s3TransferManager.copy( src, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testCopy_AmazonClientExceptionDuringCopy() throws FileSystemException, InterruptedException {
+    Copy copy = mock( Copy.class );
+    when( transferManager.copy( anyString(), anyString(), anyString(), anyString() ) ).thenReturn( copy );
+    doThrow( new AmazonClientException( "fail" ) ).when( copy ).waitForCompletion();
+    var s3Client = mock( com.amazonaws.services.s3.AmazonS3.class );
+    when( transferManager.getAmazonS3Client() ).thenReturn( s3Client );
+    s3TransferManager.copy( src, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testCopy_InterruptedException() throws FileSystemException, InterruptedException {
+    Copy copy = mock( Copy.class );
+    when( transferManager.copy( anyString(), anyString(), anyString(), anyString() ) ).thenReturn( copy );
+    doThrow( new InterruptedException( "interrupted" ) ).when( copy ).waitForCompletion();
+    var s3Client = mock( com.amazonaws.services.s3.AmazonS3.class );
+    when( transferManager.getAmazonS3Client() ).thenReturn( s3Client );
+    try {
+      s3TransferManager.copy( src, dst );
+    } finally {
+      // Clear the interrupted status so it doesn't affect other tests
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void testUpload_Success() throws Exception {
+    FileObject srcMock = mock( FileObject.class );
+    FileContent content = mock( FileContent.class );
+    InputStream inputStream = mock( InputStream.class );
+    when( srcMock.getContent() ).thenReturn( content );
+    when( content.getInputStream() ).thenReturn( inputStream );
+    when( content.getSize() ).thenReturn( 123L );
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength( 123L );
+    com.amazonaws.services.s3.transfer.Upload upload = mock( com.amazonaws.services.s3.transfer.Upload.class );
+    when( transferManager.upload( eq( "dst-bucket" ), eq( "dst-key" ), eq( inputStream ), any( ObjectMetadata.class ) ) ).thenReturn( upload );
+    s3TransferManager.upload( srcMock, dst );
+    verify( transferManager, times( 1 ) ).upload( eq( "dst-bucket" ), eq( "dst-key" ), eq( inputStream ), any( ObjectMetadata.class ) );
+    verify( upload, times( 1 ) ).waitForUploadResult();
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testUpload_NullArguments() throws Exception {
+    s3TransferManager.upload( null, null );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testUpload_FileSystemException() throws Exception {
+    FileObject srcMock = mock( FileObject.class );
+    FileContent content = mock( FileContent.class );
+    when( srcMock.getContent() ).thenReturn( content );
+    when( content.getInputStream() ).thenThrow( new FileSystemException( "Input stream error" ) );
+    s3TransferManager.upload( srcMock, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testUpload_AmazonClientException() throws Exception {
+    FileObject srcMock = mock( FileObject.class );
+    FileContent content = mock( FileContent.class );
+    InputStream inputStream = mock( InputStream.class );
+    when( srcMock.getContent() ).thenReturn( content );
+    when( content.getInputStream() ).thenReturn( inputStream );
+    when( content.getSize() ).thenReturn( 123L );
+    when( transferManager.upload( eq( "dst-bucket" ), eq( "dst-key" ), eq( inputStream ), any( ObjectMetadata.class ) ) )
+      .thenThrow( new AmazonClientException( "Amazon error" ) );
+    s3TransferManager.upload( srcMock, dst );
+  }
+
+  @Test( expected = FileSystemException.class )
+  public void testUpload_InterruptedException() throws Exception {
+    FileObject srcMock = mock( FileObject.class );
+    FileContent content = mock( FileContent.class );
+    InputStream inputStream = mock( InputStream.class );
+    when( srcMock.getContent() ).thenReturn( content );
+    when( content.getInputStream() ).thenReturn( inputStream );
+    when( content.getSize() ).thenReturn( 123L );
+    com.amazonaws.services.s3.transfer.Upload upload = mock( com.amazonaws.services.s3.transfer.Upload.class );
+    when( transferManager.upload( eq( "dst-bucket" ), eq( "dst-key" ), eq( inputStream ), any( ObjectMetadata.class ) ) ).thenReturn( upload );
+    doThrow( new InterruptedException( "interrupted" ) ).when( upload ).waitForUploadResult();
+    try {
+      s3TransferManager.upload( srcMock, dst );
+    } finally {
+      Thread.interrupted();
+    }
+  }
+}

--- a/s3-vfs/src/test/java/org/pentaho/s3common/TestCleanupUtil.java
+++ b/s3-vfs/src/test/java/org/pentaho/s3common/TestCleanupUtil.java
@@ -1,0 +1,33 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+
+package org.pentaho.s3common;
+
+import java.io.File;
+
+public class TestCleanupUtil {
+  private TestCleanupUtil() { }
+
+  public static void cleanUpLogsDir() {
+    File logsDir = new File( "logs" );
+    if ( logsDir.exists() && logsDir.isDirectory() ) {
+      File[] files = logsDir.listFiles();
+      if ( files != null ) {
+        for ( File f : files ) {
+          f.delete();
+        }
+      }
+      logsDir.delete();
+    }
+  }
+}


### PR DESCRIPTION
* perf[PDI-20370]: Enhance S3 file tranfer

* refactor: move copyFrom to S3CommonFileObject to be used by all implementations

* fix: reinstate doGetOutputStream impl, as it's still required for createFile

* fix: standardize S3 copy log messages to use '->' instead of '→'