### PR TITLE
build[PDI-20311]: replace trilead-ssh2 with apache-sshd

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -894,9 +894,12 @@
       <version>1.0</version>
     </dependency>
     <dependency>
-      <groupId>trilead-ssh2</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>build213</version>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-sftp</artifactId>
     </dependency>
     <dependency>
       <groupId>woodstox</groupId>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -224,7 +224,8 @@
         <include>stax:stax</include>
         <include>stax:stax-api</include>
         <include>sun:jlfgr</include>
-        <include>trilead-ssh2:trilead-ssh2</include>
+        <include>org.apache.sshd:sshd-core</include>
+        <include>org.apache.sshd:sshd-sftp</include>
         <include>woodstox:wstx-asl</include>
         <include>wsdl4j:wsdl4j</include>
         <include>wsdl4j:wsdl4j-qname</include>


### PR DESCRIPTION
This pull request updates the SSH library dependencies in the `pmr-libraries` assembly, replacing the older `trilead-ssh2` library with the more modern `org.apache.sshd` libraries. The change affects both the Maven dependency configuration and the assembly descriptor to ensure consistent usage of the new libraries.

**Dependency updates:**

* Replaced the `trilead-ssh2` dependency with `org.apache.sshd:sshd-core` and added `org.apache.sshd:sshd-sftp` in `pom.xml` to update the SSH support libraries.

**Assembly configuration:**

* Updated `assembly.xml` to include the new `org.apache.sshd:sshd-core` and `org.apache.sshd:sshd-sftp` dependencies instead of `trilead-ssh2:trilead-ssh2`.