### PR TITLE
[PPP-6549] CVE fix: CVE-2016-3093 in ognl:ognl

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -444,9 +444,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <!-- [PPP-6549] CVE-2016-3093: was hardcoded 2.6.9; now references the
+           centralized fix in pentaho-ce-jar-parent-pom (inherited via this repo's
+           own parent chain). -->
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>2.6.9</version>
+      <version>${ognl.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## CVE fix: CVE-2016-3093 in ognl:ognl

Advisory: CVE-2016-3093 -- OGNL < 3.0.12 DoS (CWE-20), CVSS 5.3 MEDIUM. Fixed upstream in OGNL 3.0.12.

Change: `assemblies/pmr-libraries/pom.xml` -- replaces the hardcoded `<version>2.6.9</version>` on the `ognl:ognl` dependency with `<version>${ognl.version}</version>`, now resolving to the centralized fix (`3.0.21`) via this repo's own CE parent chain (see pentaho/maven-parent-poms#899).

This dependency is bundled into the shipped `pentaho-big-data-ee-plugin`/`big-data-plugin` assembly (a Pentaho MapReduce libraries bundle), not directly invoked by first-party code here.

### Proof
`mvn dependency:tree -Dincludes=ognl:ognl` on `assemblies/pmr-libraries` completes with BUILD SUCCESS resolving the new version.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.