### PR TITLE
[PPP-6399] remove unused jetty-continuation (CVE-2026-2332)

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -956,11 +956,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-      <version>${jetty-hadoop.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-io</artifactId>
       <version>${jetty-hadoop.version}</version>
     </dependency>

--- a/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
+++ b/assemblies/pmr-libraries/src/main/descriptors/assembly.xml
@@ -143,7 +143,6 @@
         <include>org.drools:drools-compiler</include>
         <include>org.drools:drools-core</include>
         <include>org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64</include>
-        <include>org.eclipse.jetty:jetty-continuation</include>
         <include>org.eclipse.jetty:jetty-http</include>
         <include>org.eclipse.jetty:jetty-io</include>
         <include>org.eclipse.jetty:jetty-plus</include>


### PR DESCRIPTION
This pull request removes the `jetty-continuation` dependency from the `pmr-libraries` assembly. This change ensures that the assembly no longer includes an unnecessary or obsolete Jetty module.

Dependency cleanup:

* Removed the `org.eclipse.jetty:jetty-continuation` dependency from the `assemblies/pmr-libraries/pom.xml` file.
* Removed the inclusion of `org.eclipse.jetty:jetty-continuation` from the assembly descriptor in `assemblies/pmr-libraries/src/main/descriptors/assembly.xml`.