### PR TITLE
fix(SP-7427): add missing aws-java-sdk-iam dependency (PDI-20270)

### DIFF
--- a/assemblies/s3-vfs/pom.xml
+++ b/assemblies/s3-vfs/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>pentaho-s3-vfs</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-iam</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/assemblies/s3-vfs/src/main/assembly/descriptors/s3-vfs.xml
+++ b/assemblies/s3-vfs/src/main/assembly/descriptors/s3-vfs.xml
@@ -22,6 +22,7 @@
             <includes>
                 <include>com.amazonaws:aws-java-sdk-core</include>
                 <include>com.amazonaws:aws-java-sdk-s3</include>
+                <include>com.amazonaws:aws-java-sdk-iam</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
Backport of PDI-20270 to 10.2.

On 10.2 the s3-vfs plugin resides in `big-data-plugin` (`assemblies/s3-vfs`), not in `pentaho-kettle` where it was relocated for 11.0 via BACKLOG-46634. The equivalent change is applied here.

## Changes
- `assemblies/s3-vfs/pom.xml`: add `com.amazonaws:aws-java-sdk-iam` dependency
- `assemblies/s3-vfs/src/main/assembly/descriptors/s3-vfs.xml`: add `com.amazonaws:aws-java-sdk-iam` include

## Policy
- Backport target is maintenance branch only: 10.2
- Original PR: pentaho/pentaho-kettle#10538