### PR TITLE
[BACKLOG-44864] [Bigdata] PMR with S3 paths is failing using emr700 shim

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -210,6 +210,19 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho.hadoop.shims</groupId>
+      <artifactId>pentaho-hadoop-shims-emr770-pmr-libs</artifactId>
+      <version>${pentaho-hadoop-shims-emr770.version}</version>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.hadoop.shims</groupId>
       <artifactId>pentaho-hadoop-shims-dataproc1421-pmr-libs</artifactId>
       <version>${pentaho-hadoop-shims-dataproc1421.version}</version>
       <type>zip</type>
@@ -287,6 +300,12 @@
                 <artifactItem>
                   <groupId>org.pentaho.hadoop.shims</groupId>
                   <artifactId>pentaho-hadoop-shims-emr700-pmr-libs</artifactId>
+                  <type>zip</type>
+                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.pentaho.hadoop.shims</groupId>
+                  <artifactId>pentaho-hadoop-shims-emr770-pmr-libs</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/kettle-plugins/common/ui/src/main/resources/emr770sampleconfig.properties
+++ b/kettle-plugins/common/ui/src/main/resources/emr770sampleconfig.properties
@@ -1,0 +1,80 @@
+#
+#  HITACHI VANTARA PROPRIETARY AND CONFIDENTIAL
+#
+#  Copyright 2025 Hitachi Vantara. All rights reserved.
+#
+#  NOTICE: All information including source code contained herein is, and
+#  remains the sole property of Hitachi Vantara and its licensors. The intellectual
+#  and technical concepts contained herein are proprietary and confidential
+#  to, and are trade secrets of Hitachi Vantara and may be covered by U.S. and foreign
+#  patents, or patents in process, and are protected by trade secret and
+#  copyright laws. The receipt or possession of this source code and/or related
+#  information does not convey or imply any rights to reproduce, disclose or
+#  distribute its contents, or to manufacture, use, or sell anything that it
+#  may describe, in whole or in part. Any reproduction, modification, distribution,
+#  or public display of this information without the express written authorization
+#  from Hitachi Vantara is strictly prohibited and in violation of applicable laws and
+#  international treaties. Access to the source code contained herein is strictly
+#  prohibited to anyone except those individuals and entities who have executed
+#  confidentiality and non-disclosure agreements or other agreements with Hitachi Vantara,
+#  explicitly covering such access.
+#
+# ADDITIONAL RESOURCES
+# For additional questions please visit help.pentaho.com
+# Search for impersonation or secure impersonation
+#
+
+#
+#
+# THE NAME OF YOUR CONFIGURATION
+name=Amazon EMR 7.7
+#
+
+#
+#
+# GENERAL CONFIGURATIONS
+# These  are comma-separated lists of the following:
+#
+# Directories and/or file lists available for this configuration
+classpath=lib/avro-1.8.0.jar
+#
+# Native libraries
+library.path=
+#
+# Comma-separated list of classes or package names to explicitly ignore when
+# loading classes from the resources within this Hadoop configuration directory
+# or the classpath property
+# e.g.: org.apache.commons.log,org.apache.log4j
+# Note, the two packages above are automatically included for all configurations
+ignore.classes=com.ctc.wstx.stax
+#
+
+#
+#
+# SECURITY CONFIGURATIONS
+#
+# Kerberos Authentication
+pentaho.authentication.default.kerberos.principal=exampleUser@EXAMPLE.COM
+#
+# Please define one of the following:
+pentaho.authentication.default.kerberos.keytabLocation=
+pentaho.authentication.default.kerberos.password=
+#
+# Secure Impersonation
+# Please choose one of the following:
+#
+# disabled - when using an unsecured cluster
+# simple - when using a 1 to 1 mapping from the server to your cluster
+pentaho.authentication.default.mapping.impersonation.type=disabled
+pentaho.authentication.default.mapping.server.credentials.kerberos.principal=exampleUser@EXAMPLE.COM
+#
+# Please define one of the following:
+pentaho.authentication.default.mapping.server.credentials.kerberos.keytabLocation=
+pentaho.authentication.default.mapping.server.credentials.kerberos.password=
+#
+
+#
+#
+# OOZIE
+pentaho.oozie.proxy.user=oozie
+#

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <pentaho-hadoop-shims.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
     <pentaho-hadoop-shims-cdh514.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-cdh514.version>
     <pentaho-hadoop-shims-emr700.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-emr700.version>
+    <pentaho-hadoop-shims-emr770.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-emr770.version>
     <pentaho-hadoop-shims-dataproc1421.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-dataproc1421.version>
     <pentaho-hadoop-shims-cdpdc71.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-cdpdc71.version>
     <pentaho-hadoop-shims-hdi40.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-hdi40.version>


### PR DESCRIPTION
[https://hv-eng.atlassian.net/browse/BACKLOG-44864] impacting PMR functionality on EMR 700 clusters, specifically when interacting with S3 file locations. This issue stems from the EMR 700 cluster's use of Hadoop runtime 3.3.6.
    Recently, to address Protobuf-java vulnerability fixes and align with the latest Hadoop releases, we upgraded Hadoop to version 3.4.0. Consequently, when running PMR test cases with the current EMR 700 shim, we encounter this defect due to library compatibility issues. This is kind of a blocker for 10.2.0.4 release too as the changes are already backported to 10.2.0.4.

Proposed Solution:
     EMR versions 7.4.0 and newer have upgraded their Hadoop libraries to 3.4.0+.([Application versions in Amazon EMR 7.x releases - Amazon EMR](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-app-versions-7.x.html)). We successfully tested the affected PMR test case on an EMR 7.7.0 cluster, yielding positive results.
Therefore, fix can be as follows:
Creating an emr770 shim. 
Update our documentation to reflect EMR 7.7.0 as the latest supported version starting from 10.2.0.4