### PR TITLE
Revert "[BACKLOG-44864] Fix build failure caused due to versioning of pmr-libs"

### DIFF
--- a/assemblies/legacy-plugin/pom.xml
+++ b/assemblies/legacy-plugin/pom.xml
@@ -210,6 +210,19 @@
     </dependency>
     <dependency>
       <groupId>org.pentaho.hadoop.shims</groupId>
+      <artifactId>pentaho-hadoop-shims-emr770-pmr-libs</artifactId>
+      <version>${pentaho-hadoop-shims-emr770.version}</version>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.hadoop.shims</groupId>
       <artifactId>pentaho-hadoop-shims-dataproc1421-pmr-libs</artifactId>
       <version>${pentaho-hadoop-shims-dataproc1421.version}</version>
       <type>zip</type>
@@ -287,6 +300,12 @@
                 <artifactItem>
                   <groupId>org.pentaho.hadoop.shims</groupId>
                   <artifactId>pentaho-hadoop-shims-emr700-pmr-libs</artifactId>
+                  <type>zip</type>
+                  <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.pentaho.hadoop.shims</groupId>
+                  <artifactId>pentaho-hadoop-shims-emr770-pmr-libs</artifactId>
                   <type>zip</type>
                   <outputDirectory>${basedir}/target/plugins/pentaho-big-data-plugin/hadoop-configurations</outputDirectory>
                 </artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <pentaho-hadoop-shims.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims.version>
     <pentaho-hadoop-shims-cdh514.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-cdh514.version>
     <pentaho-hadoop-shims-emr700.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-emr700.version>
+    <pentaho-hadoop-shims-emr770.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-emr770.version>
     <pentaho-hadoop-shims-dataproc1421.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-dataproc1421.version>
     <pentaho-hadoop-shims-cdpdc71.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-cdpdc71.version>
     <pentaho-hadoop-shims-hdi40.version>11.0.0.0-SNAPSHOT</pentaho-hadoop-shims-hdi40.version>


### PR DESCRIPTION
Issue has been resolved by Devops without these changes and build got successful.