### PR TITLE
chore[PPP-5719]: move saxon version to pentaho parent pom

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -407,12 +407,10 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>saxon</artifactId>
-      <version>9.1.0.8</version>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>saxon-dom</artifactId>
-      <version>9.1.0.8</version>
     </dependency>
     <dependency>
       <groupId>net.sf.scannotation</groupId>


### PR DESCRIPTION
@pentaho/tatooine_dev 