### PR TITLE
CVE-2023-48795: inherit centralized jsch.version (0.2.26) from parent pom

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -25,7 +25,9 @@
     <publish-sonar-phase>site</publish-sonar-phase>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <rxjava.version>2.2.3</rxjava.version>
-    <!-- jsch.version is inherited from pentaho-parent-pom (centralized for CVE-2023-48795) -->
+    <!-- jsch.version is inherited via the parent POM chain (pentaho-big-data-assemblies
+         -> ... -> org.pentaho:pentaho-ce-jar-parent-pom -> org.pentaho:pentaho-parent-pom,
+         which defines it); centralized for CVE-2023-48795. Requires maven-parent-poms PR #902. -->
     <encryption-support.version>11.1.0.0-SNAPSHOT</encryption-support.version>
     <pdi-osgi-bridge.version>11.1.0.0-SNAPSHOT</pdi-osgi-bridge.version>
     <osgi.core.version>8.0.0</osgi.core.version>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -25,7 +25,7 @@
     <publish-sonar-phase>site</publish-sonar-phase>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <rxjava.version>2.2.3</rxjava.version>
-    <jsch.version>0.2.9</jsch.version>
+    <!-- jsch.version is inherited from pentaho-parent-pom (centralized for CVE-2023-48795) -->
     <encryption-support.version>11.1.0.0-SNAPSHOT</encryption-support.version>
     <pdi-osgi-bridge.version>11.1.0.0-SNAPSHOT</pdi-osgi-bridge.version>
     <osgi.core.version>8.0.0</osgi.core.version>

--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -25,9 +25,6 @@
     <publish-sonar-phase>site</publish-sonar-phase>
     <blueprints-core.version>2.6.0</blueprints-core.version>
     <rxjava.version>2.2.3</rxjava.version>
-    <!-- jsch.version is inherited via the parent POM chain (pentaho-big-data-assemblies
-         -> ... -> org.pentaho:pentaho-ce-jar-parent-pom -> org.pentaho:pentaho-parent-pom,
-         which defines it); centralized for CVE-2023-48795. Requires maven-parent-poms PR #902. -->
     <encryption-support.version>11.1.0.0-SNAPSHOT</encryption-support.version>
     <pdi-osgi-bridge.version>11.1.0.0-SNAPSHOT</pdi-osgi-bridge.version>
     <osgi.core.version>8.0.0</osgi.core.version>


### PR DESCRIPTION
## CVE fix: CVE-2023-48795 (Terrapin) in com.github.mwiede:jsch

Tracking: https://hv-eng.atlassian.net/browse/PPP-6577
Advisory: CVE-2023-48795 -- Medium (CVSS 5.9), SSH prefix-truncation (Terrapin)
Change: remove the local `jsch.version` override in `assemblies/pmr-libraries/pom.xml` so `com.github.mwiede:jsch` resolves to the centralized `0.2.26` pin (fixed >= 0.2.15).

### ⚠ Blocked by pentaho/maven-parent-poms#902
Inherits the `jsch.version` property added in maven-parent-poms#902. **Do not merge until #902 is merged and its `11.1.0.0-SNAPSHOT` parent is deployed**, or CI here cannot resolve `${jsch.version}`.

### Dependency tree (before -> after)
`assemblies/pmr-libraries` resolved `com.github.mwiede:jsch:jar:0.2.9` -> now `com.github.mwiede:jsch:jar:0.2.26:compile` (0.2.9 absent). The `pmr-libraries` assembly bundles only `com.github.mwiede:jsch` (verified in `assembly.xml` include list); no other jsch coordinate ships.

### Tests
Assembly/packaging module (no unit tests). Change is a version-property inheritance only; jsch resolves cleanly to 0.2.26. The prod code that uses jsch lives in pentaho-kettle, whose SFTP suite is green on 0.2.26.

### Review
Fixed and reviewed locally via codemedic-local-remediator before push.
