### PR TITLE
build[SP-7277]: update Bouncy Castle dependencies to use parent managed version

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -42,22 +42,18 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcmail-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15to18</artifactId>
-      <version>${bcprov-jdk15to18.version}</version>
     </dependency>
     <dependency>
       <groupId>bsf</groupId>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/big-data-plugin/pull/2969

## Changes
- Cherry-picked from https://github.com/pentaho/big-data-plugin/pull/2969
- Commit: abd061467a8365d66d35f446a6d64f5dc1159ab3

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
