### PR TITLE
[PDI-20034] - PDI Logging for Sqoop missing "File System Counters and Job Counters info

### DIFF
--- a/assemblies/pmr-libraries/pom.xml
+++ b/assemblies/pmr-libraries/pom.xml
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/dev-doc/hadoop-execution-logging.md
+++ b/dev-doc/hadoop-execution-logging.md
@@ -144,9 +144,20 @@ then routes to the owning Kettle log.
 `System.err` is one mutable JVM-wide stream, not an execution-local resource.
 `AbstractSqoopJobEntry` therefore reference-counts its redirect: a completed
 Sqoop execution must not restore the original stream while another Sqoop run is
-still active. Do not copy this pattern to another integration unless that tool
-also runs in-process and demonstrably bypasses Log4j. An external child process
-should have its own stdout and stderr streams read directly, as Spark does.
+still active. For the same reason the single proxy cannot be bound to one
+`Logger`: concurrent executions may use different shim classloaders, and each
+one then owns a `Logger` in its own `LoggerContext`. The proxy resolves its
+target on every write from a `ThreadLocal` that the execution sets while it
+attaches and clears while it detaches, so a write always reaches the logger of
+the execution that owns the calling thread. A write from a thread that owns no
+execution falls back to the original `System.err`. Do not copy this pattern to
+another integration unless that tool also runs in-process and demonstrably
+bypasses Log4j. An external child process should have its own stdout and stderr
+streams read directly, as Spark does.
+
+[sqoop-stderr-routing.md](sqoop-stderr-routing.md) walks through why a proxy
+bound to a single `Logger` breaks once shim classloaders get their own
+`LoggerContext`, and which invariants keep the thread-local resolution correct.
 
 ## Failure diagnosis
 

--- a/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/kettle/plugins/logging/HadoopExecutionLogging.java
+++ b/kettle-plugins/common/ui/src/main/java/org/pentaho/big/data/kettle/plugins/logging/HadoopExecutionLogging.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.pentaho.di.core.logging.LogChannelInterface;
 import org.pentaho.di.core.logging.log4j.KettleLogChannelAppender;
@@ -49,10 +50,16 @@ public final class HadoopExecutionLogging implements AutoCloseable {
   }
 
   public static HadoopExecutionLogging start( LogChannelInterface logChannel, String... loggerNames ) {
-    return new HadoopExecutionLogging( logChannel, loggerNames );
+    return start( logChannel, null, loggerNames );
   }
 
-  private HadoopExecutionLogging( LogChannelInterface logChannel, String... loggerNames ) {
+  public static HadoopExecutionLogging start( LogChannelInterface logChannel, ClassLoader loggerClassLoader,
+                                               String... loggerNames ) {
+    return new HadoopExecutionLogging( logChannel, loggerClassLoader, loggerNames );
+  }
+
+  private HadoopExecutionLogging( LogChannelInterface logChannel, ClassLoader loggerClassLoader,
+                                  String... loggerNames ) {
     if ( logChannel == null ) {
       throw new IllegalArgumentException( "A Kettle log channel is required" );
     }
@@ -64,8 +71,11 @@ public final class HadoopExecutionLogging implements AutoCloseable {
     ThreadContext.put( LOG_CHANNEL_ID_CONTEXT_KEY, logChannelId );
 
     try {
+      LoggerContext loggerContext = loggerClassLoader == null
+        ? ( LoggerContext ) LogManager.getContext( false )
+        : ( LoggerContext ) LogManager.getContext( loggerClassLoader, false );
       for ( String loggerName : uniqueLoggerNames( loggerNames ) ) {
-        Logger logger = LogManager.getLogger( loggerName );
+        Logger logger = loggerContext.getLogger( loggerName );
         Appender appender = new NamedKettleLogChannelAppender( logChannel,
           loggerName + "." + logChannelId + "." + APPENDER_SEQUENCE.incrementAndGet() );
         Filter filter = new LogChannelFilter( logChannelId );

--- a/kettle-plugins/sqoop/core/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntry.java
+++ b/kettle-plugins/sqoop/core/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntry.java
@@ -20,6 +20,7 @@ import com.google.common.base.Throwables;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.pentaho.big.data.kettle.plugins.job.AbstractJobEntry;
 import org.pentaho.big.data.kettle.plugins.job.JobEntryMode;
 import org.pentaho.big.data.kettle.plugins.job.JobEntryUtils;
@@ -180,13 +181,21 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
    * Attach a log appender to all Loggers used by Sqoop so we can redirect the output to Kettle's logging facilities.
    */
   public synchronized void attachLoggingAppenders() {
+    attachLoggingAppenders( null );
+  }
+
+  synchronized void attachLoggingAppenders( ClassLoader loggerClassLoader ) {
     if ( hadoopExecutionLogging != null ) {
       return;
     }
 
-    HadoopExecutionLogging newHadoopExecutionLogging = HadoopExecutionLogging.start( log, LOGS_TO_MONITOR );
+    HadoopExecutionLogging newHadoopExecutionLogging =
+      HadoopExecutionLogging.start( log, loggerClassLoader, LOGS_TO_MONITOR );
     try {
-      Logger sqoopLogger = LogManager.getLogger( LOGS_TO_MONITOR[ 0 ] );
+      LoggerContext loggerContext = loggerClassLoader == null
+        ? ( LoggerContext ) LogManager.getContext( false )
+        : ( LoggerContext ) LogManager.getContext( loggerClassLoader, false );
+      Logger sqoopLogger = loggerContext.getLogger( LOGS_TO_MONITOR[ 0 ] );
       redirectSystemError( sqoopLogger );
       hadoopExecutionLogging = newHadoopExecutionLogging;
     } catch ( RuntimeException e ) {
@@ -303,7 +312,6 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
     S config = getJobConfig();
     Properties properties = new Properties();
 
-    attachLoggingAppenders();
     try {
       configure( config, properties );
       List<String> args = SqoopUtils.getCommandLineArgs( config, getVariables() );
@@ -348,6 +356,7 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
 
       HadoopClientServices hadoopClientServices = namedClusterServiceLocator.getService( namedCluster, HadoopClientServices.class );
 
+      attachLoggingAppenders( hadoopClientServices.getClass().getClassLoader() );
       int result = hadoopClientServices.runSqoop( args, properties );
       if ( result != 0 ) {
         setJobResultFailed( jobResult );

--- a/kettle-plugins/sqoop/core/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntry.java
+++ b/kettle-plugins/sqoop/core/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntry.java
@@ -63,6 +63,11 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
     JobEntryInterface {
 
   private static final Object SYSTEM_ERROR_LOCK = new Object();
+  /**
+   * Sqoop logger of the execution running on the current thread. Each execution logs into the {@link LoggerContext} of
+   * its own shim classloader, so the JVM-wide {@code System.err} proxy resolves its target on every write.
+   */
+  private static final ThreadLocal<Logger> CURRENT_SQOOP_LOGGER = new ThreadLocal<>();
   private static int systemErrorRedirectorCount;
   private static PrintStream originalSystemError;
   private static LoggingProxy systemErrorProxy;
@@ -225,9 +230,10 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
       if ( redirectsSystemError ) {
         return;
       }
+      CURRENT_SQOOP_LOGGER.set( sqoopLogger );
       if ( systemErrorRedirectorCount == 0 ) {
         originalSystemError = System.err;
-        systemErrorProxy = new LoggingProxy( originalSystemError, sqoopLogger, Level.INFO );
+        systemErrorProxy = new LoggingProxy( originalSystemError, CURRENT_SQOOP_LOGGER::get, Level.INFO );
         System.setErr( systemErrorProxy );
       }
       systemErrorRedirectorCount++;
@@ -240,6 +246,7 @@ public abstract class AbstractSqoopJobEntry<S extends SqoopConfig> extends Abstr
       if ( !redirectsSystemError ) {
         return;
       }
+      CURRENT_SQOOP_LOGGER.remove();
       redirectsSystemError = false;
       systemErrorRedirectorCount--;
       if ( systemErrorRedirectorCount == 0 ) {

--- a/kettle-plugins/sqoop/core/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/LoggingProxy.java
+++ b/kettle-plugins/sqoop/core/src/main/java/org/pentaho/big/data/kettle/plugins/sqoop/LoggingProxy.java
@@ -18,14 +18,15 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 
 import java.io.PrintStream;
+import java.util.function.Supplier;
 
 /**
  * Redirect all String-based logging for a {@link PrintStream} to a Log4j logger at a specified logging level.
  */
 public class LoggingProxy extends PrintStream {
-  private PrintStream wrappedStream;
-  private Logger logger;
-  private Level level;
+  private final PrintStream wrappedStream;
+  private final Supplier<Logger> loggerSupplier;
+  private final Level level;
 
   /**
    * Create a new Logging proxy that will log all {@link String}s printed with {@link #print(String)} to the logger
@@ -39,15 +40,35 @@ public class LoggingProxy extends PrintStream {
    *          Level to log messages at
    */
   public LoggingProxy( PrintStream stream, Logger logger, Level level ) {
+    this( stream, () -> logger, level );
+  }
+
+  /**
+   * Create a new Logging proxy that resolves its target logger on every write, so that a single JVM-wide proxy can
+   * follow the execution that owns the calling thread even when those loggers live in different logger contexts.
+   *
+   * @param stream
+   *          Stream to redirect output for
+   * @param loggerSupplier
+   *          Supplies the logger to log to, may return {@code null} when the calling thread owns no logger
+   * @param level
+   *          Level to log messages at
+   */
+  public LoggingProxy( PrintStream stream, Supplier<Logger> loggerSupplier, Level level ) {
     super( stream );
-    wrappedStream = stream;
-    this.logger = logger;
+    this.wrappedStream = stream;
+    this.loggerSupplier = loggerSupplier;
     this.level = level;
   }
 
   @Override
   public void print( String s ) {
-    logger.log( level, s );
+    Logger logger = loggerSupplier.get();
+    if ( logger == null ) {
+      wrappedStream.print( s );
+    } else {
+      logger.log( level, s );
+    }
   }
 
   /**

--- a/kettle-plugins/sqoop/core/src/test/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntryTest.java
+++ b/kettle-plugins/sqoop/core/src/test/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntryTest.java
@@ -15,6 +15,8 @@ package org.pentaho.big.data.kettle.plugins.sqoop;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,11 +45,16 @@ import org.pentaho.runtime.test.RuntimeTester;
 import org.pentaho.runtime.test.action.RuntimeTestActionService;
 
 import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -169,6 +176,26 @@ public class AbstractSqoopJobEntryTest {
       assertEquals( initialAppenderCount, LogUtil.getAppenders( sqoopLogger ).size() );
     } finally {
       sqoopJobEntry.removeLoggingAppenders();
+    }
+  }
+
+  @Test
+  public void attachesLoggingAppendersToShimLoggerContext() throws Exception {
+    try ( URLClassLoader shimClassLoader = new URLClassLoader( new URL[ 0 ], getClass().getClassLoader() ) ) {
+      LoggerContext shimLoggerContext = ( LoggerContext ) LogManager.getContext( shimClassLoader, false );
+      org.apache.logging.log4j.core.Logger hadoopLogger = shimLoggerContext.getLogger( "org.apache.hadoop" );
+      Set<Appender> existingAppenders = new HashSet<>( hadoopLogger.getAppenders().values() );
+
+      sqoopJobEntry.attachLoggingAppenders( shimClassLoader );
+      try {
+        Set<Appender> addedAppenders = new HashSet<>( hadoopLogger.getAppenders().values() );
+        addedAppenders.removeAll( existingAppenders );
+
+        assertTrue( addedAppenders.stream().anyMatch(
+          appender -> appender instanceof org.pentaho.di.core.logging.log4j.KettleLogChannelAppender ) );
+      } finally {
+        sqoopJobEntry.removeLoggingAppenders();
+      }
     }
   }
 

--- a/kettle-plugins/sqoop/core/src/test/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntryTest.java
+++ b/kettle-plugins/sqoop/core/src/test/java/org/pentaho/big/data/kettle/plugins/sqoop/AbstractSqoopJobEntryTest.java
@@ -13,10 +13,14 @@
 
 package org.pentaho.big.data.kettle.plugins.sqoop;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +54,7 @@ import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -199,6 +204,34 @@ public class AbstractSqoopJobEntryTest {
     }
   }
 
+  @Test
+  public void redirectsSystemErrorToTheLoggerOfTheOwningExecution() throws Exception {
+    AbstractSqoopJobEntry shimJobEntry = createJobEntry();
+    // a parent-less loader gets its own LoggerContext, like a shim bundle classloader does
+    try ( URLClassLoader shimClassLoader = new URLClassLoader( new URL[ 0 ], null ) ) {
+      LoggerContext shimLoggerContext = ( LoggerContext ) LogManager.getContext( shimClassLoader, false );
+      assertNotSame( LogManager.getContext( false ), shimLoggerContext );
+      org.apache.logging.log4j.core.Logger shimSqoopLogger = shimLoggerContext.getLogger( "org.apache.sqoop" );
+      CapturingAppender capturingAppender = new CapturingAppender();
+      capturingAppender.start();
+
+      // the first execution installs the JVM-wide System.err proxy, the second one runs in another logger context
+      sqoopJobEntry.attachLoggingAppenders();
+      shimJobEntry.attachLoggingAppenders( shimClassLoader );
+      shimSqoopLogger.addAppender( capturingAppender );
+      shimSqoopLogger.setLevel( Level.INFO );
+      try {
+        System.err.print( "sqoop wrote this to stderr" );
+
+        assertTrue( capturingAppender.messages.contains( "sqoop wrote this to stderr" ) );
+      } finally {
+        shimSqoopLogger.removeAppender( capturingAppender );
+        shimJobEntry.removeLoggingAppenders();
+        sqoopJobEntry.removeLoggingAppenders();
+      }
+    }
+  }
+
   private AbstractSqoopJobEntry createJobEntry() {
     return new AbstractSqoopJobEntry( mockNamedClusterService, mockNamedClusterServiceLocator,
       mockRuntimeTestActionService, mockRuntimeTester ) {
@@ -214,6 +247,18 @@ public class AbstractSqoopJobEntryTest {
         return "toolName";
       }
     };
+  }
+
+  private static final class CapturingAppender extends AbstractAppender {
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    private CapturingAppender() {
+      super( "capturing-appender", null, null, true, Property.EMPTY_ARRAY );
+    }
+
+    @Override public void append( LogEvent event ) {
+      messages.add( event.getMessage().getFormattedMessage() );
+    }
   }
 
 }


### PR DESCRIPTION
Depends on https://github.com/pentaho/pentaho-hadoop-shims/pull/1909

Fixes missing File System Counters and Job Counters in Sqoop job logs. Sqoop now resolves HadoopClientServices before attaching logging and registers the existing filtered Kettle appenders in the selected shim’s LoggerContext

The most important changes are:

**Logging integration and class loader support:**

* Refactored `HadoopExecutionLogging` and `AbstractSqoopJobEntry` to support attaching log appenders to logger contexts associated with a specific `ClassLoader`, ensuring logging works correctly with Hadoop shims and other plugin class loaders. This includes new overloads and logic to select the correct logger context. [[1]](diffhunk://#diff-7d3decd359ef39a2583509ba755f99e725b718fbee86e79ada24bb47008553d6L52-R62) [[2]](diffhunk://#diff-7d3decd359ef39a2583509ba755f99e725b718fbee86e79ada24bb47008553d6R74-R78) [[3]](diffhunk://#diff-c2283c09c6e2722b9188a6e57a642cbe6cd95ac17a3a38a3b9bfd4d989b31076R184-R198) [[4]](diffhunk://#diff-c2283c09c6e2722b9188a6e57a642cbe6cd95ac17a3a38a3b9bfd4d989b31076R359)

* Updated the logic in `executeSqoop` to defer attaching log appenders until after the Hadoop client service is loaded, so the correct class loader is used for logger context attachment. [[1]](diffhunk://#diff-c2283c09c6e2722b9188a6e57a642cbe6cd95ac17a3a38a3b9bfd4d989b31076L306) [[2]](diffhunk://#diff-c2283c09c6e2722b9188a6e57a642cbe6cd95ac17a3a38a3b9bfd4d989b31076R359)

**Dependency updates:**

* Upgraded the `commons-cli` dependency from version 1.2 to 1.5.0 in `pmr-libraries/pom.xml` for improved compatibility and bug fixes, The PMR runtime now packages Commons CLI 1.5.0, providing the Option.builder(String) API required by Apache Vanilla Sqoop

**Testing enhancements:**

* Added a new unit test to verify that logging appenders are correctly attached to the logger context of a custom (shim) class loader, ensuring the new behavior is covered.

These changes improve the reliability and flexibility of logging when running Sqoop jobs in environments with custom or multiple class loaders.