### PR TITLE
PPP-6577: upgrade com.github.mwiede:jsch to 0.2.26

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -25,7 +25,7 @@
     <publish-sonar-phase>site</publish-sonar-phase>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <rxjava.version>2.2.3</rxjava.version>
-    <jsch.version>0.2.9</jsch.version>
+      <jsch.version>0.2.26</jsch.version>
     <encryption-support.version>11.1.0.0-SNAPSHOT</encryption-support.version>
     <pdi-osgi-bridge.version>11.1.0.0-SNAPSHOT</pdi-osgi-bridge.version>
     <osgi.core.version>8.0.0</osgi.core.version>


### PR DESCRIPTION
## Summary
- addresses PPP-6577
- upgrades com.github.mwiede:jsch from 0.2.9 to 0.2.26

## Context
JFrog Xray ticket PPP-6577 flags CVE-2023-48795 against com.github.mwiede:jsch:0.2.9 in pdia-master artifacts.

## Validation
- updated shared jsch.version property in the affected build