### PR TITLE
fix(SP-7409): CVE-2026-35554 | pdia-master has a security violation in gav://org.apache.kafka:kafka-clients:3.9.1

### DIFF
--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelper.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelper.java
@@ -36,6 +36,8 @@ import org.pentaho.di.ui.core.widget.TableView;
 import org.pentaho.di.ui.core.widget.TextVar;
 import org.pentaho.metastore.locator.api.MetastoreLocator;
 
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,11 +45,45 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import static org.pentaho.big.data.kettle.plugins.kafka.KafkaConsumerInputMeta.ConnectionType.CLUSTER;
 import static org.pentaho.big.data.kettle.plugins.kafka.KafkaConsumerInputMeta.ConnectionType.DIRECT;
 
 public class KafkaDialogHelper {
+
+  /**
+   * An {@link Executor} that submits tasks to {@link ForkJoinPool#commonPool()} while
+   * ensuring each task runs with the kafka-clients classloader as the thread context
+   * classloader.
+   *
+   * <p>Kafka 4.x's {@code ConsumerConfig} and {@code ProducerConfig} static initializers
+   * call {@code ConfigDef.parseType()} → {@code Utils.loadClass()} using the <em>thread
+   * context classloader</em> to validate CLASS-type config defaults (e.g.
+   * {@code DefaultJwtRetriever}).  {@link ForkJoinPool#commonPool()} worker threads inherit
+   * the <em>system</em> classloader, not the PDI plugin classloader, so those lookups fail
+   * with a {@link NoClassDefFoundError} and leave the Kafka config classes permanently
+   * broken ({@link ExceptionInInitializerError}).
+   *
+   * <p>By routing all async Kafka work through this executor every submitted task is
+   * guaranteed to run with the correct classloader, regardless of which pool thread is used.
+   */
+  private static final Executor KAFKA_CLASSLOADER_EXECUTOR;
+
+  static {
+    ClassLoader kafkaClassLoader = KafkaConsumer.class.getClassLoader();
+    KAFKA_CLASSLOADER_EXECUTOR = task -> ForkJoinPool.commonPool().execute( () -> {
+      Thread current = Thread.currentThread();
+      ClassLoader original = current.getContextClassLoader();
+      current.setContextClassLoader( kafkaClassLoader );
+      try {
+        task.run();
+      } finally {
+        current.setContextClassLoader( original );
+      }
+    } );
+  }
   protected ComboVar wTopic;
   protected ComboVar wClusterName;
   protected Button wbCluster;
@@ -94,7 +130,7 @@ public class KafkaDialogHelper {
     }
 
     CompletableFuture
-      .supplyAsync( () -> listTopics( clusterName, isCluster, directBootstrapServers, config ) )
+      .supplyAsync( () -> listTopics( clusterName, isCluster, directBootstrapServers, config ), KAFKA_CLASSLOADER_EXECUTOR )
       .thenAccept( topicMap -> Display.getDefault().syncExec( () -> populateTopics( topicMap, current ) ) );
   }
 
@@ -123,6 +159,7 @@ public class KafkaDialogHelper {
       localMeta.setConnectionType( isCluster ? CLUSTER : DIRECT );
       localMeta.setClusterName( clusterName );
       localMeta.setDirectBootstrapServers( directBootstrapServers );
+      localMeta.setConsumerGroup( "kettle-topic-listing-temp" );
       localMeta.setConfig( config );
       localMeta.setParentStepMeta( parentMeta );
       kafkaConsumer = kafkaFactory.consumer( localMeta, Function.identity() );

--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaStreamSource.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaStreamSource.java
@@ -26,6 +26,7 @@ import org.pentaho.di.trans.streaming.common.BlockingQueueStreamSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -104,6 +105,7 @@ public class KafkaStreamSource extends BlockingQueueStreamSource<List<Object>> {
   }
 
   class KafkaConsumerCallable implements Callable<Void> {
+    private static final Duration POLL_DURATION = Duration.ofMillis( 1000 );
     private final AtomicBoolean closed = new AtomicBoolean( false );
     private final Consumer consumer;
     private Runnable onClose;
@@ -123,7 +125,7 @@ public class KafkaStreamSource extends BlockingQueueStreamSource<List<Object>> {
         while ( !closed.get() ) {
           commitOffsets();
           @SuppressWarnings( "unchecked" ) //should revisit generic type here
-          ConsumerRecords<String, String> records = consumer.poll( 1000 );
+          ConsumerRecords<String, String> records = consumer.poll( POLL_DURATION );
 
           List<List<Object>> rows = new ArrayList<>();
           for ( ConsumerRecord<String, String> record : records ) {

--- a/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaStreamSource.java
+++ b/kettle-plugins/kafka/src/main/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaStreamSource.java
@@ -51,6 +51,8 @@ import static org.pentaho.big.data.kettle.plugins.kafka.KafkaConsumerField.Name.
 
 public class KafkaStreamSource extends BlockingQueueStreamSource<List<Object>> {
 
+  private static final Duration POLL_DURATION = Duration.ofMillis( 1000 );
+
   private final Logger logger = LoggerFactory.getLogger( getClass() );
 
   private final VariableSpace variables;
@@ -105,7 +107,6 @@ public class KafkaStreamSource extends BlockingQueueStreamSource<List<Object>> {
   }
 
   class KafkaConsumerCallable implements Callable<Void> {
-    private static final Duration POLL_DURATION = Duration.ofMillis( 1000 );
     private final AtomicBoolean closed = new AtomicBoolean( false );
     private final Consumer consumer;
     private Runnable onClose;

--- a/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputTest.java
+++ b/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaConsumerInputTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
+import java.time.Duration;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -280,7 +281,7 @@ public class KafkaConsumerInputTest {
     records = new ConsumerRecords<>( messages );
     // provide some data when we try to poll for kafka messages
     CountDownLatch latch = new CountDownLatch( 1 );
-    when( consumer.poll( ArgumentMatchers.anyLong() ) ).thenReturn( records ).then( invocationOnMock -> {
+    when( consumer.poll( ArgumentMatchers.any( Duration.class ) ) ).thenReturn( records ).then( invocationOnMock -> {
       latch.countDown();
       return Collections.emptyList();
     } );
@@ -352,7 +353,7 @@ public class KafkaConsumerInputTest {
     messages.put( topic, createRecords( topic.topic(), messageCount ) );
     records = new ConsumerRecords<>( messages );
     // provide some data when we try to poll for kafka messages
-    when( consumer.poll( 1000 ) ).thenReturn( records )
+    when( consumer.poll( Duration.ofMillis( 1000 ) ) ).thenReturn( records )
             .then( invocationOnMock -> {
               while ( trans.getSteps().get( 0 ).step.getLinesWritten() < 4 ) {
                 //noinspection UnnecessaryContinue
@@ -397,7 +398,7 @@ public class KafkaConsumerInputTest {
     messages.put( topic, createRecords( topic.topic(), messageCount ) );
     records = new ConsumerRecords<>( messages );
     // provide some data when we try to poll for kafka messages
-    when( consumer.poll( 1000 ) ).thenReturn( records )
+    when( consumer.poll( Duration.ofMillis( 1000 ) ) ).thenReturn( records )
             .thenReturn( new ConsumerRecords<>( Collections.emptyMap() ) );
     when( factory.consumer( eq( kafkaMeta ), any(), eq( String ), eq( String ) ) )
             .thenReturn( consumer );
@@ -431,7 +432,7 @@ public class KafkaConsumerInputTest {
     records = new ConsumerRecords<>( messages );
     CountDownLatch latch = new CountDownLatch( 1 );
     // provide some data when we try to poll for kafka messages
-    when( consumer.poll( 1000 ) )
+    when( consumer.poll( Duration.ofMillis( 1000 ) ) )
             .then( invocationOnMock -> {
               trans.pauseRunning();
               latch.countDown();
@@ -478,7 +479,7 @@ public class KafkaConsumerInputTest {
     messages.put( topic, createRecords( topic.topic(), messageCount ) );
     records = new ConsumerRecords<>( messages );
     // provide some data when we try to poll for kafka messages
-    when( consumer.poll( 1000 ) ).thenReturn( records );
+    when( consumer.poll( Duration.ofMillis( 1000 ) ) ).thenReturn( records );
     when( factory.consumer( eq( kafkaMeta ), any(), eq( String ), eq( String ) ) ).thenReturn( consumer );
     when( factory.checkKafkaConnectionStatus( any( KafkaConsumerInputMeta.class ), any( Variables.class )
             ,any( LogChannelInterface.class ) ) ).thenReturn( true );
@@ -518,7 +519,7 @@ public class KafkaConsumerInputTest {
     messages.put( topic, createRecords( topic.topic(), messageCount ) );
     records = new ConsumerRecords<>( messages );
     // provide some data when we try to poll for kafka messages
-    when( consumer.poll( 1000 ) )
+    when( consumer.poll( Duration.ofMillis( 1000 ) ) )
             .thenReturn( records )
             .then( invocationOnMock -> {
               for ( StepStatus stepStatus : trans.getSteps().get( 0 ).step.subStatuses() ) {

--- a/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelperTest.java
+++ b/kettle-plugins/kafka/src/test/java/org/pentaho/big/data/kettle/plugins/kafka/KafkaDialogHelperTest.java
@@ -1,0 +1,167 @@
+/*! ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2029-07-20
+ ******************************************************************************/
+
+package org.pentaho.big.data.kettle.plugins.kafka;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith( MockitoJUnitRunner.class )
+public class KafkaDialogHelperTest {
+
+  private static Executor kafkaClassloaderExecutor() throws Exception {
+    Field field = KafkaDialogHelper.class.getDeclaredField( "KAFKA_CLASSLOADER_EXECUTOR" );
+    field.setAccessible( true );
+    return (Executor) field.get( null );
+  }
+
+  @Test
+  public void kafkaClassloaderExecutorIsInitialized() throws Exception {
+    assertNotNull( kafkaClassloaderExecutor() );
+  }
+
+  @Test
+  public void submittedTaskIsExecuted() throws Exception {
+    CountDownLatch latch = new CountDownLatch( 1 );
+    AtomicBoolean executed = new AtomicBoolean( false );
+
+    kafkaClassloaderExecutor().execute( () -> {
+      executed.set( true );
+      latch.countDown();
+    } );
+
+    assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+    assertTrue( executed.get() );
+  }
+
+  @Test
+  public void taskRunsWithKafkaClientsAsContextClassloader() throws Exception {
+    CountDownLatch latch = new CountDownLatch( 1 );
+    AtomicReference<ClassLoader> capturedClassLoader = new AtomicReference<>();
+
+    kafkaClassloaderExecutor().execute( () -> {
+      capturedClassLoader.set( Thread.currentThread().getContextClassLoader() );
+      latch.countDown();
+    } );
+
+    assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+    assertSame( KafkaConsumer.class.getClassLoader(), capturedClassLoader.get() );
+  }
+
+  @Test
+  public void taskRunsWithKafkaClientsClassloaderRegardlessOfCallingThreadClassloader() throws Exception {
+    CountDownLatch latch = new CountDownLatch( 1 );
+    AtomicReference<ClassLoader> capturedClassLoader = new AtomicReference<>();
+
+    Thread callingThread = Thread.currentThread();
+    ClassLoader originalCallerClassLoader = callingThread.getContextClassLoader();
+    ClassLoader customClassLoader = new ClassLoader( originalCallerClassLoader ) { };
+    callingThread.setContextClassLoader( customClassLoader );
+
+    try {
+      kafkaClassloaderExecutor().execute( () -> {
+        capturedClassLoader.set( Thread.currentThread().getContextClassLoader() );
+        latch.countDown();
+      } );
+
+      assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+      assertSame( KafkaConsumer.class.getClassLoader(), capturedClassLoader.get() );
+      assertNotSame( customClassLoader, capturedClassLoader.get() );
+    } finally {
+      callingThread.setContextClassLoader( originalCallerClassLoader );
+    }
+  }
+
+  @Test
+  public void subsequentTasksExecuteAfterPreviousTaskThrowsException() throws Exception {
+    CountDownLatch firstTaskLatch = new CountDownLatch( 1 );
+    CountDownLatch secondTaskLatch = new CountDownLatch( 1 );
+    AtomicBoolean secondTaskExecuted = new AtomicBoolean( false );
+
+    Executor executor = kafkaClassloaderExecutor();
+
+    executor.execute( () -> {
+      firstTaskLatch.countDown();
+      throw new RuntimeException( "intentional failure to verify finally-block classloader restore" );
+    } );
+
+    assertTrue( firstTaskLatch.await( 5, TimeUnit.SECONDS ) );
+
+    executor.execute( () -> {
+      secondTaskExecuted.set( true );
+      secondTaskLatch.countDown();
+    } );
+
+    assertTrue( secondTaskLatch.await( 5, TimeUnit.SECONDS ) );
+    assertTrue( secondTaskExecuted.get() );
+  }
+
+  @Test
+  public void taskAfterThrowingTaskStillRunsWithKafkaClientsClassloader() throws Exception {
+    CountDownLatch firstTaskLatch = new CountDownLatch( 1 );
+    CountDownLatch secondTaskLatch = new CountDownLatch( 1 );
+    AtomicReference<ClassLoader> classloaderAfterFailure = new AtomicReference<>();
+
+    Executor executor = kafkaClassloaderExecutor();
+
+    executor.execute( () -> {
+      firstTaskLatch.countDown();
+      throw new RuntimeException( "intentional failure" );
+    } );
+
+    assertTrue( firstTaskLatch.await( 5, TimeUnit.SECONDS ) );
+
+    executor.execute( () -> {
+      classloaderAfterFailure.set( Thread.currentThread().getContextClassLoader() );
+      secondTaskLatch.countDown();
+    } );
+
+    assertTrue( secondTaskLatch.await( 5, TimeUnit.SECONDS ) );
+    assertSame( KafkaConsumer.class.getClassLoader(), classloaderAfterFailure.get() );
+  }
+
+  @Test
+  public void multipleConcurrentTasksAllRunWithKafkaClientsClassloader() throws Exception {
+    int taskCount = 5;
+    CountDownLatch latch = new CountDownLatch( taskCount );
+    AtomicBoolean allHadCorrectClassloader = new AtomicBoolean( true );
+    ClassLoader expectedClassLoader = KafkaConsumer.class.getClassLoader();
+
+    Executor executor = kafkaClassloaderExecutor();
+
+    for ( int i = 0; i < taskCount; i++ ) {
+      executor.execute( () -> {
+        if ( Thread.currentThread().getContextClassLoader() != expectedClassLoader ) {
+          allHadCorrectClassloader.set( false );
+        }
+        latch.countDown();
+      } );
+    }
+
+    assertTrue( latch.await( 5, TimeUnit.SECONDS ) );
+    assertTrue( allHadCorrectClassloader.get() );
+  }
+}


### PR DESCRIPTION
Backport of PPP-6393 to 10.2.

On 10.2 the kafka plugin resides in `big-data-plugin` (`kettle-plugins/kafka`), not in `pentaho-kettle` where it was relocated for 11.0. The equivalent changes from pentaho-kettle commits `a0f1a4e` and `5cf03661` are applied here with path remapping (`plugins/kafka/core/` → `kettle-plugins/kafka/`).

## Changes
- `KafkaStreamSource.java`: `consumer.poll(long)` → `consumer.poll(Duration)`
- `KafkaDialogHelper.java`: add kafka-clients classloader executor for Kafka 4.x static initializers; route async topic listing through it; set temp consumer group
- `KafkaConsumerInputTest.java`: migrate poll mocks to `Duration`
- `KafkaDialogHelperTest.java`: new tests for the classloader executor

## Companion PR
- Dependency bump: pentaho/maven-parent-poms#930 (kafka-clients 4.1.2)

## Policy
- Backport target is maintenance branch only: 10.2
- Source PRs: pentaho/pentaho-kettle#10573, pentaho/pentaho-kettle#10598

Note: local compile not run here due to a pre-existing SWT dependency-range resolution issue affecting the module; CI will validate.