### PR TITLE
[BACKLOG-44786] - Update native spark steps (amqp, mqtt. meta inject,kafka) to reference libraries from the pdi plugin

### DIFF
--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputMeta.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputMeta.java
@@ -27,6 +27,7 @@ import org.pentaho.di.core.injection.InjectionDeep;
 import org.pentaho.di.core.injection.InjectionSupported;
 import org.pentaho.di.core.namedcluster.NamedClusterManager;
 import org.pentaho.di.core.namedcluster.model.NamedCluster;
+import org.pentaho.di.core.plugins.ParentFirst;
 import org.pentaho.di.core.row.RowMeta;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.row.ValueMetaInterface;
@@ -88,6 +89,7 @@ import static org.pentaho.metaverse.api.analyzer.kettle.step.ExternalResourceSte
 @Metaverse.EntityLink ( entity = KAFKA_SERVER_METAVERSE, link = LINK_PARENT_CONCEPT, parentEntity = NODE_TYPE_EXTERNAL_CONNECTION )
 @Metaverse.EntityLink ( entity = KAFKA_TOPIC_METAVERSE, link = LINK_CONTAINS_CONCEPT, parentEntity = KAFKA_SERVER_METAVERSE )
 @Metaverse.EntityLink ( entity = KAFKA_TOPIC_METAVERSE, link = LINK_PARENT_CONCEPT )
+@ParentFirst( patterns = { ".*" } )
 public class KafkaConsumerInputMeta extends BaseStreamStepMeta implements StepMetaInterface {
   public enum ConnectionType {
     DIRECT,


### PR DESCRIPTION
Related PR
https://github.com/pentaho/spark-execution/pull/35
https://github.com/pentaho/pentaho-kettle/pull/10058
https://github.com/pentaho/pdi-plugins-ee/pull/2098