### PR TITLE
build[SP-7224]: Bump version of validation-api dependency to 1.1.0.Final

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -338,7 +338,6 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
-      <version>1.0.0.GA</version>
     </dependency>
     <dependency>
       <groupId>javax.xml</groupId>


### PR DESCRIPTION
## Summary
- remove repo-local javax.validation:validation-api version ownership
- inherit javax.validation:validation-api 1.1.0.Final from pentaho-parent-pom on 10.2